### PR TITLE
NewNode codegen

### DIFF
--- a/codescienceGenerated/src/main/scala/generated/Accessors.scala
+++ b/codescienceGenerated/src/main/scala/generated/Accessors.scala
@@ -4,638 +4,1446 @@ import io.shiftleft.codepropertygraph.generated.v2.nodes
 import scala.collection.immutable.IndexedSeq
 
 object Accessors {
-  class Access_property_ALIAS_TYPE_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def aliasTypeFullName: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 0, node.seq)
-  }
-
-  class Access_property_ANNOTATION_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def annotationFullName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 1, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_ANNOTATION_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def annotationName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 2, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_ARGUMENT_INDEX(val node: nodes.StoredNode) extends AnyVal {
-    def argumentIndex: Int =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 3, node.seq(), -1: Int)
-  }
-
-  class Access_property_ARGUMENT_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def argumentName: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 4, node.seq)
-  }
-
-  class Access_property_AST_PARENT_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def astParentFullName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 5, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_AST_PARENT_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def astParentType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 6, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_BINARY_SIGNATURE(val node: nodes.StoredNode) extends AnyVal {
-    def binarySignature: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 7, node.seq)
-  }
-
-  class Access_property_CANONICAL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def canonicalName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 8, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_CATEGORIES(val node: nodes.StoredNode) extends AnyVal {
-    def categories: IndexedSeq[String] =
-      odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 9, node.seq)
-  }
-
-  class Access_property_CATEGORY(val node: nodes.StoredNode) extends AnyVal {
-    def category: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 10, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_CLASS_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def className: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 11, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_CLASS_SHORT_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def classShortName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 12, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_CLOSURE_BINDING_ID(val node: nodes.StoredNode) extends AnyVal {
-    def closureBindingId: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 13, node.seq)
-  }
-
-  class Access_property_CLOSURE_ORIGINAL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def closureOriginalName: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 14, node.seq)
-  }
-
-  class Access_property_CODE(val node: nodes.StoredNode) extends AnyVal {
-    def code: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 15, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_COLUMN_NUMBER(val node: nodes.StoredNode) extends AnyVal {
-    def columnNumber: Option[Int] =
-      odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 16, node.seq)
-  }
-
-  class Access_property_COLUMN_NUMBER_END(val node: nodes.StoredNode) extends AnyVal {
-    def columnNumberEnd: Option[Int] =
-      odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 17, node.seq)
-  }
-
-  class Access_property_CONTAINED_REF(val node: nodes.StoredNode) extends AnyVal {
-    def containedRef: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 18, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_CONTENT(val node: nodes.StoredNode) extends AnyVal {
-    def content: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 19, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_CONTROL_STRUCTURE_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def controlStructureType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 20, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_DEPENDENCY_GROUP_ID(val node: nodes.StoredNode) extends AnyVal {
-    def dependencyGroupId: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 21, node.seq)
-  }
-
-  class Access_property_DEPENDENCY_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def dependencyType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 22, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_DEPTH_FIRST_ORDER(val node: nodes.StoredNode) extends AnyVal {
-    def depthFirstOrder: Int =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 23, node.seq(), -1: Int)
-  }
-
-  class Access_property_DESCRIPTION(val node: nodes.StoredNode) extends AnyVal {
-    def description: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 24, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_DISPATCH_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def dispatchName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 25, node.seq(), "": String)
-  }
-
-  class Access_property_DISPATCH_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def dispatchType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 26, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_DYNAMIC_TYPE_HINT_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def dynamicTypeHintFullName: IndexedSeq[String] =
-      odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 27, node.seq)
-  }
-
-  class Access_property_EVALUATION_STRATEGY(val node: nodes.StoredNode) extends AnyVal {
-    def evaluationStrategy: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 28, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_EVALUATION_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def evaluationType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 29, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_EVAL_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def evalType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 30, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_EXPLICIT_AS(val node: nodes.StoredNode) extends AnyVal {
-    def explicitAs: Option[Boolean] =
-      odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 31, node.seq)
-  }
-
-  class Access_property_FILENAME(val node: nodes.StoredNode) extends AnyVal {
-    def filename: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 32, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_FINGERPRINT(val node: nodes.StoredNode) extends AnyVal {
-    def fingerprint: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 33, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def fullName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 34, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_HASH(val node: nodes.StoredNode) extends AnyVal {
-    def hash: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 35, node.seq)
-  }
-
-  class Access_property_HAS_MAPPING(val node: nodes.StoredNode) extends AnyVal {
-    def hasMapping: Option[Boolean] =
-      odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 36, node.seq)
-  }
-
-  class Access_property_IMPORTED_AS(val node: nodes.StoredNode) extends AnyVal {
-    def importedAs: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 37, node.seq)
-  }
-
-  class Access_property_IMPORTED_ENTITY(val node: nodes.StoredNode) extends AnyVal {
-    def importedEntity: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 38, node.seq)
-  }
-
-  class Access_property_INDEX(val node: nodes.StoredNode) extends AnyVal {
-    def index: Int =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 39, node.seq(), -1: Int)
-  }
-
-  class Access_property_INHERITS_FROM_TYPE_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def inheritsFromTypeFullName: IndexedSeq[String] =
-      odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 40, node.seq)
-  }
-
-  class Access_property_INTERNAL_FLAGS(val node: nodes.StoredNode) extends AnyVal {
-    def internalFlags: Int =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 41, node.seq(), 0: Int)
-  }
-
-  class Access_property_IS_EXPLICIT(val node: nodes.StoredNode) extends AnyVal {
-    def isExplicit: Option[Boolean] =
-      odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 42, node.seq)
-  }
-
-  class Access_property_IS_EXTERNAL(val node: nodes.StoredNode) extends AnyVal {
-    def isExternal: Boolean =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 43, node.seq(), false: Boolean)
-  }
-
-  class Access_property_IS_METHOD_NEVER_OVERRIDDEN(val node: nodes.StoredNode) extends AnyVal {
-    def isMethodNeverOverridden: Option[Boolean] =
-      odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 44, node.seq)
-  }
-
-  class Access_property_IS_STATIC(val node: nodes.StoredNode) extends AnyVal {
-    def isStatic: Boolean =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 45, node.seq(), false: Boolean)
-  }
-
-  class Access_property_IS_VARIADIC(val node: nodes.StoredNode) extends AnyVal {
-    def isVariadic: Boolean =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 46, node.seq(), false: Boolean)
-  }
-
-  class Access_property_IS_WILDCARD(val node: nodes.StoredNode) extends AnyVal {
-    def isWildcard: Option[Boolean] =
-      odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 47, node.seq)
-  }
-
-  class Access_property_KEY(val node: nodes.StoredNode) extends AnyVal {
-    def key: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 48, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_LANGUAGE(val node: nodes.StoredNode) extends AnyVal {
-    def language: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 49, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_LINE_NUMBER(val node: nodes.StoredNode) extends AnyVal {
-    def lineNumber: Option[Int] =
-      odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 50, node.seq)
-  }
-
-  class Access_property_LINE_NUMBER_END(val node: nodes.StoredNode) extends AnyVal {
-    def lineNumberEnd: Option[Int] =
-      odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 51, node.seq)
-  }
-
-  class Access_property_LITERALS_TO_SINK(val node: nodes.StoredNode) extends AnyVal {
-    def literalsToSink: IndexedSeq[String] =
-      odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 52, node.seq)
-  }
-
-  class Access_property_METHOD_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def methodFullName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 53, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_METHOD_INST_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def methodInstFullName: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 54, node.seq)
-  }
-
-  class Access_property_METHOD_SHORT_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def methodShortName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 55, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_ML_ASSISTED(val node: nodes.StoredNode) extends AnyVal {
-    def mlAssisted: Boolean =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 56, node.seq(), false: Boolean)
-  }
-
-  class Access_property_MODIFIER_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def modifierType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 57, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def name: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 58, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_NODE_LABEL(val node: nodes.StoredNode) extends AnyVal {
-    def nodeLabel: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 59, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_ORDER(val node: nodes.StoredNode) extends AnyVal {
-    def order: Int =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 60, node.seq(), -1: Int)
-  }
-
-  class Access_property_OVERLAYS(val node: nodes.StoredNode) extends AnyVal {
-    def overlays: IndexedSeq[String] =
-      odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 61, node.seq)
-  }
-
-  class Access_property_PACKAGE_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def packageName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 62, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_PARAMETER_INDEX(val node: nodes.StoredNode) extends AnyVal {
-    def parameterIndex: Option[Int] =
-      odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 63, node.seq)
-  }
-
-  class Access_property_PARSER_TYPE_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def parserTypeName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 64, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_PATH(val node: nodes.StoredNode) extends AnyVal {
-    def path: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 65, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_PATTERN(val node: nodes.StoredNode) extends AnyVal {
-    def pattern: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 66, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_POLICY_DIRECTORIES(val node: nodes.StoredNode) extends AnyVal {
-    def policyDirectories: IndexedSeq[String] =
-      odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 67, node.seq)
-  }
-
-  class Access_property_RESOLVED(val node: nodes.StoredNode) extends AnyVal {
-    def resolved: Option[Boolean] =
-      odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 68, node.seq)
-  }
-
-  class Access_property_ROOT(val node: nodes.StoredNode) extends AnyVal {
-    def root: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 69, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_SCORE(val node: nodes.StoredNode) extends AnyVal {
-    def score: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 70, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_SIGNATURE(val node: nodes.StoredNode) extends AnyVal {
-    def signature: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 71, node.seq(), "": String)
-  }
-
-  class Access_property_SINK_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def sinkType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 72, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_SOURCE_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def sourceType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 73, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_SPID(val node: nodes.StoredNode) extends AnyVal {
-    def spid: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 74, node.seq)
-  }
-
-  class Access_property_STRUCTURED_FINGERPRINT(val node: nodes.StoredNode) extends AnyVal {
-    def structuredFingerprint: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 75, node.seq(), "null": String)
-  }
-
-  class Access_property_SYMBOL(val node: nodes.StoredNode) extends AnyVal {
-    def symbol: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 76, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_TYPE_DECL_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def typeDeclFullName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 77, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_TYPE_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def typeFullName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 78, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_URL(val node: nodes.StoredNode) extends AnyVal {
-    def url: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 79, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_VALUE(val node: nodes.StoredNode) extends AnyVal {
-    def value: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 80, node.seq(), "": String)
-  }
-
-  class Access_property_VARARG_PARAMETER(val node: nodes.StoredNode) extends AnyVal {
-    def varargParameter: Int =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 81, node.seq(), -1: Int)
-  }
-
-  class Access_property_VAR_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def varType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 82, node.seq(), "<empty>": String)
-  }
-
-  class Access_property_VERSION(val node: nodes.StoredNode) extends AnyVal {
-    def version: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 83, node.seq(), "<empty>": String)
+  final class Access_Property_ALIAS_TYPE_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def aliasTypeFullName: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 0, node.seq)
+  }
+  final class Access_Property_ANNOTATION_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def annotationFullName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 1, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_ANNOTATION_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def annotationName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 2, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_ARGUMENT_INDEX(val node: nodes.StoredNode) extends AnyVal {
+    def argumentIndex: Int = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 3, node.seq(), -1: Int)
+  }
+  final class Access_Property_ARGUMENT_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def argumentName: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 4, node.seq)
+  }
+  final class Access_Property_AST_PARENT_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def astParentFullName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 5, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_AST_PARENT_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def astParentType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 6, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_BINARY_SIGNATURE(val node: nodes.StoredNode) extends AnyVal {
+    def binarySignature: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 7, node.seq)
+  }
+  final class Access_Property_CANONICAL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def canonicalName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 8, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_CATEGORIES(val node: nodes.StoredNode) extends AnyVal {
+    def categories: IndexedSeq[String] = odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 9, node.seq)
+  }
+  final class Access_Property_CATEGORY(val node: nodes.StoredNode) extends AnyVal {
+    def category: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 10, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_CLASS_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def className: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 11, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_CLASS_SHORT_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def classShortName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 12, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_CLOSURE_BINDING_ID(val node: nodes.StoredNode) extends AnyVal {
+    def closureBindingId: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 13, node.seq)
+  }
+  final class Access_Property_CLOSURE_ORIGINAL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def closureOriginalName: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 14, node.seq)
+  }
+  final class Access_Property_CODE(val node: nodes.StoredNode) extends AnyVal {
+    def code: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 15, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_COLUMN_NUMBER(val node: nodes.StoredNode) extends AnyVal {
+    def columnNumber: Option[Int] = odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 16, node.seq)
+  }
+  final class Access_Property_COLUMN_NUMBER_END(val node: nodes.StoredNode) extends AnyVal {
+    def columnNumberEnd: Option[Int] = odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 17, node.seq)
+  }
+  final class Access_Property_CONTAINED_REF(val node: nodes.StoredNode) extends AnyVal {
+    def containedRef: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 18, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_CONTENT(val node: nodes.StoredNode) extends AnyVal {
+    def content: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 19, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_CONTROL_STRUCTURE_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def controlStructureType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 20, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_DEPENDENCY_GROUP_ID(val node: nodes.StoredNode) extends AnyVal {
+    def dependencyGroupId: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 21, node.seq)
+  }
+  final class Access_Property_DEPENDENCY_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def dependencyType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 22, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_DEPTH_FIRST_ORDER(val node: nodes.StoredNode) extends AnyVal {
+    def depthFirstOrder: Int = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 23, node.seq(), -1: Int)
+  }
+  final class Access_Property_DESCRIPTION(val node: nodes.StoredNode) extends AnyVal {
+    def description: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 24, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_DISPATCH_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def dispatchName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 25, node.seq(), "": String)
+  }
+  final class Access_Property_DISPATCH_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def dispatchType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 26, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 27, node.seq)
+  }
+  final class Access_Property_EVALUATION_STRATEGY(val node: nodes.StoredNode) extends AnyVal {
+    def evaluationStrategy: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 28, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_EVALUATION_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def evaluationType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 29, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_EVAL_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def evalType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 30, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_EXPLICIT_AS(val node: nodes.StoredNode) extends AnyVal {
+    def explicitAs: Option[Boolean] = odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 31, node.seq)
+  }
+  final class Access_Property_FILENAME(val node: nodes.StoredNode) extends AnyVal {
+    def filename: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 32, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_FINGERPRINT(val node: nodes.StoredNode) extends AnyVal {
+    def fingerprint: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 33, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def fullName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 34, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_HASH(val node: nodes.StoredNode) extends AnyVal {
+    def hash: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 35, node.seq)
+  }
+  final class Access_Property_HAS_MAPPING(val node: nodes.StoredNode) extends AnyVal {
+    def hasMapping: Option[Boolean] = odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 36, node.seq)
+  }
+  final class Access_Property_IMPORTED_AS(val node: nodes.StoredNode) extends AnyVal {
+    def importedAs: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 37, node.seq)
+  }
+  final class Access_Property_IMPORTED_ENTITY(val node: nodes.StoredNode) extends AnyVal {
+    def importedEntity: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 38, node.seq)
+  }
+  final class Access_Property_INDEX(val node: nodes.StoredNode) extends AnyVal {
+    def index: Int = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 39, node.seq(), -1: Int)
+  }
+  final class Access_Property_INHERITS_FROM_TYPE_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def inheritsFromTypeFullName: IndexedSeq[String] = odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 40, node.seq)
+  }
+  final class Access_Property_INTERNAL_FLAGS(val node: nodes.StoredNode) extends AnyVal {
+    def internalFlags: Int = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 41, node.seq(), 0: Int)
+  }
+  final class Access_Property_IS_EXPLICIT(val node: nodes.StoredNode) extends AnyVal {
+    def isExplicit: Option[Boolean] = odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 42, node.seq)
+  }
+  final class Access_Property_IS_EXTERNAL(val node: nodes.StoredNode) extends AnyVal {
+    def isExternal: Boolean = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 43, node.seq(), false: Boolean)
+  }
+  final class Access_Property_IS_METHOD_NEVER_OVERRIDDEN(val node: nodes.StoredNode) extends AnyVal {
+    def isMethodNeverOverridden: Option[Boolean] = odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 44, node.seq)
+  }
+  final class Access_Property_IS_STATIC(val node: nodes.StoredNode) extends AnyVal {
+    def isStatic: Boolean = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 45, node.seq(), false: Boolean)
+  }
+  final class Access_Property_IS_VARIADIC(val node: nodes.StoredNode) extends AnyVal {
+    def isVariadic: Boolean = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 46, node.seq(), false: Boolean)
+  }
+  final class Access_Property_IS_WILDCARD(val node: nodes.StoredNode) extends AnyVal {
+    def isWildcard: Option[Boolean] = odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 47, node.seq)
+  }
+  final class Access_Property_KEY(val node: nodes.StoredNode) extends AnyVal {
+    def key: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 48, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_LANGUAGE(val node: nodes.StoredNode) extends AnyVal {
+    def language: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 49, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_LINE_NUMBER(val node: nodes.StoredNode) extends AnyVal {
+    def lineNumber: Option[Int] = odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 50, node.seq)
+  }
+  final class Access_Property_LINE_NUMBER_END(val node: nodes.StoredNode) extends AnyVal {
+    def lineNumberEnd: Option[Int] = odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 51, node.seq)
+  }
+  final class Access_Property_LITERALS_TO_SINK(val node: nodes.StoredNode) extends AnyVal {
+    def literalsToSink: IndexedSeq[String] = odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 52, node.seq)
+  }
+  final class Access_Property_METHOD_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def methodFullName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 53, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_METHOD_INST_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def methodInstFullName: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 54, node.seq)
+  }
+  final class Access_Property_METHOD_SHORT_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def methodShortName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 55, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_ML_ASSISTED(val node: nodes.StoredNode) extends AnyVal {
+    def mlAssisted: Boolean = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 56, node.seq(), false: Boolean)
+  }
+  final class Access_Property_MODIFIER_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def modifierType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 57, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def name: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 58, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_NODE_LABEL(val node: nodes.StoredNode) extends AnyVal {
+    def nodeLabel: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 59, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_ORDER(val node: nodes.StoredNode) extends AnyVal {
+    def order: Int = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 60, node.seq(), -1: Int)
+  }
+  final class Access_Property_OVERLAYS(val node: nodes.StoredNode) extends AnyVal {
+    def overlays: IndexedSeq[String] = odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 61, node.seq)
+  }
+  final class Access_Property_PACKAGE_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def packageName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 62, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_PARAMETER_INDEX(val node: nodes.StoredNode) extends AnyVal {
+    def parameterIndex: Option[Int] = odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 63, node.seq)
+  }
+  final class Access_Property_PARSER_TYPE_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def parserTypeName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 64, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_PATH(val node: nodes.StoredNode) extends AnyVal {
+    def path: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 65, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_PATTERN(val node: nodes.StoredNode) extends AnyVal {
+    def pattern: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 66, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_POLICY_DIRECTORIES(val node: nodes.StoredNode) extends AnyVal {
+    def policyDirectories: IndexedSeq[String] = odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 67, node.seq)
+  }
+  final class Access_Property_RESOLVED(val node: nodes.StoredNode) extends AnyVal {
+    def resolved: Option[Boolean] = odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 68, node.seq)
+  }
+  final class Access_Property_ROOT(val node: nodes.StoredNode) extends AnyVal {
+    def root: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 69, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_SCORE(val node: nodes.StoredNode) extends AnyVal {
+    def score: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 70, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_SIGNATURE(val node: nodes.StoredNode) extends AnyVal {
+    def signature: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 71, node.seq(), "": String)
+  }
+  final class Access_Property_SINK_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def sinkType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 72, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_SOURCE_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def sourceType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 73, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_SPID(val node: nodes.StoredNode) extends AnyVal {
+    def spid: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 74, node.seq)
+  }
+  final class Access_Property_STRUCTURED_FINGERPRINT(val node: nodes.StoredNode) extends AnyVal {
+    def structuredFingerprint: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 75, node.seq(), "null": String)
+  }
+  final class Access_Property_SYMBOL(val node: nodes.StoredNode) extends AnyVal {
+    def symbol: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 76, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_TYPE_DECL_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def typeDeclFullName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 77, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_TYPE_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def typeFullName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 78, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_URL(val node: nodes.StoredNode) extends AnyVal {
+    def url: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 79, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_VALUE(val node: nodes.StoredNode) extends AnyVal {
+    def value: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 80, node.seq(), "": String)
+  }
+  final class Access_Property_VARARG_PARAMETER(val node: nodes.StoredNode) extends AnyVal {
+    def varargParameter: Int = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 81, node.seq(), -1: Int)
+  }
+  final class Access_Property_VAR_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def varType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 82, node.seq(), "<empty>": String)
+  }
+  final class Access_Property_VERSION(val node: nodes.StoredNode) extends AnyVal {
+    def version: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 83, node.seq(), "<empty>": String)
+  }
+  //
+  final class Access_AnnotationBase(val node: nodes.AnnotationBase) extends AnyVal {
+    def fullName: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_FULL_NAME(stored).fullName
+      case newNode: nodes.NewAnnotation => newNode.fullName
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewAnnotation => newNode.name
+    }
+  }
+  final class Access_AnnotationLiteralBase(val node: nodes.AnnotationLiteralBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode            => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewAnnotationLiteral => newNode.name
+    }
+  }
+  final class Access_AnnotationParameterBase(val node: nodes.AnnotationParameterBase)             extends AnyVal {}
+  final class Access_AnnotationParameterAssignBase(val node: nodes.AnnotationParameterAssignBase) extends AnyVal {}
+  final class Access_ArrayInitializerBase(val node: nodes.ArrayInitializerBase)                   extends AnyVal {}
+  final class Access_BindingBase(val node: nodes.BindingBase) extends AnyVal {
+    def isMethodNeverOverridden: Option[Boolean] = node match {
+      case stored: nodes.StoredNode  => new Access_Property_IS_METHOD_NEVER_OVERRIDDEN(stored).isMethodNeverOverridden
+      case newNode: nodes.NewBinding => newNode.isMethodNeverOverridden
+    }
+    def methodFullName: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_METHOD_FULL_NAME(stored).methodFullName
+      case newNode: nodes.NewBinding => newNode.methodFullName
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewBinding => newNode.name
+    }
+    def signature: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_SIGNATURE(stored).signature
+      case newNode: nodes.NewBinding => newNode.signature
+    }
+  }
+  final class Access_BlockBase(val node: nodes.BlockBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewBlock  => newNode.dynamicTypeHintFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewBlock  => newNode.typeFullName
+    }
+  }
+  final class Access_CallBase(val node: nodes.CallBase) extends AnyVal {
+    def dispatchName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_DISPATCH_NAME(stored).dispatchName
+      case newNode: nodes.NewCall   => newNode.dispatchName
+    }
+    def dispatchType: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_DISPATCH_TYPE(stored).dispatchType
+      case newNode: nodes.NewCall   => newNode.dispatchType
+    }
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewCall   => newNode.dynamicTypeHintFullName
+    }
+    def methodFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_METHOD_FULL_NAME(stored).methodFullName
+      case newNode: nodes.NewCall   => newNode.methodFullName
+    }
+    def methodInstFullName: Option[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_METHOD_INST_FULL_NAME(stored).methodInstFullName
+      case newNode: nodes.NewCall   => newNode.methodInstFullName
+    }
+    def resolved: Option[Boolean] = node match {
+      case stored: nodes.StoredNode => new Access_Property_RESOLVED(stored).resolved
+      case newNode: nodes.NewCall   => newNode.resolved
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewCall   => newNode.typeFullName
+    }
+  }
+  final class Access_CallChainBase(val node: nodes.CallChainBase) extends AnyVal {}
+  final class Access_CallSiteBase(val node: nodes.CallSiteBase)   extends AnyVal {}
+  final class Access_ClosureBindingBase(val node: nodes.ClosureBindingBase) extends AnyVal {
+    def closureBindingId: Option[String] = node match {
+      case stored: nodes.StoredNode         => new Access_Property_CLOSURE_BINDING_ID(stored).closureBindingId
+      case newNode: nodes.NewClosureBinding => newNode.closureBindingId
+    }
+    def closureOriginalName: Option[String] = node match {
+      case stored: nodes.StoredNode         => new Access_Property_CLOSURE_ORIGINAL_NAME(stored).closureOriginalName
+      case newNode: nodes.NewClosureBinding => newNode.closureOriginalName
+    }
+    def evaluationStrategy: String = node match {
+      case stored: nodes.StoredNode         => new Access_Property_EVALUATION_STRATEGY(stored).evaluationStrategy
+      case newNode: nodes.NewClosureBinding => newNode.evaluationStrategy
+    }
+  }
+  final class Access_CommentBase(val node: nodes.CommentBase) extends AnyVal {
+    def filename: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_FILENAME(stored).filename
+      case newNode: nodes.NewComment => newNode.filename
+    }
+  }
+  final class Access_ConfigFileBase(val node: nodes.ConfigFileBase) extends AnyVal {
+    def content: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_CONTENT(stored).content
+      case newNode: nodes.NewConfigFile => newNode.content
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewConfigFile => newNode.name
+    }
+  }
+  final class Access_ControlStructureBase(val node: nodes.ControlStructureBase) extends AnyVal {
+    def controlStructureType: String = node match {
+      case stored: nodes.StoredNode           => new Access_Property_CONTROL_STRUCTURE_TYPE(stored).controlStructureType
+      case newNode: nodes.NewControlStructure => newNode.controlStructureType
+    }
+    def parserTypeName: String = node match {
+      case stored: nodes.StoredNode           => new Access_Property_PARSER_TYPE_NAME(stored).parserTypeName
+      case newNode: nodes.NewControlStructure => newNode.parserTypeName
+    }
+  }
+  final class Access_DependencyBase(val node: nodes.DependencyBase) extends AnyVal {
+    def dependencyGroupId: Option[String] = node match {
+      case stored: nodes.StoredNode     => new Access_Property_DEPENDENCY_GROUP_ID(stored).dependencyGroupId
+      case newNode: nodes.NewDependency => newNode.dependencyGroupId
+    }
+    def dependencyType: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_DEPENDENCY_TYPE(stored).dependencyType
+      case newNode: nodes.NewDependency => newNode.dependencyType
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewDependency => newNode.name
+    }
+    def version: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_VERSION(stored).version
+      case newNode: nodes.NewDependency => newNode.version
+    }
+  }
+  final class Access_DomAttributeBase(val node: nodes.DomAttributeBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode       => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewDomAttribute => newNode.name
+    }
+    def value: String = node match {
+      case stored: nodes.StoredNode       => new Access_Property_VALUE(stored).value
+      case newNode: nodes.NewDomAttribute => newNode.value
+    }
+  }
+  final class Access_DomNodeBase(val node: nodes.DomNodeBase) extends AnyVal {
+    def columnNumber: Option[Int] = node match {
+      case stored: nodes.StoredNode  => new Access_Property_COLUMN_NUMBER(stored).columnNumber
+      case newNode: nodes.NewDomNode => newNode.columnNumber
+    }
+    def lineNumber: Option[Int] = node match {
+      case stored: nodes.StoredNode  => new Access_Property_LINE_NUMBER(stored).lineNumber
+      case newNode: nodes.NewDomNode => newNode.lineNumber
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewDomNode => newNode.name
+    }
+  }
+  final class Access_FieldIdentifierBase(val node: nodes.FieldIdentifierBase) extends AnyVal {
+    def canonicalName: String = node match {
+      case stored: nodes.StoredNode          => new Access_Property_CANONICAL_NAME(stored).canonicalName
+      case newNode: nodes.NewFieldIdentifier => newNode.canonicalName
+    }
+  }
+  final class Access_FileBase(val node: nodes.FileBase) extends AnyVal {
+    def hash: Option[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_HASH(stored).hash
+      case newNode: nodes.NewFile   => newNode.hash
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewFile   => newNode.name
+    }
+  }
+  final class Access_FindingBase(val node: nodes.FindingBase) extends AnyVal {
+    def structuredFingerprint: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_STRUCTURED_FINGERPRINT(stored).structuredFingerprint
+      case newNode: nodes.NewFinding => newNode.structuredFingerprint
+    }
+  }
+  final class Access_FlowBase(val node: nodes.FlowBase) extends AnyVal {}
+  final class Access_FrameworkBase(val node: nodes.FrameworkBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewFramework => newNode.name
+    }
+  }
+  final class Access_FrameworkDataBase(val node: nodes.FrameworkDataBase) extends AnyVal {
+    def content: String = node match {
+      case stored: nodes.StoredNode        => new Access_Property_CONTENT(stored).content
+      case newNode: nodes.NewFrameworkData => newNode.content
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode        => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewFrameworkData => newNode.name
+    }
+  }
+  final class Access_IdentifierBase(val node: nodes.IdentifierBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode     => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewIdentifier => newNode.dynamicTypeHintFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewIdentifier => newNode.typeFullName
+    }
+  }
+  final class Access_ImplicitCallBase(val node: nodes.ImplicitCallBase) extends AnyVal {}
+  final class Access_ImportBase(val node: nodes.ImportBase) extends AnyVal {
+    def explicitAs: Option[Boolean] = node match {
+      case stored: nodes.StoredNode => new Access_Property_EXPLICIT_AS(stored).explicitAs
+      case newNode: nodes.NewImport => newNode.explicitAs
+    }
+    def importedAs: Option[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_IMPORTED_AS(stored).importedAs
+      case newNode: nodes.NewImport => newNode.importedAs
+    }
+    def importedEntity: Option[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_IMPORTED_ENTITY(stored).importedEntity
+      case newNode: nodes.NewImport => newNode.importedEntity
+    }
+    def isExplicit: Option[Boolean] = node match {
+      case stored: nodes.StoredNode => new Access_Property_IS_EXPLICIT(stored).isExplicit
+      case newNode: nodes.NewImport => newNode.isExplicit
+    }
+    def isWildcard: Option[Boolean] = node match {
+      case stored: nodes.StoredNode => new Access_Property_IS_WILDCARD(stored).isWildcard
+      case newNode: nodes.NewImport => newNode.isWildcard
+    }
+  }
+  final class Access_IoflowBase(val node: nodes.IoflowBase) extends AnyVal {
+    def fingerprint: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_FINGERPRINT(stored).fingerprint
+      case newNode: nodes.NewIoflow => newNode.fingerprint
+    }
+    def literalsToSink: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_LITERALS_TO_SINK(stored).literalsToSink
+      case newNode: nodes.NewIoflow => newNode.literalsToSink
+    }
+    def mlAssisted: Boolean = node match {
+      case stored: nodes.StoredNode => new Access_Property_ML_ASSISTED(stored).mlAssisted
+      case newNode: nodes.NewIoflow => newNode.mlAssisted
+    }
+  }
+  final class Access_JumpLabelBase(val node: nodes.JumpLabelBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewJumpLabel => newNode.name
+    }
+    def parserTypeName: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_PARSER_TYPE_NAME(stored).parserTypeName
+      case newNode: nodes.NewJumpLabel => newNode.parserTypeName
+    }
+  }
+  final class Access_JumpTargetBase(val node: nodes.JumpTargetBase) extends AnyVal {
+    def argumentIndex: Int = node match {
+      case stored: nodes.StoredNode     => new Access_Property_ARGUMENT_INDEX(stored).argumentIndex
+      case newNode: nodes.NewJumpTarget => newNode.argumentIndex
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewJumpTarget => newNode.name
+    }
+    def parserTypeName: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_PARSER_TYPE_NAME(stored).parserTypeName
+      case newNode: nodes.NewJumpTarget => newNode.parserTypeName
+    }
+  }
+  final class Access_KeyValuePairBase(val node: nodes.KeyValuePairBase) extends AnyVal {
+    def key: String = node match {
+      case stored: nodes.StoredNode       => new Access_Property_KEY(stored).key
+      case newNode: nodes.NewKeyValuePair => newNode.key
+    }
+    def value: String = node match {
+      case stored: nodes.StoredNode       => new Access_Property_VALUE(stored).value
+      case newNode: nodes.NewKeyValuePair => newNode.value
+    }
+  }
+  final class Access_LiteralBase(val node: nodes.LiteralBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode  => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewLiteral => newNode.dynamicTypeHintFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewLiteral => newNode.typeFullName
+    }
+  }
+  final class Access_LocalBase(val node: nodes.LocalBase) extends AnyVal {
+    def closureBindingId: Option[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_CLOSURE_BINDING_ID(stored).closureBindingId
+      case newNode: nodes.NewLocal  => newNode.closureBindingId
+    }
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewLocal  => newNode.dynamicTypeHintFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewLocal  => newNode.typeFullName
+    }
+  }
+  final class Access_LocationBase(val node: nodes.LocationBase) extends AnyVal {
+    def className: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_CLASS_NAME(stored).className
+      case newNode: nodes.NewLocation => newNode.className
+    }
+    def classShortName: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_CLASS_SHORT_NAME(stored).classShortName
+      case newNode: nodes.NewLocation => newNode.classShortName
+    }
+    def filename: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_FILENAME(stored).filename
+      case newNode: nodes.NewLocation => newNode.filename
+    }
+    def lineNumber: Option[Int] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_LINE_NUMBER(stored).lineNumber
+      case newNode: nodes.NewLocation => newNode.lineNumber
+    }
+    def methodFullName: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_METHOD_FULL_NAME(stored).methodFullName
+      case newNode: nodes.NewLocation => newNode.methodFullName
+    }
+    def methodShortName: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_METHOD_SHORT_NAME(stored).methodShortName
+      case newNode: nodes.NewLocation => newNode.methodShortName
+    }
+    def nodeLabel: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_NODE_LABEL(stored).nodeLabel
+      case newNode: nodes.NewLocation => newNode.nodeLabel
+    }
+    def packageName: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_PACKAGE_NAME(stored).packageName
+      case newNode: nodes.NewLocation => newNode.packageName
+    }
+    def symbol: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_SYMBOL(stored).symbol
+      case newNode: nodes.NewLocation => newNode.symbol
+    }
+  }
+  final class Access_MatchInfoBase(val node: nodes.MatchInfoBase) extends AnyVal {
+    def category: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_CATEGORY(stored).category
+      case newNode: nodes.NewMatchInfo => newNode.category
+    }
+    def pattern: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_PATTERN(stored).pattern
+      case newNode: nodes.NewMatchInfo => newNode.pattern
+    }
+  }
+  final class Access_MemberBase(val node: nodes.MemberBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewMember => newNode.dynamicTypeHintFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewMember => newNode.typeFullName
+    }
+  }
+  final class Access_MetaDataBase(val node: nodes.MetaDataBase) extends AnyVal {
+    def hash: Option[String] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_HASH(stored).hash
+      case newNode: nodes.NewMetaData => newNode.hash
+    }
+    def language: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_LANGUAGE(stored).language
+      case newNode: nodes.NewMetaData => newNode.language
+    }
+    def overlays: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_OVERLAYS(stored).overlays
+      case newNode: nodes.NewMetaData => newNode.overlays
+    }
+    def policyDirectories: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_POLICY_DIRECTORIES(stored).policyDirectories
+      case newNode: nodes.NewMetaData => newNode.policyDirectories
+    }
+    def root: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_ROOT(stored).root
+      case newNode: nodes.NewMetaData => newNode.root
+    }
+    def spid: Option[String] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_SPID(stored).spid
+      case newNode: nodes.NewMetaData => newNode.spid
+    }
+    def version: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_VERSION(stored).version
+      case newNode: nodes.NewMetaData => newNode.version
+    }
+  }
+  final class Access_MethodBase(val node: nodes.MethodBase) extends AnyVal {
+    def astParentFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_AST_PARENT_FULL_NAME(stored).astParentFullName
+      case newNode: nodes.NewMethod => newNode.astParentFullName
+    }
+    def astParentType: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_AST_PARENT_TYPE(stored).astParentType
+      case newNode: nodes.NewMethod => newNode.astParentType
+    }
+    def binarySignature: Option[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_BINARY_SIGNATURE(stored).binarySignature
+      case newNode: nodes.NewMethod => newNode.binarySignature
+    }
+    def columnNumberEnd: Option[Int] = node match {
+      case stored: nodes.StoredNode => new Access_Property_COLUMN_NUMBER_END(stored).columnNumberEnd
+      case newNode: nodes.NewMethod => newNode.columnNumberEnd
+    }
+    def filename: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_FILENAME(stored).filename
+      case newNode: nodes.NewMethod => newNode.filename
+    }
+    def fullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_FULL_NAME(stored).fullName
+      case newNode: nodes.NewMethod => newNode.fullName
+    }
+    def hash: Option[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_HASH(stored).hash
+      case newNode: nodes.NewMethod => newNode.hash
+    }
+    def hasMapping: Option[Boolean] = node match {
+      case stored: nodes.StoredNode => new Access_Property_HAS_MAPPING(stored).hasMapping
+      case newNode: nodes.NewMethod => newNode.hasMapping
+    }
+    def isExternal: Boolean = node match {
+      case stored: nodes.StoredNode => new Access_Property_IS_EXTERNAL(stored).isExternal
+      case newNode: nodes.NewMethod => newNode.isExternal
+    }
+    def lineNumberEnd: Option[Int] = node match {
+      case stored: nodes.StoredNode => new Access_Property_LINE_NUMBER_END(stored).lineNumberEnd
+      case newNode: nodes.NewMethod => newNode.lineNumberEnd
+    }
+    def signature: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_SIGNATURE(stored).signature
+      case newNode: nodes.NewMethod => newNode.signature
+    }
+    def varargParameter: Int = node match {
+      case stored: nodes.StoredNode => new Access_Property_VARARG_PARAMETER(stored).varargParameter
+      case newNode: nodes.NewMethod => newNode.varargParameter
+    }
+  }
+  final class Access_MethodInstBase(val node: nodes.MethodInstBase) extends AnyVal {
+    def fullName: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_FULL_NAME(stored).fullName
+      case newNode: nodes.NewMethodInst => newNode.fullName
+    }
+    def methodFullName: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_METHOD_FULL_NAME(stored).methodFullName
+      case newNode: nodes.NewMethodInst => newNode.methodFullName
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewMethodInst => newNode.name
+    }
+    def signature: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_SIGNATURE(stored).signature
+      case newNode: nodes.NewMethodInst => newNode.signature
+    }
+  }
+  final class Access_MethodParameterInBase(val node: nodes.MethodParameterInBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode            => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewMethodParameterIn => newNode.dynamicTypeHintFullName
+    }
+    def evaluationStrategy: String = node match {
+      case stored: nodes.StoredNode            => new Access_Property_EVALUATION_STRATEGY(stored).evaluationStrategy
+      case newNode: nodes.NewMethodParameterIn => newNode.evaluationStrategy
+    }
+    def index: Int = node match {
+      case stored: nodes.StoredNode            => new Access_Property_INDEX(stored).index
+      case newNode: nodes.NewMethodParameterIn => newNode.index
+    }
+    def isVariadic: Boolean = node match {
+      case stored: nodes.StoredNode            => new Access_Property_IS_VARIADIC(stored).isVariadic
+      case newNode: nodes.NewMethodParameterIn => newNode.isVariadic
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode            => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewMethodParameterIn => newNode.typeFullName
+    }
+  }
+  final class Access_MethodParameterOutBase(val node: nodes.MethodParameterOutBase) extends AnyVal {
+    def evaluationStrategy: String = node match {
+      case stored: nodes.StoredNode             => new Access_Property_EVALUATION_STRATEGY(stored).evaluationStrategy
+      case newNode: nodes.NewMethodParameterOut => newNode.evaluationStrategy
+    }
+    def index: Int = node match {
+      case stored: nodes.StoredNode             => new Access_Property_INDEX(stored).index
+      case newNode: nodes.NewMethodParameterOut => newNode.index
+    }
+    def isVariadic: Boolean = node match {
+      case stored: nodes.StoredNode             => new Access_Property_IS_VARIADIC(stored).isVariadic
+      case newNode: nodes.NewMethodParameterOut => newNode.isVariadic
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode             => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewMethodParameterOut => newNode.typeFullName
+    }
+  }
+  final class Access_MethodRefBase(val node: nodes.MethodRefBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode    => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewMethodRef => newNode.dynamicTypeHintFullName
+    }
+    def methodFullName: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_METHOD_FULL_NAME(stored).methodFullName
+      case newNode: nodes.NewMethodRef => newNode.methodFullName
+    }
+    def methodInstFullName: Option[String] = node match {
+      case stored: nodes.StoredNode    => new Access_Property_METHOD_INST_FULL_NAME(stored).methodInstFullName
+      case newNode: nodes.NewMethodRef => newNode.methodInstFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewMethodRef => newNode.typeFullName
+    }
+  }
+  final class Access_MethodReturnBase(val node: nodes.MethodReturnBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode       => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewMethodReturn => newNode.dynamicTypeHintFullName
+    }
+    def evaluationStrategy: String = node match {
+      case stored: nodes.StoredNode       => new Access_Property_EVALUATION_STRATEGY(stored).evaluationStrategy
+      case newNode: nodes.NewMethodReturn => newNode.evaluationStrategy
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode       => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewMethodReturn => newNode.typeFullName
+    }
+  }
+  final class Access_MethodSummaryBase(val node: nodes.MethodSummaryBase) extends AnyVal {
+    def binarySignature: Option[String] = node match {
+      case stored: nodes.StoredNode        => new Access_Property_BINARY_SIGNATURE(stored).binarySignature
+      case newNode: nodes.NewMethodSummary => newNode.binarySignature
+    }
+    def isExternal: Boolean = node match {
+      case stored: nodes.StoredNode        => new Access_Property_IS_EXTERNAL(stored).isExternal
+      case newNode: nodes.NewMethodSummary => newNode.isExternal
+    }
+    def isStatic: Boolean = node match {
+      case stored: nodes.StoredNode        => new Access_Property_IS_STATIC(stored).isStatic
+      case newNode: nodes.NewMethodSummary => newNode.isStatic
+    }
+  }
+  final class Access_ModifierBase(val node: nodes.ModifierBase) extends AnyVal {
+    def modifierType: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_MODIFIER_TYPE(stored).modifierType
+      case newNode: nodes.NewModifier => newNode.modifierType
+    }
+  }
+  final class Access_NamespaceBase(val node: nodes.NamespaceBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewNamespace => newNode.name
+    }
+  }
+  final class Access_NamespaceBlockBase(val node: nodes.NamespaceBlockBase) extends AnyVal {
+    def filename: String = node match {
+      case stored: nodes.StoredNode         => new Access_Property_FILENAME(stored).filename
+      case newNode: nodes.NewNamespaceBlock => newNode.filename
+    }
+    def fullName: String = node match {
+      case stored: nodes.StoredNode         => new Access_Property_FULL_NAME(stored).fullName
+      case newNode: nodes.NewNamespaceBlock => newNode.fullName
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode         => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewNamespaceBlock => newNode.name
+    }
+  }
+  final class Access_PackagePrefixBase(val node: nodes.PackagePrefixBase) extends AnyVal {
+    def value: String = node match {
+      case stored: nodes.StoredNode        => new Access_Property_VALUE(stored).value
+      case newNode: nodes.NewPackagePrefix => newNode.value
+    }
+  }
+  final class Access_PostExecutionCallBase(val node: nodes.PostExecutionCallBase) extends AnyVal {}
+  final class Access_ProgramPointBase(val node: nodes.ProgramPointBase)           extends AnyVal {}
+  final class Access_ReadBase(val node: nodes.ReadBase)                           extends AnyVal {}
+  final class Access_ReturnBase(val node: nodes.ReturnBase)                       extends AnyVal {}
+  final class Access_RouteBase(val node: nodes.RouteBase) extends AnyVal {
+    def path: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_PATH(stored).path
+      case newNode: nodes.NewRoute  => newNode.path
+    }
+  }
+  final class Access_SensitiveDataTypeBase(val node: nodes.SensitiveDataTypeBase) extends AnyVal {
+    def fullName: String = node match {
+      case stored: nodes.StoredNode            => new Access_Property_FULL_NAME(stored).fullName
+      case newNode: nodes.NewSensitiveDataType => newNode.fullName
+    }
+  }
+  final class Access_SensitiveMemberBase(val node: nodes.SensitiveMemberBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode          => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewSensitiveMember => newNode.name
+    }
+  }
+  final class Access_SensitiveReferenceBase(val node: nodes.SensitiveReferenceBase) extends AnyVal {}
+  final class Access_SensitiveVariableBase(val node: nodes.SensitiveVariableBase) extends AnyVal {
+    def categories: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode            => new Access_Property_CATEGORIES(stored).categories
+      case newNode: nodes.NewSensitiveVariable => newNode.categories
+    }
+    def evalType: String = node match {
+      case stored: nodes.StoredNode            => new Access_Property_EVAL_TYPE(stored).evalType
+      case newNode: nodes.NewSensitiveVariable => newNode.evalType
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode            => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewSensitiveVariable => newNode.name
+    }
+  }
+  final class Access_SinkBase(val node: nodes.SinkBase) extends AnyVal {
+    def sinkType: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_SINK_TYPE(stored).sinkType
+      case newNode: nodes.NewSink   => newNode.sinkType
+    }
+    def structuredFingerprint: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_STRUCTURED_FINGERPRINT(stored).structuredFingerprint
+      case newNode: nodes.NewSink   => newNode.structuredFingerprint
+    }
+  }
+  final class Access_SourceBase(val node: nodes.SourceBase) extends AnyVal {
+    def sourceType: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_SOURCE_TYPE(stored).sourceType
+      case newNode: nodes.NewSource => newNode.sourceType
+    }
+    def structuredFingerprint: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_STRUCTURED_FINGERPRINT(stored).structuredFingerprint
+      case newNode: nodes.NewSource => newNode.structuredFingerprint
+    }
+  }
+  final class Access_SpAnnotationParameterBase(val node: nodes.SpAnnotationParameterBase) extends AnyVal {
+    def annotationFullName: String = node match {
+      case stored: nodes.StoredNode                => new Access_Property_ANNOTATION_FULL_NAME(stored).annotationFullName
+      case newNode: nodes.NewSpAnnotationParameter => newNode.annotationFullName
+    }
+    def annotationName: String = node match {
+      case stored: nodes.StoredNode                => new Access_Property_ANNOTATION_NAME(stored).annotationName
+      case newNode: nodes.NewSpAnnotationParameter => newNode.annotationName
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode                => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewSpAnnotationParameter => newNode.name
+    }
+    def value: String = node match {
+      case stored: nodes.StoredNode                => new Access_Property_VALUE(stored).value
+      case newNode: nodes.NewSpAnnotationParameter => newNode.value
+    }
+  }
+  final class Access_SpBlacklistBase(val node: nodes.SpBlacklistBase) extends AnyVal {}
+  final class Access_TagBase(val node: nodes.TagBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewTag    => newNode.name
+    }
+    def value: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_VALUE(stored).value
+      case newNode: nodes.NewTag    => newNode.value
+    }
+  }
+  final class Access_TagsBase(val node: nodes.TagsBase)               extends AnyVal {}
+  final class Access_TagNodePairBase(val node: nodes.TagNodePairBase) extends AnyVal {}
+  final class Access_TemplateDomBase(val node: nodes.TemplateDomBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode      => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewTemplateDom => newNode.name
+    }
+  }
+  final class Access_TransformBase(val node: nodes.TransformBase)           extends AnyVal {}
+  final class Access_TransformationBase(val node: nodes.TransformationBase) extends AnyVal {}
+  final class Access_TypeBase(val node: nodes.TypeBase) extends AnyVal {
+    def fullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_FULL_NAME(stored).fullName
+      case newNode: nodes.NewType   => newNode.fullName
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewType   => newNode.name
+    }
+    def typeDeclFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_TYPE_DECL_FULL_NAME(stored).typeDeclFullName
+      case newNode: nodes.NewType   => newNode.typeDeclFullName
+    }
+  }
+  final class Access_TypeArgumentBase(val node: nodes.TypeArgumentBase) extends AnyVal {}
+  final class Access_TypeDeclBase(val node: nodes.TypeDeclBase) extends AnyVal {
+    def aliasTypeFullName: Option[String] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_ALIAS_TYPE_FULL_NAME(stored).aliasTypeFullName
+      case newNode: nodes.NewTypeDecl => newNode.aliasTypeFullName
+    }
+    def astParentFullName: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_AST_PARENT_FULL_NAME(stored).astParentFullName
+      case newNode: nodes.NewTypeDecl => newNode.astParentFullName
+    }
+    def astParentType: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_AST_PARENT_TYPE(stored).astParentType
+      case newNode: nodes.NewTypeDecl => newNode.astParentType
+    }
+    def filename: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_FILENAME(stored).filename
+      case newNode: nodes.NewTypeDecl => newNode.filename
+    }
+    def fullName: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_FULL_NAME(stored).fullName
+      case newNode: nodes.NewTypeDecl => newNode.fullName
+    }
+    def inheritsFromTypeFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_INHERITS_FROM_TYPE_FULL_NAME(stored).inheritsFromTypeFullName
+      case newNode: nodes.NewTypeDecl => newNode.inheritsFromTypeFullName
+    }
+    def isExternal: Boolean = node match {
+      case stored: nodes.StoredNode   => new Access_Property_IS_EXTERNAL(stored).isExternal
+      case newNode: nodes.NewTypeDecl => newNode.isExternal
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewTypeDecl => newNode.name
+    }
+  }
+  final class Access_TypeParameterBase(val node: nodes.TypeParameterBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode        => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewTypeParameter => newNode.name
+    }
+  }
+  final class Access_TypeRefBase(val node: nodes.TypeRefBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode  => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewTypeRef => newNode.dynamicTypeHintFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewTypeRef => newNode.typeFullName
+    }
+  }
+  final class Access_UnknownBase(val node: nodes.UnknownBase) extends AnyVal {
+    def containedRef: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_CONTAINED_REF(stored).containedRef
+      case newNode: nodes.NewUnknown => newNode.containedRef
+    }
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode  => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewUnknown => newNode.dynamicTypeHintFullName
+    }
+    def parserTypeName: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_PARSER_TYPE_NAME(stored).parserTypeName
+      case newNode: nodes.NewUnknown => newNode.parserTypeName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewUnknown => newNode.typeFullName
+    }
+  }
+  final class Access_VariableInfoBase(val node: nodes.VariableInfoBase) extends AnyVal {
+    def evaluationType: String = node match {
+      case stored: nodes.StoredNode       => new Access_Property_EVALUATION_TYPE(stored).evaluationType
+      case newNode: nodes.NewVariableInfo => newNode.evaluationType
+    }
+    def parameterIndex: Option[Int] = node match {
+      case stored: nodes.StoredNode       => new Access_Property_PARAMETER_INDEX(stored).parameterIndex
+      case newNode: nodes.NewVariableInfo => newNode.parameterIndex
+    }
+    def varType: String = node match {
+      case stored: nodes.StoredNode       => new Access_Property_VAR_TYPE(stored).varType
+      case newNode: nodes.NewVariableInfo => newNode.varType
+    }
+  }
+  final class Access_VulnerabilityBase(val node: nodes.VulnerabilityBase) extends AnyVal {
+    def description: String = node match {
+      case stored: nodes.StoredNode        => new Access_Property_DESCRIPTION(stored).description
+      case newNode: nodes.NewVulnerability => newNode.description
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode        => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewVulnerability => newNode.name
+    }
+    def score: String = node match {
+      case stored: nodes.StoredNode        => new Access_Property_SCORE(stored).score
+      case newNode: nodes.NewVulnerability => newNode.score
+    }
+    def url: String = node match {
+      case stored: nodes.StoredNode        => new Access_Property_URL(stored).url
+      case newNode: nodes.NewVulnerability => newNode.url
+    }
+  }
+  final class Access_WriteBase(val node: nodes.WriteBase) extends AnyVal {}
+  final class Access_AstNodeBase(val node: nodes.AstNodeBase) extends AnyVal {
+    def code: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_CODE(stored).code
+      case newNode: nodes.AstNodeNew => newNode.code
+    }
+    def columnNumber: Option[Int] = node match {
+      case stored: nodes.StoredNode  => new Access_Property_COLUMN_NUMBER(stored).columnNumber
+      case newNode: nodes.AstNodeNew => newNode.columnNumber
+    }
+    def lineNumber: Option[Int] = node match {
+      case stored: nodes.StoredNode  => new Access_Property_LINE_NUMBER(stored).lineNumber
+      case newNode: nodes.AstNodeNew => newNode.lineNumber
+    }
+    def order: Int = node match {
+      case stored: nodes.StoredNode  => new Access_Property_ORDER(stored).order
+      case newNode: nodes.AstNodeNew => newNode.order
+    }
+  }
+  final class Access_CallReprBase(val node: nodes.CallReprBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_NAME(stored).name
+      case newNode: nodes.CallReprNew => newNode.name
+    }
+    def signature: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_SIGNATURE(stored).signature
+      case newNode: nodes.CallReprNew => newNode.signature
+    }
+  }
+  final class Access_CfgNodeBase(val node: nodes.CfgNodeBase) extends AnyVal {
+    def depthFirstOrder: Int = node match {
+      case stored: nodes.StoredNode  => new Access_Property_DEPTH_FIRST_ORDER(stored).depthFirstOrder
+      case newNode: nodes.CfgNodeNew => newNode.depthFirstOrder
+    }
+    def internalFlags: Int = node match {
+      case stored: nodes.StoredNode  => new Access_Property_INTERNAL_FLAGS(stored).internalFlags
+      case newNode: nodes.CfgNodeNew => newNode.internalFlags
+    }
+  }
+  final class Access_ExpressionBase(val node: nodes.ExpressionBase) extends AnyVal {
+    def argumentIndex: Int = node match {
+      case stored: nodes.StoredNode     => new Access_Property_ARGUMENT_INDEX(stored).argumentIndex
+      case newNode: nodes.ExpressionNew => newNode.argumentIndex
+    }
+    def argumentName: Option[String] = node match {
+      case stored: nodes.StoredNode     => new Access_Property_ARGUMENT_NAME(stored).argumentName
+      case newNode: nodes.ExpressionNew => newNode.argumentName
+    }
+  }
+  final class Access_DeclarationBase(val node: nodes.DeclarationBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode      => new Access_Property_NAME(stored).name
+      case newNode: nodes.DeclarationNew => newNode.name
+    }
+  }
+  final class Access_TrackingPointBase(val node: nodes.TrackingPointBase) extends AnyVal {
+    def code: String = node match {
+      case stored: nodes.StoredNode        => new Access_Property_CODE(stored).code
+      case newNode: nodes.TrackingPointNew => newNode.code
+    }
+  }
+  final class Access_LocalLikeBase(val node: nodes.LocalLikeBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_NAME(stored).name
+      case newNode: nodes.LocalLikeNew => newNode.name
+    }
   }
 }
 
-object Lang extends ImplicitAccessors
-trait ImplicitAccessors {
+object Lang extends ConcreteStoredConversions {}
+
+trait ConcreteStoredConversions extends ConcreteBaseConversions {
   import Accessors._
   implicit def accessPropertyAliasTypeFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasAliasTypeFullNameT]
-  ): Access_property_ALIAS_TYPE_FULL_NAME = new Access_property_ALIAS_TYPE_FULL_NAME(node)
+  ): Access_Property_ALIAS_TYPE_FULL_NAME = new Access_Property_ALIAS_TYPE_FULL_NAME(node)
   implicit def accessPropertyAnnotationFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasAnnotationFullNameT]
-  ): Access_property_ANNOTATION_FULL_NAME = new Access_property_ANNOTATION_FULL_NAME(node)
+  ): Access_Property_ANNOTATION_FULL_NAME = new Access_Property_ANNOTATION_FULL_NAME(node)
   implicit def accessPropertyAnnotationName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasAnnotationNameT]
-  ): Access_property_ANNOTATION_NAME = new Access_property_ANNOTATION_NAME(node)
+  ): Access_Property_ANNOTATION_NAME = new Access_Property_ANNOTATION_NAME(node)
   implicit def accessPropertyArgumentIndex(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasArgumentIndexT]
-  ): Access_property_ARGUMENT_INDEX = new Access_property_ARGUMENT_INDEX(node)
+  ): Access_Property_ARGUMENT_INDEX = new Access_Property_ARGUMENT_INDEX(node)
   implicit def accessPropertyArgumentName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasArgumentNameT]
-  ): Access_property_ARGUMENT_NAME = new Access_property_ARGUMENT_NAME(node)
+  ): Access_Property_ARGUMENT_NAME = new Access_Property_ARGUMENT_NAME(node)
   implicit def accessPropertyAstParentFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasAstParentFullNameT]
-  ): Access_property_AST_PARENT_FULL_NAME = new Access_property_AST_PARENT_FULL_NAME(node)
+  ): Access_Property_AST_PARENT_FULL_NAME = new Access_Property_AST_PARENT_FULL_NAME(node)
   implicit def accessPropertyAstParentType(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasAstParentTypeT]
-  ): Access_property_AST_PARENT_TYPE = new Access_property_AST_PARENT_TYPE(node)
+  ): Access_Property_AST_PARENT_TYPE = new Access_Property_AST_PARENT_TYPE(node)
   implicit def accessPropertyBinarySignature(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasBinarySignatureT]
-  ): Access_property_BINARY_SIGNATURE = new Access_property_BINARY_SIGNATURE(node)
+  ): Access_Property_BINARY_SIGNATURE = new Access_Property_BINARY_SIGNATURE(node)
   implicit def accessPropertyCanonicalName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasCanonicalNameT]
-  ): Access_property_CANONICAL_NAME = new Access_property_CANONICAL_NAME(node)
-  implicit def accessPropertyCategories(node: nodes.StoredNode with nodes.StaticType[nodes.HasCategoriesT]): Access_property_CATEGORIES =
-    new Access_property_CATEGORIES(node)
-  implicit def accessPropertyCategory(node: nodes.StoredNode with nodes.StaticType[nodes.HasCategoryT]): Access_property_CATEGORY =
-    new Access_property_CATEGORY(node)
-  implicit def accessPropertyClassName(node: nodes.StoredNode with nodes.StaticType[nodes.HasClassNameT]): Access_property_CLASS_NAME =
-    new Access_property_CLASS_NAME(node)
+  ): Access_Property_CANONICAL_NAME = new Access_Property_CANONICAL_NAME(node)
+  implicit def accessPropertyCategories(node: nodes.StoredNode with nodes.StaticType[nodes.HasCategoriesT]): Access_Property_CATEGORIES =
+    new Access_Property_CATEGORIES(node)
+  implicit def accessPropertyCategory(node: nodes.StoredNode with nodes.StaticType[nodes.HasCategoryT]): Access_Property_CATEGORY =
+    new Access_Property_CATEGORY(node)
+  implicit def accessPropertyClassName(node: nodes.StoredNode with nodes.StaticType[nodes.HasClassNameT]): Access_Property_CLASS_NAME =
+    new Access_Property_CLASS_NAME(node)
   implicit def accessPropertyClassShortName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasClassShortNameT]
-  ): Access_property_CLASS_SHORT_NAME = new Access_property_CLASS_SHORT_NAME(node)
+  ): Access_Property_CLASS_SHORT_NAME = new Access_Property_CLASS_SHORT_NAME(node)
   implicit def accessPropertyClosureBindingId(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasClosureBindingIdT]
-  ): Access_property_CLOSURE_BINDING_ID = new Access_property_CLOSURE_BINDING_ID(node)
+  ): Access_Property_CLOSURE_BINDING_ID = new Access_Property_CLOSURE_BINDING_ID(node)
   implicit def accessPropertyClosureOriginalName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasClosureOriginalNameT]
-  ): Access_property_CLOSURE_ORIGINAL_NAME = new Access_property_CLOSURE_ORIGINAL_NAME(node)
-  implicit def accessPropertyCode(node: nodes.StoredNode with nodes.StaticType[nodes.HasCodeT]): Access_property_CODE =
-    new Access_property_CODE(node)
+  ): Access_Property_CLOSURE_ORIGINAL_NAME = new Access_Property_CLOSURE_ORIGINAL_NAME(node)
+  implicit def accessPropertyCode(node: nodes.StoredNode with nodes.StaticType[nodes.HasCodeT]): Access_Property_CODE =
+    new Access_Property_CODE(node)
   implicit def accessPropertyColumnNumber(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasColumnNumberT]
-  ): Access_property_COLUMN_NUMBER = new Access_property_COLUMN_NUMBER(node)
+  ): Access_Property_COLUMN_NUMBER = new Access_Property_COLUMN_NUMBER(node)
   implicit def accessPropertyColumnNumberEnd(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasColumnNumberEndT]
-  ): Access_property_COLUMN_NUMBER_END = new Access_property_COLUMN_NUMBER_END(node)
+  ): Access_Property_COLUMN_NUMBER_END = new Access_Property_COLUMN_NUMBER_END(node)
   implicit def accessPropertyContainedRef(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasContainedRefT]
-  ): Access_property_CONTAINED_REF = new Access_property_CONTAINED_REF(node)
-  implicit def accessPropertyContent(node: nodes.StoredNode with nodes.StaticType[nodes.HasContentT]): Access_property_CONTENT =
-    new Access_property_CONTENT(node)
+  ): Access_Property_CONTAINED_REF = new Access_Property_CONTAINED_REF(node)
+  implicit def accessPropertyContent(node: nodes.StoredNode with nodes.StaticType[nodes.HasContentT]): Access_Property_CONTENT =
+    new Access_Property_CONTENT(node)
   implicit def accessPropertyControlStructureType(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasControlStructureTypeT]
-  ): Access_property_CONTROL_STRUCTURE_TYPE = new Access_property_CONTROL_STRUCTURE_TYPE(node)
+  ): Access_Property_CONTROL_STRUCTURE_TYPE = new Access_Property_CONTROL_STRUCTURE_TYPE(node)
   implicit def accessPropertyDependencyGroupId(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasDependencyGroupIdT]
-  ): Access_property_DEPENDENCY_GROUP_ID = new Access_property_DEPENDENCY_GROUP_ID(node)
+  ): Access_Property_DEPENDENCY_GROUP_ID = new Access_Property_DEPENDENCY_GROUP_ID(node)
   implicit def accessPropertyDependencyType(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasDependencyTypeT]
-  ): Access_property_DEPENDENCY_TYPE = new Access_property_DEPENDENCY_TYPE(node)
+  ): Access_Property_DEPENDENCY_TYPE = new Access_Property_DEPENDENCY_TYPE(node)
   implicit def accessPropertyDepthFirstOrder(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasDepthFirstOrderT]
-  ): Access_property_DEPTH_FIRST_ORDER = new Access_property_DEPTH_FIRST_ORDER(node)
-  implicit def accessPropertyDescription(node: nodes.StoredNode with nodes.StaticType[nodes.HasDescriptionT]): Access_property_DESCRIPTION =
-    new Access_property_DESCRIPTION(node)
+  ): Access_Property_DEPTH_FIRST_ORDER = new Access_Property_DEPTH_FIRST_ORDER(node)
+  implicit def accessPropertyDescription(node: nodes.StoredNode with nodes.StaticType[nodes.HasDescriptionT]): Access_Property_DESCRIPTION =
+    new Access_Property_DESCRIPTION(node)
   implicit def accessPropertyDispatchName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasDispatchNameT]
-  ): Access_property_DISPATCH_NAME = new Access_property_DISPATCH_NAME(node)
+  ): Access_Property_DISPATCH_NAME = new Access_Property_DISPATCH_NAME(node)
   implicit def accessPropertyDispatchType(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasDispatchTypeT]
-  ): Access_property_DISPATCH_TYPE = new Access_property_DISPATCH_TYPE(node)
+  ): Access_Property_DISPATCH_TYPE = new Access_Property_DISPATCH_TYPE(node)
   implicit def accessPropertyDynamicTypeHintFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasDynamicTypeHintFullNameT]
-  ): Access_property_DYNAMIC_TYPE_HINT_FULL_NAME = new Access_property_DYNAMIC_TYPE_HINT_FULL_NAME(node)
+  ): Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME = new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(node)
   implicit def accessPropertyEvaluationStrategy(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasEvaluationStrategyT]
-  ): Access_property_EVALUATION_STRATEGY = new Access_property_EVALUATION_STRATEGY(node)
+  ): Access_Property_EVALUATION_STRATEGY = new Access_Property_EVALUATION_STRATEGY(node)
   implicit def accessPropertyEvaluationType(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasEvaluationTypeT]
-  ): Access_property_EVALUATION_TYPE = new Access_property_EVALUATION_TYPE(node)
-  implicit def accessPropertyEvalType(node: nodes.StoredNode with nodes.StaticType[nodes.HasEvalTypeT]): Access_property_EVAL_TYPE =
-    new Access_property_EVAL_TYPE(node)
-  implicit def accessPropertyExplicitAs(node: nodes.StoredNode with nodes.StaticType[nodes.HasExplicitAsT]): Access_property_EXPLICIT_AS =
-    new Access_property_EXPLICIT_AS(node)
-  implicit def accessPropertyFilename(node: nodes.StoredNode with nodes.StaticType[nodes.HasFilenameT]): Access_property_FILENAME =
-    new Access_property_FILENAME(node)
-  implicit def accessPropertyFingerprint(node: nodes.StoredNode with nodes.StaticType[nodes.HasFingerprintT]): Access_property_FINGERPRINT =
-    new Access_property_FINGERPRINT(node)
-  implicit def accessPropertyFullName(node: nodes.StoredNode with nodes.StaticType[nodes.HasFullNameT]): Access_property_FULL_NAME =
-    new Access_property_FULL_NAME(node)
-  implicit def accessPropertyHash(node: nodes.StoredNode with nodes.StaticType[nodes.HasHashT]): Access_property_HASH =
-    new Access_property_HASH(node)
-  implicit def accessPropertyHasMapping(node: nodes.StoredNode with nodes.StaticType[nodes.HasHasMappingT]): Access_property_HAS_MAPPING =
-    new Access_property_HAS_MAPPING(node)
-  implicit def accessPropertyImportedAs(node: nodes.StoredNode with nodes.StaticType[nodes.HasImportedAsT]): Access_property_IMPORTED_AS =
-    new Access_property_IMPORTED_AS(node)
+  ): Access_Property_EVALUATION_TYPE = new Access_Property_EVALUATION_TYPE(node)
+  implicit def accessPropertyEvalType(node: nodes.StoredNode with nodes.StaticType[nodes.HasEvalTypeT]): Access_Property_EVAL_TYPE =
+    new Access_Property_EVAL_TYPE(node)
+  implicit def accessPropertyExplicitAs(node: nodes.StoredNode with nodes.StaticType[nodes.HasExplicitAsT]): Access_Property_EXPLICIT_AS =
+    new Access_Property_EXPLICIT_AS(node)
+  implicit def accessPropertyFilename(node: nodes.StoredNode with nodes.StaticType[nodes.HasFilenameT]): Access_Property_FILENAME =
+    new Access_Property_FILENAME(node)
+  implicit def accessPropertyFingerprint(node: nodes.StoredNode with nodes.StaticType[nodes.HasFingerprintT]): Access_Property_FINGERPRINT =
+    new Access_Property_FINGERPRINT(node)
+  implicit def accessPropertyFullName(node: nodes.StoredNode with nodes.StaticType[nodes.HasFullNameT]): Access_Property_FULL_NAME =
+    new Access_Property_FULL_NAME(node)
+  implicit def accessPropertyHash(node: nodes.StoredNode with nodes.StaticType[nodes.HasHashT]): Access_Property_HASH =
+    new Access_Property_HASH(node)
+  implicit def accessPropertyHasMapping(node: nodes.StoredNode with nodes.StaticType[nodes.HasHasMappingT]): Access_Property_HAS_MAPPING =
+    new Access_Property_HAS_MAPPING(node)
+  implicit def accessPropertyImportedAs(node: nodes.StoredNode with nodes.StaticType[nodes.HasImportedAsT]): Access_Property_IMPORTED_AS =
+    new Access_Property_IMPORTED_AS(node)
   implicit def accessPropertyImportedEntity(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasImportedEntityT]
-  ): Access_property_IMPORTED_ENTITY = new Access_property_IMPORTED_ENTITY(node)
-  implicit def accessPropertyIndex(node: nodes.StoredNode with nodes.StaticType[nodes.HasIndexT]): Access_property_INDEX =
-    new Access_property_INDEX(node)
+  ): Access_Property_IMPORTED_ENTITY = new Access_Property_IMPORTED_ENTITY(node)
+  implicit def accessPropertyIndex(node: nodes.StoredNode with nodes.StaticType[nodes.HasIndexT]): Access_Property_INDEX =
+    new Access_Property_INDEX(node)
   implicit def accessPropertyInheritsFromTypeFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasInheritsFromTypeFullNameT]
-  ): Access_property_INHERITS_FROM_TYPE_FULL_NAME = new Access_property_INHERITS_FROM_TYPE_FULL_NAME(node)
+  ): Access_Property_INHERITS_FROM_TYPE_FULL_NAME = new Access_Property_INHERITS_FROM_TYPE_FULL_NAME(node)
   implicit def accessPropertyInternalFlags(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasInternalFlagsT]
-  ): Access_property_INTERNAL_FLAGS = new Access_property_INTERNAL_FLAGS(node)
-  implicit def accessPropertyIsExplicit(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsExplicitT]): Access_property_IS_EXPLICIT =
-    new Access_property_IS_EXPLICIT(node)
-  implicit def accessPropertyIsExternal(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsExternalT]): Access_property_IS_EXTERNAL =
-    new Access_property_IS_EXTERNAL(node)
+  ): Access_Property_INTERNAL_FLAGS = new Access_Property_INTERNAL_FLAGS(node)
+  implicit def accessPropertyIsExplicit(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsExplicitT]): Access_Property_IS_EXPLICIT =
+    new Access_Property_IS_EXPLICIT(node)
+  implicit def accessPropertyIsExternal(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsExternalT]): Access_Property_IS_EXTERNAL =
+    new Access_Property_IS_EXTERNAL(node)
   implicit def accessPropertyIsMethodNeverOverridden(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasIsMethodNeverOverriddenT]
-  ): Access_property_IS_METHOD_NEVER_OVERRIDDEN = new Access_property_IS_METHOD_NEVER_OVERRIDDEN(node)
-  implicit def accessPropertyIsStatic(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsStaticT]): Access_property_IS_STATIC =
-    new Access_property_IS_STATIC(node)
-  implicit def accessPropertyIsVariadic(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsVariadicT]): Access_property_IS_VARIADIC =
-    new Access_property_IS_VARIADIC(node)
-  implicit def accessPropertyIsWildcard(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsWildcardT]): Access_property_IS_WILDCARD =
-    new Access_property_IS_WILDCARD(node)
-  implicit def accessPropertyKey(node: nodes.StoredNode with nodes.StaticType[nodes.HasKeyT]): Access_property_KEY =
-    new Access_property_KEY(node)
-  implicit def accessPropertyLanguage(node: nodes.StoredNode with nodes.StaticType[nodes.HasLanguageT]): Access_property_LANGUAGE =
-    new Access_property_LANGUAGE(node)
-  implicit def accessPropertyLineNumber(node: nodes.StoredNode with nodes.StaticType[nodes.HasLineNumberT]): Access_property_LINE_NUMBER =
-    new Access_property_LINE_NUMBER(node)
+  ): Access_Property_IS_METHOD_NEVER_OVERRIDDEN = new Access_Property_IS_METHOD_NEVER_OVERRIDDEN(node)
+  implicit def accessPropertyIsStatic(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsStaticT]): Access_Property_IS_STATIC =
+    new Access_Property_IS_STATIC(node)
+  implicit def accessPropertyIsVariadic(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsVariadicT]): Access_Property_IS_VARIADIC =
+    new Access_Property_IS_VARIADIC(node)
+  implicit def accessPropertyIsWildcard(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsWildcardT]): Access_Property_IS_WILDCARD =
+    new Access_Property_IS_WILDCARD(node)
+  implicit def accessPropertyKey(node: nodes.StoredNode with nodes.StaticType[nodes.HasKeyT]): Access_Property_KEY =
+    new Access_Property_KEY(node)
+  implicit def accessPropertyLanguage(node: nodes.StoredNode with nodes.StaticType[nodes.HasLanguageT]): Access_Property_LANGUAGE =
+    new Access_Property_LANGUAGE(node)
+  implicit def accessPropertyLineNumber(node: nodes.StoredNode with nodes.StaticType[nodes.HasLineNumberT]): Access_Property_LINE_NUMBER =
+    new Access_Property_LINE_NUMBER(node)
   implicit def accessPropertyLineNumberEnd(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasLineNumberEndT]
-  ): Access_property_LINE_NUMBER_END = new Access_property_LINE_NUMBER_END(node)
+  ): Access_Property_LINE_NUMBER_END = new Access_Property_LINE_NUMBER_END(node)
   implicit def accessPropertyLiteralsToSink(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasLiteralsToSinkT]
-  ): Access_property_LITERALS_TO_SINK = new Access_property_LITERALS_TO_SINK(node)
+  ): Access_Property_LITERALS_TO_SINK = new Access_Property_LITERALS_TO_SINK(node)
   implicit def accessPropertyMethodFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasMethodFullNameT]
-  ): Access_property_METHOD_FULL_NAME = new Access_property_METHOD_FULL_NAME(node)
+  ): Access_Property_METHOD_FULL_NAME = new Access_Property_METHOD_FULL_NAME(node)
   implicit def accessPropertyMethodInstFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasMethodInstFullNameT]
-  ): Access_property_METHOD_INST_FULL_NAME = new Access_property_METHOD_INST_FULL_NAME(node)
+  ): Access_Property_METHOD_INST_FULL_NAME = new Access_Property_METHOD_INST_FULL_NAME(node)
   implicit def accessPropertyMethodShortName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasMethodShortNameT]
-  ): Access_property_METHOD_SHORT_NAME = new Access_property_METHOD_SHORT_NAME(node)
-  implicit def accessPropertyMlAssisted(node: nodes.StoredNode with nodes.StaticType[nodes.HasMlAssistedT]): Access_property_ML_ASSISTED =
-    new Access_property_ML_ASSISTED(node)
+  ): Access_Property_METHOD_SHORT_NAME = new Access_Property_METHOD_SHORT_NAME(node)
+  implicit def accessPropertyMlAssisted(node: nodes.StoredNode with nodes.StaticType[nodes.HasMlAssistedT]): Access_Property_ML_ASSISTED =
+    new Access_Property_ML_ASSISTED(node)
   implicit def accessPropertyModifierType(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasModifierTypeT]
-  ): Access_property_MODIFIER_TYPE = new Access_property_MODIFIER_TYPE(node)
-  implicit def accessPropertyName(node: nodes.StoredNode with nodes.StaticType[nodes.HasNameT]): Access_property_NAME =
-    new Access_property_NAME(node)
-  implicit def accessPropertyNodeLabel(node: nodes.StoredNode with nodes.StaticType[nodes.HasNodeLabelT]): Access_property_NODE_LABEL =
-    new Access_property_NODE_LABEL(node)
-  implicit def accessPropertyOrder(node: nodes.StoredNode with nodes.StaticType[nodes.HasOrderT]): Access_property_ORDER =
-    new Access_property_ORDER(node)
-  implicit def accessPropertyOverlays(node: nodes.StoredNode with nodes.StaticType[nodes.HasOverlaysT]): Access_property_OVERLAYS =
-    new Access_property_OVERLAYS(node)
+  ): Access_Property_MODIFIER_TYPE = new Access_Property_MODIFIER_TYPE(node)
+  implicit def accessPropertyName(node: nodes.StoredNode with nodes.StaticType[nodes.HasNameT]): Access_Property_NAME =
+    new Access_Property_NAME(node)
+  implicit def accessPropertyNodeLabel(node: nodes.StoredNode with nodes.StaticType[nodes.HasNodeLabelT]): Access_Property_NODE_LABEL =
+    new Access_Property_NODE_LABEL(node)
+  implicit def accessPropertyOrder(node: nodes.StoredNode with nodes.StaticType[nodes.HasOrderT]): Access_Property_ORDER =
+    new Access_Property_ORDER(node)
+  implicit def accessPropertyOverlays(node: nodes.StoredNode with nodes.StaticType[nodes.HasOverlaysT]): Access_Property_OVERLAYS =
+    new Access_Property_OVERLAYS(node)
   implicit def accessPropertyPackageName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasPackageNameT]
-  ): Access_property_PACKAGE_NAME = new Access_property_PACKAGE_NAME(node)
+  ): Access_Property_PACKAGE_NAME = new Access_Property_PACKAGE_NAME(node)
   implicit def accessPropertyParameterIndex(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasParameterIndexT]
-  ): Access_property_PARAMETER_INDEX = new Access_property_PARAMETER_INDEX(node)
+  ): Access_Property_PARAMETER_INDEX = new Access_Property_PARAMETER_INDEX(node)
   implicit def accessPropertyParserTypeName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasParserTypeNameT]
-  ): Access_property_PARSER_TYPE_NAME = new Access_property_PARSER_TYPE_NAME(node)
-  implicit def accessPropertyPath(node: nodes.StoredNode with nodes.StaticType[nodes.HasPathT]): Access_property_PATH =
-    new Access_property_PATH(node)
-  implicit def accessPropertyPattern(node: nodes.StoredNode with nodes.StaticType[nodes.HasPatternT]): Access_property_PATTERN =
-    new Access_property_PATTERN(node)
+  ): Access_Property_PARSER_TYPE_NAME = new Access_Property_PARSER_TYPE_NAME(node)
+  implicit def accessPropertyPath(node: nodes.StoredNode with nodes.StaticType[nodes.HasPathT]): Access_Property_PATH =
+    new Access_Property_PATH(node)
+  implicit def accessPropertyPattern(node: nodes.StoredNode with nodes.StaticType[nodes.HasPatternT]): Access_Property_PATTERN =
+    new Access_Property_PATTERN(node)
   implicit def accessPropertyPolicyDirectories(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasPolicyDirectoriesT]
-  ): Access_property_POLICY_DIRECTORIES = new Access_property_POLICY_DIRECTORIES(node)
-  implicit def accessPropertyResolved(node: nodes.StoredNode with nodes.StaticType[nodes.HasResolvedT]): Access_property_RESOLVED =
-    new Access_property_RESOLVED(node)
-  implicit def accessPropertyRoot(node: nodes.StoredNode with nodes.StaticType[nodes.HasRootT]): Access_property_ROOT =
-    new Access_property_ROOT(node)
-  implicit def accessPropertyScore(node: nodes.StoredNode with nodes.StaticType[nodes.HasScoreT]): Access_property_SCORE =
-    new Access_property_SCORE(node)
-  implicit def accessPropertySignature(node: nodes.StoredNode with nodes.StaticType[nodes.HasSignatureT]): Access_property_SIGNATURE =
-    new Access_property_SIGNATURE(node)
-  implicit def accessPropertySinkType(node: nodes.StoredNode with nodes.StaticType[nodes.HasSinkTypeT]): Access_property_SINK_TYPE =
-    new Access_property_SINK_TYPE(node)
-  implicit def accessPropertySourceType(node: nodes.StoredNode with nodes.StaticType[nodes.HasSourceTypeT]): Access_property_SOURCE_TYPE =
-    new Access_property_SOURCE_TYPE(node)
-  implicit def accessPropertySpid(node: nodes.StoredNode with nodes.StaticType[nodes.HasSpidT]): Access_property_SPID =
-    new Access_property_SPID(node)
+  ): Access_Property_POLICY_DIRECTORIES = new Access_Property_POLICY_DIRECTORIES(node)
+  implicit def accessPropertyResolved(node: nodes.StoredNode with nodes.StaticType[nodes.HasResolvedT]): Access_Property_RESOLVED =
+    new Access_Property_RESOLVED(node)
+  implicit def accessPropertyRoot(node: nodes.StoredNode with nodes.StaticType[nodes.HasRootT]): Access_Property_ROOT =
+    new Access_Property_ROOT(node)
+  implicit def accessPropertyScore(node: nodes.StoredNode with nodes.StaticType[nodes.HasScoreT]): Access_Property_SCORE =
+    new Access_Property_SCORE(node)
+  implicit def accessPropertySignature(node: nodes.StoredNode with nodes.StaticType[nodes.HasSignatureT]): Access_Property_SIGNATURE =
+    new Access_Property_SIGNATURE(node)
+  implicit def accessPropertySinkType(node: nodes.StoredNode with nodes.StaticType[nodes.HasSinkTypeT]): Access_Property_SINK_TYPE =
+    new Access_Property_SINK_TYPE(node)
+  implicit def accessPropertySourceType(node: nodes.StoredNode with nodes.StaticType[nodes.HasSourceTypeT]): Access_Property_SOURCE_TYPE =
+    new Access_Property_SOURCE_TYPE(node)
+  implicit def accessPropertySpid(node: nodes.StoredNode with nodes.StaticType[nodes.HasSpidT]): Access_Property_SPID =
+    new Access_Property_SPID(node)
   implicit def accessPropertyStructuredFingerprint(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasStructuredFingerprintT]
-  ): Access_property_STRUCTURED_FINGERPRINT = new Access_property_STRUCTURED_FINGERPRINT(node)
-  implicit def accessPropertySymbol(node: nodes.StoredNode with nodes.StaticType[nodes.HasSymbolT]): Access_property_SYMBOL =
-    new Access_property_SYMBOL(node)
+  ): Access_Property_STRUCTURED_FINGERPRINT = new Access_Property_STRUCTURED_FINGERPRINT(node)
+  implicit def accessPropertySymbol(node: nodes.StoredNode with nodes.StaticType[nodes.HasSymbolT]): Access_Property_SYMBOL =
+    new Access_Property_SYMBOL(node)
   implicit def accessPropertyTypeDeclFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasTypeDeclFullNameT]
-  ): Access_property_TYPE_DECL_FULL_NAME = new Access_property_TYPE_DECL_FULL_NAME(node)
+  ): Access_Property_TYPE_DECL_FULL_NAME = new Access_Property_TYPE_DECL_FULL_NAME(node)
   implicit def accessPropertyTypeFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasTypeFullNameT]
-  ): Access_property_TYPE_FULL_NAME = new Access_property_TYPE_FULL_NAME(node)
-  implicit def accessPropertyUrl(node: nodes.StoredNode with nodes.StaticType[nodes.HasUrlT]): Access_property_URL =
-    new Access_property_URL(node)
-  implicit def accessPropertyValue(node: nodes.StoredNode with nodes.StaticType[nodes.HasValueT]): Access_property_VALUE =
-    new Access_property_VALUE(node)
+  ): Access_Property_TYPE_FULL_NAME = new Access_Property_TYPE_FULL_NAME(node)
+  implicit def accessPropertyUrl(node: nodes.StoredNode with nodes.StaticType[nodes.HasUrlT]): Access_Property_URL =
+    new Access_Property_URL(node)
+  implicit def accessPropertyValue(node: nodes.StoredNode with nodes.StaticType[nodes.HasValueT]): Access_Property_VALUE =
+    new Access_Property_VALUE(node)
   implicit def accessPropertyVarargParameter(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasVarargParameterT]
-  ): Access_property_VARARG_PARAMETER = new Access_property_VARARG_PARAMETER(node)
-  implicit def accessPropertyVarType(node: nodes.StoredNode with nodes.StaticType[nodes.HasVarTypeT]): Access_property_VAR_TYPE =
-    new Access_property_VAR_TYPE(node)
-  implicit def accessPropertyVersion(node: nodes.StoredNode with nodes.StaticType[nodes.HasVersionT]): Access_property_VERSION =
-    new Access_property_VERSION(node)
+  ): Access_Property_VARARG_PARAMETER = new Access_Property_VARARG_PARAMETER(node)
+  implicit def accessPropertyVarType(node: nodes.StoredNode with nodes.StaticType[nodes.HasVarTypeT]): Access_Property_VAR_TYPE =
+    new Access_Property_VAR_TYPE(node)
+  implicit def accessPropertyVersion(node: nodes.StoredNode with nodes.StaticType[nodes.HasVersionT]): Access_Property_VERSION =
+    new Access_Property_VERSION(node)
+}
+
+trait ConcreteBaseConversions extends AbstractBaseConversions0 {
+  import Accessors._
+  implicit def access_AnnotationBase(node: nodes.AnnotationBase): Access_AnnotationBase = new Access_AnnotationBase(node)
+  implicit def access_AnnotationLiteralBase(node: nodes.AnnotationLiteralBase): Access_AnnotationLiteralBase =
+    new Access_AnnotationLiteralBase(node)
+  implicit def access_AnnotationParameterBase(node: nodes.AnnotationParameterBase): Access_AnnotationParameterBase =
+    new Access_AnnotationParameterBase(node)
+  implicit def access_AnnotationParameterAssignBase(node: nodes.AnnotationParameterAssignBase): Access_AnnotationParameterAssignBase =
+    new Access_AnnotationParameterAssignBase(node)
+  implicit def access_ArrayInitializerBase(node: nodes.ArrayInitializerBase): Access_ArrayInitializerBase = new Access_ArrayInitializerBase(
+    node
+  )
+  implicit def access_BindingBase(node: nodes.BindingBase): Access_BindingBase                      = new Access_BindingBase(node)
+  implicit def access_BlockBase(node: nodes.BlockBase): Access_BlockBase                            = new Access_BlockBase(node)
+  implicit def access_CallBase(node: nodes.CallBase): Access_CallBase                               = new Access_CallBase(node)
+  implicit def access_CallChainBase(node: nodes.CallChainBase): Access_CallChainBase                = new Access_CallChainBase(node)
+  implicit def access_CallSiteBase(node: nodes.CallSiteBase): Access_CallSiteBase                   = new Access_CallSiteBase(node)
+  implicit def access_ClosureBindingBase(node: nodes.ClosureBindingBase): Access_ClosureBindingBase = new Access_ClosureBindingBase(node)
+  implicit def access_CommentBase(node: nodes.CommentBase): Access_CommentBase                      = new Access_CommentBase(node)
+  implicit def access_ConfigFileBase(node: nodes.ConfigFileBase): Access_ConfigFileBase             = new Access_ConfigFileBase(node)
+  implicit def access_ControlStructureBase(node: nodes.ControlStructureBase): Access_ControlStructureBase = new Access_ControlStructureBase(
+    node
+  )
+  implicit def access_DependencyBase(node: nodes.DependencyBase): Access_DependencyBase       = new Access_DependencyBase(node)
+  implicit def access_DomAttributeBase(node: nodes.DomAttributeBase): Access_DomAttributeBase = new Access_DomAttributeBase(node)
+  implicit def access_DomNodeBase(node: nodes.DomNodeBase): Access_DomNodeBase                = new Access_DomNodeBase(node)
+  implicit def access_FieldIdentifierBase(node: nodes.FieldIdentifierBase): Access_FieldIdentifierBase = new Access_FieldIdentifierBase(
+    node
+  )
+  implicit def access_FileBase(node: nodes.FileBase): Access_FileBase                            = new Access_FileBase(node)
+  implicit def access_FindingBase(node: nodes.FindingBase): Access_FindingBase                   = new Access_FindingBase(node)
+  implicit def access_FlowBase(node: nodes.FlowBase): Access_FlowBase                            = new Access_FlowBase(node)
+  implicit def access_FrameworkBase(node: nodes.FrameworkBase): Access_FrameworkBase             = new Access_FrameworkBase(node)
+  implicit def access_FrameworkDataBase(node: nodes.FrameworkDataBase): Access_FrameworkDataBase = new Access_FrameworkDataBase(node)
+  implicit def access_IdentifierBase(node: nodes.IdentifierBase): Access_IdentifierBase          = new Access_IdentifierBase(node)
+  implicit def access_ImplicitCallBase(node: nodes.ImplicitCallBase): Access_ImplicitCallBase    = new Access_ImplicitCallBase(node)
+  implicit def access_ImportBase(node: nodes.ImportBase): Access_ImportBase                      = new Access_ImportBase(node)
+  implicit def access_IoflowBase(node: nodes.IoflowBase): Access_IoflowBase                      = new Access_IoflowBase(node)
+  implicit def access_JumpLabelBase(node: nodes.JumpLabelBase): Access_JumpLabelBase             = new Access_JumpLabelBase(node)
+  implicit def access_JumpTargetBase(node: nodes.JumpTargetBase): Access_JumpTargetBase          = new Access_JumpTargetBase(node)
+  implicit def access_KeyValuePairBase(node: nodes.KeyValuePairBase): Access_KeyValuePairBase    = new Access_KeyValuePairBase(node)
+  implicit def access_LiteralBase(node: nodes.LiteralBase): Access_LiteralBase                   = new Access_LiteralBase(node)
+  implicit def access_LocalBase(node: nodes.LocalBase): Access_LocalBase                         = new Access_LocalBase(node)
+  implicit def access_LocationBase(node: nodes.LocationBase): Access_LocationBase                = new Access_LocationBase(node)
+  implicit def access_MatchInfoBase(node: nodes.MatchInfoBase): Access_MatchInfoBase             = new Access_MatchInfoBase(node)
+  implicit def access_MemberBase(node: nodes.MemberBase): Access_MemberBase                      = new Access_MemberBase(node)
+  implicit def access_MetaDataBase(node: nodes.MetaDataBase): Access_MetaDataBase                = new Access_MetaDataBase(node)
+  implicit def access_MethodBase(node: nodes.MethodBase): Access_MethodBase                      = new Access_MethodBase(node)
+  implicit def access_MethodInstBase(node: nodes.MethodInstBase): Access_MethodInstBase          = new Access_MethodInstBase(node)
+  implicit def access_MethodParameterInBase(node: nodes.MethodParameterInBase): Access_MethodParameterInBase =
+    new Access_MethodParameterInBase(node)
+  implicit def access_MethodParameterOutBase(node: nodes.MethodParameterOutBase): Access_MethodParameterOutBase =
+    new Access_MethodParameterOutBase(node)
+  implicit def access_MethodRefBase(node: nodes.MethodRefBase): Access_MethodRefBase                = new Access_MethodRefBase(node)
+  implicit def access_MethodReturnBase(node: nodes.MethodReturnBase): Access_MethodReturnBase       = new Access_MethodReturnBase(node)
+  implicit def access_MethodSummaryBase(node: nodes.MethodSummaryBase): Access_MethodSummaryBase    = new Access_MethodSummaryBase(node)
+  implicit def access_ModifierBase(node: nodes.ModifierBase): Access_ModifierBase                   = new Access_ModifierBase(node)
+  implicit def access_NamespaceBase(node: nodes.NamespaceBase): Access_NamespaceBase                = new Access_NamespaceBase(node)
+  implicit def access_NamespaceBlockBase(node: nodes.NamespaceBlockBase): Access_NamespaceBlockBase = new Access_NamespaceBlockBase(node)
+  implicit def access_PackagePrefixBase(node: nodes.PackagePrefixBase): Access_PackagePrefixBase    = new Access_PackagePrefixBase(node)
+  implicit def access_PostExecutionCallBase(node: nodes.PostExecutionCallBase): Access_PostExecutionCallBase =
+    new Access_PostExecutionCallBase(node)
+  implicit def access_ProgramPointBase(node: nodes.ProgramPointBase): Access_ProgramPointBase = new Access_ProgramPointBase(node)
+  implicit def access_ReadBase(node: nodes.ReadBase): Access_ReadBase                         = new Access_ReadBase(node)
+  implicit def access_ReturnBase(node: nodes.ReturnBase): Access_ReturnBase                   = new Access_ReturnBase(node)
+  implicit def access_RouteBase(node: nodes.RouteBase): Access_RouteBase                      = new Access_RouteBase(node)
+  implicit def access_SensitiveDataTypeBase(node: nodes.SensitiveDataTypeBase): Access_SensitiveDataTypeBase =
+    new Access_SensitiveDataTypeBase(node)
+  implicit def access_SensitiveMemberBase(node: nodes.SensitiveMemberBase): Access_SensitiveMemberBase = new Access_SensitiveMemberBase(
+    node
+  )
+  implicit def access_SensitiveReferenceBase(node: nodes.SensitiveReferenceBase): Access_SensitiveReferenceBase =
+    new Access_SensitiveReferenceBase(node)
+  implicit def access_SensitiveVariableBase(node: nodes.SensitiveVariableBase): Access_SensitiveVariableBase =
+    new Access_SensitiveVariableBase(node)
+  implicit def access_SinkBase(node: nodes.SinkBase): Access_SinkBase       = new Access_SinkBase(node)
+  implicit def access_SourceBase(node: nodes.SourceBase): Access_SourceBase = new Access_SourceBase(node)
+  implicit def access_SpAnnotationParameterBase(node: nodes.SpAnnotationParameterBase): Access_SpAnnotationParameterBase =
+    new Access_SpAnnotationParameterBase(node)
+  implicit def access_SpBlacklistBase(node: nodes.SpBlacklistBase): Access_SpBlacklistBase          = new Access_SpBlacklistBase(node)
+  implicit def access_TagBase(node: nodes.TagBase): Access_TagBase                                  = new Access_TagBase(node)
+  implicit def access_TagsBase(node: nodes.TagsBase): Access_TagsBase                               = new Access_TagsBase(node)
+  implicit def access_TagNodePairBase(node: nodes.TagNodePairBase): Access_TagNodePairBase          = new Access_TagNodePairBase(node)
+  implicit def access_TemplateDomBase(node: nodes.TemplateDomBase): Access_TemplateDomBase          = new Access_TemplateDomBase(node)
+  implicit def access_TransformBase(node: nodes.TransformBase): Access_TransformBase                = new Access_TransformBase(node)
+  implicit def access_TransformationBase(node: nodes.TransformationBase): Access_TransformationBase = new Access_TransformationBase(node)
+  implicit def access_TypeBase(node: nodes.TypeBase): Access_TypeBase                               = new Access_TypeBase(node)
+  implicit def access_TypeArgumentBase(node: nodes.TypeArgumentBase): Access_TypeArgumentBase       = new Access_TypeArgumentBase(node)
+  implicit def access_TypeDeclBase(node: nodes.TypeDeclBase): Access_TypeDeclBase                   = new Access_TypeDeclBase(node)
+  implicit def access_TypeParameterBase(node: nodes.TypeParameterBase): Access_TypeParameterBase    = new Access_TypeParameterBase(node)
+  implicit def access_TypeRefBase(node: nodes.TypeRefBase): Access_TypeRefBase                      = new Access_TypeRefBase(node)
+  implicit def access_UnknownBase(node: nodes.UnknownBase): Access_UnknownBase                      = new Access_UnknownBase(node)
+  implicit def access_VariableInfoBase(node: nodes.VariableInfoBase): Access_VariableInfoBase       = new Access_VariableInfoBase(node)
+  implicit def access_VulnerabilityBase(node: nodes.VulnerabilityBase): Access_VulnerabilityBase    = new Access_VulnerabilityBase(node)
+  implicit def access_WriteBase(node: nodes.WriteBase): Access_WriteBase                            = new Access_WriteBase(node)
+}
+
+trait AbstractBaseConversions0 extends AbstractBaseConversions1 {
+  import Accessors._
+  implicit def access_AstNodeBase(node: nodes.AstNodeBase): Access_AstNodeBase          = new Access_AstNodeBase(node)
+  implicit def access_CallReprBase(node: nodes.CallReprBase): Access_CallReprBase       = new Access_CallReprBase(node)
+  implicit def access_CfgNodeBase(node: nodes.CfgNodeBase): Access_CfgNodeBase          = new Access_CfgNodeBase(node)
+  implicit def access_ExpressionBase(node: nodes.ExpressionBase): Access_ExpressionBase = new Access_ExpressionBase(node)
+}
+
+trait AbstractBaseConversions1 extends AbstractBaseConversions2 {
+  import Accessors._
+  implicit def access_DeclarationBase(node: nodes.DeclarationBase): Access_DeclarationBase       = new Access_DeclarationBase(node)
+  implicit def access_TrackingPointBase(node: nodes.TrackingPointBase): Access_TrackingPointBase = new Access_TrackingPointBase(node)
+}
+
+trait AbstractBaseConversions2 {
+  import Accessors._
+  implicit def access_LocalLikeBase(node: nodes.LocalLikeBase): Access_LocalLikeBase = new Access_LocalLikeBase(node)
 }

--- a/codescienceGenerated/src/main/scala/generated/BaseTypes.scala
+++ b/codescienceGenerated/src/main/scala/generated/BaseTypes.scala
@@ -8,11 +8,25 @@ trait AstNodeBase extends AbstractNode with StaticType[AstNodeT]
 // inherited properties:
 // inherited interfaces:
 // implementing nodes: ANNOTATION, ANNOTATION_LITERAL, ANNOTATION_PARAMETER, ANNOTATION_PARAMETER_ASSIGN, ARRAY_INITIALIZER, BLOCK, CALL, COMMENT, CONTROL_STRUCTURE, FIELD_IDENTIFIER, FILE, IDENTIFIER, IMPLICIT_CALL, IMPORT, JUMP_LABEL, JUMP_TARGET, LITERAL, LOCAL, MEMBER, METHOD, METHOD_INST, METHOD_PARAMETER_IN, METHOD_PARAMETER_OUT, METHOD_REF, METHOD_RETURN, MODIFIER, NAMESPACE, NAMESPACE_BLOCK, POST_EXECUTION_CALL, RETURN, TEMPLATE_DOM, TYPE_ARGUMENT, TYPE_DECL, TYPE_PARAMETER, TYPE_REF, UNKNOWN
-trait AstNode extends StoredNode with AstNodeBase with StaticType[AstNodeT] {
-//{accessors}
-}
+trait AstNode extends StoredNode with AstNodeBase with StaticType[AstNodeT]
 
-trait AstNodeNew extends NewNode with AstNodeBase with StaticType[AstNodeT]
+trait AstNodeNew extends NewNode with AstNodeBase with StaticType[AstNodeT] {
+  type RelatedStored <: AstNode
+  def code: String
+  def code_=(value: String): Unit
+  def code(value: String): this.type
+  def columnNumber: Option[Int]
+  def columnNumber_=(value: Option[Int]): Unit
+  def columnNumber(value: Option[Int]): this.type
+  def columnNumber(value: Int): this.type
+  def lineNumber: Option[Int]
+  def lineNumber_=(value: Option[Int]): Unit
+  def lineNumber(value: Option[Int]): this.type
+  def lineNumber(value: Int): this.type
+  def order: Int
+  def order_=(value: Int): Unit
+  def order(value: Int): this.type
+}
 
 trait CallReprT extends AnyRef with CfgNodeT with HasNameT with HasSignatureT
 
@@ -21,11 +35,17 @@ trait CallReprBase extends AbstractNode with CfgNodeBase with StaticType[CallRep
 // inherited properties: CODE, COLUMN_NUMBER, DEPTH_FIRST_ORDER, INTERNAL_FLAGS, LINE_NUMBER, ORDER
 // inherited interfaces: AST_NODE, TRACKING_POINT
 // implementing nodes: CALL, IMPLICIT_CALL, POST_EXECUTION_CALL
-trait CallRepr extends StoredNode with CallReprBase with CfgNode with StaticType[CallReprT] {
-//{accessors}
-}
+trait CallRepr extends StoredNode with CallReprBase with CfgNode with StaticType[CallReprT]
 
-trait CallReprNew extends NewNode with CallReprBase with CfgNodeNew with StaticType[CallReprT]
+trait CallReprNew extends NewNode with CallReprBase with CfgNodeNew with StaticType[CallReprT] {
+  type RelatedStored <: CallRepr
+  def name: String
+  def name_=(value: String): Unit
+  def name(value: String): this.type
+  def signature: String
+  def signature_=(value: String): Unit
+  def signature(value: String): this.type
+}
 
 trait CfgNodeT extends AnyRef with AstNodeT with TrackingPointT with HasDepthFirstOrderT with HasInternalFlagsT
 
@@ -34,11 +54,17 @@ trait CfgNodeBase extends AbstractNode with AstNodeBase with TrackingPointBase w
 // inherited properties: CODE, COLUMN_NUMBER, LINE_NUMBER, ORDER
 // inherited interfaces:
 // implementing nodes: ANNOTATION, ANNOTATION_LITERAL, ARRAY_INITIALIZER, BLOCK, CALL, CONTROL_STRUCTURE, FIELD_IDENTIFIER, IDENTIFIER, IMPLICIT_CALL, JUMP_TARGET, LITERAL, METHOD, METHOD_PARAMETER_IN, METHOD_PARAMETER_OUT, METHOD_REF, METHOD_RETURN, POST_EXECUTION_CALL, RETURN, TEMPLATE_DOM, TYPE_REF, UNKNOWN
-trait CfgNode extends StoredNode with CfgNodeBase with AstNode with TrackingPoint with StaticType[CfgNodeT] {
-//{accessors}
-}
+trait CfgNode extends StoredNode with CfgNodeBase with AstNode with TrackingPoint with StaticType[CfgNodeT]
 
-trait CfgNodeNew extends NewNode with CfgNodeBase with AstNodeNew with TrackingPointNew with StaticType[CfgNodeT]
+trait CfgNodeNew extends NewNode with CfgNodeBase with AstNodeNew with TrackingPointNew with StaticType[CfgNodeT] {
+  type RelatedStored <: CfgNode
+  def depthFirstOrder: Int
+  def depthFirstOrder_=(value: Int): Unit
+  def depthFirstOrder(value: Int): this.type
+  def internalFlags: Int
+  def internalFlags_=(value: Int): Unit
+  def internalFlags(value: Int): this.type
+}
 
 trait DeclarationT extends AnyRef with HasNameT
 
@@ -47,11 +73,14 @@ trait DeclarationBase extends AbstractNode with StaticType[DeclarationT]
 // inherited properties:
 // inherited interfaces:
 // implementing nodes: LOCAL, MEMBER, METHOD, METHOD_PARAMETER_IN, METHOD_PARAMETER_OUT
-trait Declaration extends StoredNode with DeclarationBase with StaticType[DeclarationT] {
-//{accessors}
-}
+trait Declaration extends StoredNode with DeclarationBase with StaticType[DeclarationT]
 
-trait DeclarationNew extends NewNode with DeclarationBase with StaticType[DeclarationT]
+trait DeclarationNew extends NewNode with DeclarationBase with StaticType[DeclarationT] {
+  type RelatedStored <: Declaration
+  def name: String
+  def name_=(value: String): Unit
+  def name(value: String): this.type
+}
 
 trait ExpressionT extends AnyRef with CfgNodeT with HasArgumentIndexT with HasArgumentNameT
 
@@ -60,11 +89,18 @@ trait ExpressionBase extends AbstractNode with CfgNodeBase with StaticType[Expre
 // inherited properties: CODE, COLUMN_NUMBER, DEPTH_FIRST_ORDER, INTERNAL_FLAGS, LINE_NUMBER, ORDER
 // inherited interfaces: AST_NODE, TRACKING_POINT
 // implementing nodes: ANNOTATION, ANNOTATION_LITERAL, ARRAY_INITIALIZER, BLOCK, CALL, CONTROL_STRUCTURE, FIELD_IDENTIFIER, IDENTIFIER, LITERAL, METHOD_REF, RETURN, TEMPLATE_DOM, TYPE_REF, UNKNOWN
-trait Expression extends StoredNode with ExpressionBase with CfgNode with StaticType[ExpressionT] {
-//{accessors}
-}
+trait Expression extends StoredNode with ExpressionBase with CfgNode with StaticType[ExpressionT]
 
-trait ExpressionNew extends NewNode with ExpressionBase with CfgNodeNew with AstNodeNew with TrackingPointNew with StaticType[ExpressionT]
+trait ExpressionNew extends NewNode with ExpressionBase with CfgNodeNew with AstNodeNew with TrackingPointNew with StaticType[ExpressionT] {
+  type RelatedStored <: Expression
+  def argumentIndex: Int
+  def argumentIndex_=(value: Int): Unit
+  def argumentIndex(value: Int): this.type
+  def argumentName: Option[String]
+  def argumentName_=(value: Option[String]): Unit
+  def argumentName(value: Option[String]): this.type
+  def argumentName(value: String): this.type
+}
 
 trait LocalLikeT extends AnyRef with HasNameT
 
@@ -73,11 +109,14 @@ trait LocalLikeBase extends AbstractNode with StaticType[LocalLikeT]
 // inherited properties:
 // inherited interfaces:
 // implementing nodes: IDENTIFIER, LOCAL, METHOD_PARAMETER_IN
-trait LocalLike extends StoredNode with LocalLikeBase with StaticType[LocalLikeT] {
-//{accessors}
-}
+trait LocalLike extends StoredNode with LocalLikeBase with StaticType[LocalLikeT]
 
-trait LocalLikeNew extends NewNode with LocalLikeBase with StaticType[LocalLikeT]
+trait LocalLikeNew extends NewNode with LocalLikeBase with StaticType[LocalLikeT] {
+  type RelatedStored <: LocalLike
+  def name: String
+  def name_=(value: String): Unit
+  def name(value: String): this.type
+}
 
 trait TrackingPointT extends AnyRef with HasCodeT
 
@@ -86,11 +125,14 @@ trait TrackingPointBase extends AbstractNode with TrackingPointMarker with Stati
 // inherited properties:
 // inherited interfaces:
 // implementing nodes: ANNOTATION, ANNOTATION_LITERAL, ARRAY_INITIALIZER, BLOCK, CALL, CONFIG_FILE, CONTROL_STRUCTURE, DOM_NODE, FIELD_IDENTIFIER, IDENTIFIER, IMPLICIT_CALL, JUMP_TARGET, LITERAL, METHOD, METHOD_PARAMETER_IN, METHOD_PARAMETER_OUT, METHOD_REF, METHOD_RETURN, POST_EXECUTION_CALL, RETURN, TEMPLATE_DOM, TYPE_REF, UNKNOWN
-trait TrackingPoint extends StoredNode with TrackingPointBase with TrackingPointMarker with StaticType[TrackingPointT] {
-//{accessors}
-}
+trait TrackingPoint extends StoredNode with TrackingPointBase with TrackingPointMarker with StaticType[TrackingPointT]
 
-trait TrackingPointNew extends NewNode with TrackingPointBase with TrackingPointMarker with StaticType[TrackingPointT]
+trait TrackingPointNew extends NewNode with TrackingPointBase with TrackingPointMarker with StaticType[TrackingPointT] {
+  type RelatedStored <: TrackingPoint
+  def code: String
+  def code_=(value: String): Unit
+  def code(value: String): this.type
+}
 
 trait TrackingBase
 trait TrackingPointMarker

--- a/codescienceGenerated/src/main/scala/generated/NodeTypes.scala
+++ b/codescienceGenerated/src/main/scala/generated/NodeTypes.scala
@@ -1,64 +1,210 @@
 package io.shiftleft.codepropertygraph.generated.v2.nodes
 import io.joern.odb2
+import scala.collection.immutable.{IndexedSeq, ArraySeq}
 
-trait AnnotationT extends AnyRef with ExpressionT with HasFullNameT with HasNameT
+trait AnnotationT    extends AnyRef with ExpressionT with HasFullNameT with HasNameT
+trait AnnotationBase extends AbstractNode with ExpressionBase with StaticType[AnnotationT] {}
 class Annotation(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 0.toShort, seq_4762)
+    with AnnotationBase
     with Expression
-    with StaticType[AnnotationT] {
-//{propAccess}
-
+    with StaticType[AnnotationT] {}
+object NewAnnotation             { def apply(): NewAnnotation = new NewAnnotation }
+class NewAnnotation extends NewNode(0.toShort) with AnnotationBase {
+  type RelatedStored = Annotation
+  override def label: String                         = "ANNOTATION"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var depthFirstOrder: Int                           = -1: Int
+  var fullName: String                               = "<empty>": String
+  var internalFlags: Int                             = 0: Int
+  var lineNumber: Option[Int]                        = None
+  var name: String                                   = "<empty>": String
+  var order: Int                                     = -1: Int
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type         = { this.depthFirstOrder = value; this }
+  def fullName(value: String): this.type             = { this.fullName = value; this }
+  def internalFlags(value: Int): this.type           = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def name(value: String): this.type                 = { this.name = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
 }
 
-trait AnnotationLiteralT extends AnyRef with ExpressionT with HasNameT
+trait AnnotationLiteralT    extends AnyRef with ExpressionT with HasNameT
+trait AnnotationLiteralBase extends AbstractNode with ExpressionBase with StaticType[AnnotationLiteralT] {}
 class AnnotationLiteral(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 1.toShort, seq_4762)
+    with AnnotationLiteralBase
     with Expression
-    with StaticType[AnnotationLiteralT] {
-//{propAccess}
-
+    with StaticType[AnnotationLiteralT] {}
+object NewAnnotationLiteral             { def apply(): NewAnnotationLiteral = new NewAnnotationLiteral }
+class NewAnnotationLiteral extends NewNode(1.toShort) with AnnotationLiteralBase {
+  type RelatedStored = AnnotationLiteral
+  override def label: String                         = "ANNOTATION_LITERAL"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var depthFirstOrder: Int                           = -1: Int
+  var internalFlags: Int                             = 0: Int
+  var lineNumber: Option[Int]                        = None
+  var name: String                                   = "<empty>": String
+  var order: Int                                     = -1: Int
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type         = { this.depthFirstOrder = value; this }
+  def internalFlags(value: Int): this.type           = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def name(value: String): this.type                 = { this.name = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
 }
 
-trait AnnotationParameterT extends AnyRef with AstNodeT
+trait AnnotationParameterT    extends AnyRef with AstNodeT
+trait AnnotationParameterBase extends AbstractNode with AstNodeBase with StaticType[AnnotationParameterT] {}
 class AnnotationParameter(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 2.toShort, seq_4762)
+    with AnnotationParameterBase
     with AstNode
-    with StaticType[AnnotationParameterT] {
-//{propAccess}
-
+    with StaticType[AnnotationParameterT] {}
+object NewAnnotationParameter             { def apply(): NewAnnotationParameter = new NewAnnotationParameter }
+class NewAnnotationParameter extends NewNode(2.toShort) with AnnotationParameterBase {
+  type RelatedStored = AnnotationParameter
+  override def label: String                      = "ANNOTATION_PARAMETER"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait AnnotationParameterAssignT extends AnyRef with AstNodeT
+trait AnnotationParameterAssignT    extends AnyRef with AstNodeT
+trait AnnotationParameterAssignBase extends AbstractNode with AstNodeBase with StaticType[AnnotationParameterAssignT] {}
 class AnnotationParameterAssign(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 3.toShort, seq_4762)
+    with AnnotationParameterAssignBase
     with AstNode
-    with StaticType[AnnotationParameterAssignT] {
-//{propAccess}
-
+    with StaticType[AnnotationParameterAssignT] {}
+object NewAnnotationParameterAssign             { def apply(): NewAnnotationParameterAssign = new NewAnnotationParameterAssign }
+class NewAnnotationParameterAssign extends NewNode(3.toShort) with AnnotationParameterAssignBase {
+  type RelatedStored = AnnotationParameterAssign
+  override def label: String                      = "ANNOTATION_PARAMETER_ASSIGN"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait ArrayInitializerT extends AnyRef with ExpressionT
+trait ArrayInitializerT    extends AnyRef with ExpressionT
+trait ArrayInitializerBase extends AbstractNode with ExpressionBase with StaticType[ArrayInitializerT] {}
 class ArrayInitializer(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 4.toShort, seq_4762)
+    with ArrayInitializerBase
     with Expression
-    with StaticType[ArrayInitializerT] {
-//{propAccess}
-
+    with StaticType[ArrayInitializerT] {}
+object NewArrayInitializer             { def apply(): NewArrayInitializer = new NewArrayInitializer }
+class NewArrayInitializer extends NewNode(4.toShort) with ArrayInitializerBase {
+  type RelatedStored = ArrayInitializer
+  override def label: String                         = "ARRAY_INITIALIZER"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var depthFirstOrder: Int                           = -1: Int
+  var internalFlags: Int                             = 0: Int
+  var lineNumber: Option[Int]                        = None
+  var order: Int                                     = -1: Int
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type         = { this.depthFirstOrder = value; this }
+  def internalFlags(value: Int): this.type           = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
 }
 
-trait BindingT extends AnyRef with HasIsMethodNeverOverriddenT with HasMethodFullNameT with HasNameT with HasSignatureT
-class Binding(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 5.toShort, seq_4762) with StaticType[BindingT] {
-//{propAccess}
-
+trait BindingT    extends AnyRef with HasIsMethodNeverOverriddenT with HasMethodFullNameT with HasNameT with HasSignatureT
+trait BindingBase extends AbstractNode with StaticType[BindingT] {}
+class Binding(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 5.toShort, seq_4762)
+    with BindingBase
+    with StaticType[BindingT] {}
+object NewBinding             { def apply(): NewBinding = new NewBinding }
+class NewBinding extends NewNode(5.toShort) with BindingBase {
+  type RelatedStored = Binding
+  override def label: String                                     = "BINDING"
+  var isMethodNeverOverridden: Option[Boolean]                   = None
+  var methodFullName: String                                     = "<empty>": String
+  var name: String                                               = "<empty>": String
+  var signature: String                                          = "": String
+  def isMethodNeverOverridden(value: Boolean): this.type         = { this.isMethodNeverOverridden = Option(value); this }
+  def isMethodNeverOverridden(value: Option[Boolean]): this.type = { this.isMethodNeverOverridden = value; this }
+  def methodFullName(value: String): this.type                   = { this.methodFullName = value; this }
+  def name(value: String): this.type                             = { this.name = value; this }
+  def signature(value: String): this.type                        = { this.signature = value; this }
 }
 
-trait BlockT extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait BlockT    extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait BlockBase extends AbstractNode with ExpressionBase with StaticType[BlockT] {}
 class Block(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 6.toShort, seq_4762)
+    with BlockBase
     with Expression
-    with StaticType[BlockT] {
-//{propAccess}
-
+    with StaticType[BlockT] {}
+object NewBlock             { def apply(): NewBlock = new NewBlock }
+class NewBlock extends NewNode(6.toShort) with BlockBase {
+  type RelatedStored = Block
+  override def label: String                                          = "BLOCK"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var depthFirstOrder: Int                                            = -1: Int
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var internalFlags: Int                                              = 0: Int
+  var lineNumber: Option[Int]                                         = None
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type                          = { this.depthFirstOrder = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def internalFlags(value: Int): this.type                            = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
 trait CallT
@@ -72,114 +218,375 @@ trait CallT
     with HasMethodInstFullNameT
     with HasResolvedT
     with HasTypeFullNameT
+trait CallBase extends AbstractNode with CallReprBase with ExpressionBase with StaticType[CallT] {}
 class Call(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 7.toShort, seq_4762)
+    with CallBase
     with CallRepr
     with Expression
-    with StaticType[CallT] {
-//{propAccess}
-
+    with StaticType[CallT] {}
+object NewCall             { def apply(): NewCall = new NewCall }
+class NewCall extends NewNode(7.toShort) with CallBase {
+  type RelatedStored = Call
+  override def label: String                                          = "CALL"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var depthFirstOrder: Int                                            = -1: Int
+  var dispatchName: String                                            = "": String
+  var dispatchType: String                                            = "<empty>": String
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var internalFlags: Int                                              = 0: Int
+  var lineNumber: Option[Int]                                         = None
+  var methodFullName: String                                          = "<empty>": String
+  var methodInstFullName: Option[String]                              = None
+  var name: String                                                    = "<empty>": String
+  var order: Int                                                      = -1: Int
+  var resolved: Option[Boolean]                                       = None
+  var signature: String                                               = "": String
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type                          = { this.depthFirstOrder = value; this }
+  def dispatchName(value: String): this.type                          = { this.dispatchName = value; this }
+  def dispatchType(value: String): this.type                          = { this.dispatchType = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def internalFlags(value: Int): this.type                            = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def methodFullName(value: String): this.type                        = { this.methodFullName = value; this }
+  def methodInstFullName(value: Option[String]): this.type            = { this.methodInstFullName = value; this }
+  def methodInstFullName(value: String): this.type                    = { this.methodInstFullName = Option(value); this }
+  def name(value: String): this.type                                  = { this.name = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def resolved(value: Boolean): this.type                             = { this.resolved = Option(value); this }
+  def resolved(value: Option[Boolean]): this.type                     = { this.resolved = value; this }
+  def signature(value: String): this.type                             = { this.signature = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
-trait CallChainT                                       extends AnyRef
-class CallChain(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 8.toShort, seq_4762) with StaticType[CallChainT] {
-//{propAccess}
+trait CallChainT extends AnyRef
+trait CallChainBase extends AbstractNode with StaticType[CallChainT] {
+  def calls: IndexedSeq[CallBase]
+  def methods: IndexedSeq[MethodBase]
+}
+class CallChain(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 8.toShort, seq_4762)
+    with CallChainBase
+    with StaticType[CallChainT] {
   def calls: IndexedSeq[Call]     = odb2.Accessors.getNodePropertyMulti[Call](graph, nodeKind, 84, seq)
   def methods: IndexedSeq[Method] = odb2.Accessors.getNodePropertyMulti[Method](graph, nodeKind, 85, seq)
 }
+object NewCallChain { def apply(): NewCallChain = new NewCallChain }
+class NewCallChain extends NewNode(8.toShort) with CallChainBase {
+  type RelatedStored = CallChain
+  override def label: String                              = "CALL_CHAIN"
+  var calls: IndexedSeq[CallBase]                         = ArraySeq.empty
+  var methods: IndexedSeq[MethodBase]                     = ArraySeq.empty
+  def calls(value: IterableOnce[CallBase]): this.type     = { this.calls = value.iterator.to(ArraySeq); this }
+  def methods(value: IterableOnce[MethodBase]): this.type = { this.methods = value.iterator.to(ArraySeq); this }
+}
 
-trait CallSiteT                                       extends AnyRef
-class CallSite(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 9.toShort, seq_4762) with StaticType[CallSiteT] {
-//{propAccess}
+trait CallSiteT extends AnyRef
+trait CallSiteBase extends AbstractNode with StaticType[CallSiteT] {
+  def call: CallBase
+  def callerMethod: MethodBase
+  def method: MethodBase
+}
+class CallSite(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 9.toShort, seq_4762)
+    with CallSiteBase
+    with StaticType[CallSiteT] {
   def call: Call           = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 86, seq, null: Call)
   def callerMethod: Method = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 84, seq, null: Method)
   def method: Method       = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 85, seq, null: Method)
 }
+object NewCallSite { def apply(): NewCallSite = new NewCallSite }
+class NewCallSite extends NewNode(9.toShort) with CallSiteBase {
+  type RelatedStored = CallSite
+  override def label: String                     = "CALL_SITE"
+  var call: CallBase                             = null
+  var callerMethod: MethodBase                   = null
+  var method: MethodBase                         = null
+  def call(value: CallBase): this.type           = { this.call = value; this }
+  def callerMethod(value: MethodBase): this.type = { this.callerMethod = value; this }
+  def method(value: MethodBase): this.type       = { this.method = value; this }
+}
 
-trait ClosureBindingT extends AnyRef with HasClosureBindingIdT with HasClosureOriginalNameT with HasEvaluationStrategyT
+trait ClosureBindingT    extends AnyRef with HasClosureBindingIdT with HasClosureOriginalNameT with HasEvaluationStrategyT
+trait ClosureBindingBase extends AbstractNode with StaticType[ClosureBindingT] {}
 class ClosureBinding(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 10.toShort, seq_4762)
-    with StaticType[ClosureBindingT] {
-//{propAccess}
-
+    with ClosureBindingBase
+    with StaticType[ClosureBindingT] {}
+object NewClosureBinding             { def apply(): NewClosureBinding = new NewClosureBinding }
+class NewClosureBinding extends NewNode(10.toShort) with ClosureBindingBase {
+  type RelatedStored = ClosureBinding
+  override def label: String                                = "CLOSURE_BINDING"
+  var closureBindingId: Option[String]                      = None
+  var closureOriginalName: Option[String]                   = None
+  var evaluationStrategy: String                            = "<empty>": String
+  def closureBindingId(value: Option[String]): this.type    = { this.closureBindingId = value; this }
+  def closureBindingId(value: String): this.type            = { this.closureBindingId = Option(value); this }
+  def closureOriginalName(value: Option[String]): this.type = { this.closureOriginalName = value; this }
+  def closureOriginalName(value: String): this.type         = { this.closureOriginalName = Option(value); this }
+  def evaluationStrategy(value: String): this.type          = { this.evaluationStrategy = value; this }
 }
 
-trait CommentT extends AnyRef with AstNodeT with HasFilenameT
+trait CommentT    extends AnyRef with AstNodeT with HasFilenameT
+trait CommentBase extends AbstractNode with AstNodeBase with StaticType[CommentT] {}
 class Comment(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 11.toShort, seq_4762)
+    with CommentBase
     with AstNode
-    with StaticType[CommentT] {
-//{propAccess}
-
+    with StaticType[CommentT] {}
+object NewComment             { def apply(): NewComment = new NewComment }
+class NewComment extends NewNode(11.toShort) with CommentBase {
+  type RelatedStored = Comment
+  override def label: String                      = "COMMENT"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var filename: String                            = "<empty>": String
+  var lineNumber: Option[Int]                     = None
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def filename(value: String): this.type          = { this.filename = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait ConfigFileT extends AnyRef with TrackingPointT with HasContentT with HasNameT
+trait ConfigFileT    extends AnyRef with TrackingPointT with HasContentT with HasNameT
+trait ConfigFileBase extends AbstractNode with TrackingPointBase with StaticType[ConfigFileT] {}
 class ConfigFile(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 12.toShort, seq_4762)
+    with ConfigFileBase
     with TrackingPoint
-    with StaticType[ConfigFileT] {
-//{propAccess}
-
+    with StaticType[ConfigFileT] {}
+object NewConfigFile             { def apply(): NewConfigFile = new NewConfigFile }
+class NewConfigFile extends NewNode(12.toShort) with ConfigFileBase {
+  type RelatedStored = ConfigFile
+  override def label: String            = "CONFIG_FILE"
+  var code: String                      = "<empty>": String
+  var content: String                   = "<empty>": String
+  var name: String                      = "<empty>": String
+  def code(value: String): this.type    = { this.code = value; this }
+  def content(value: String): this.type = { this.content = value; this }
+  def name(value: String): this.type    = { this.name = value; this }
 }
 
-trait ControlStructureT extends AnyRef with ExpressionT with HasControlStructureTypeT with HasParserTypeNameT
+trait ControlStructureT    extends AnyRef with ExpressionT with HasControlStructureTypeT with HasParserTypeNameT
+trait ControlStructureBase extends AbstractNode with ExpressionBase with StaticType[ControlStructureT] {}
 class ControlStructure(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 13.toShort, seq_4762)
+    with ControlStructureBase
     with Expression
-    with StaticType[ControlStructureT] {
-//{propAccess}
-
+    with StaticType[ControlStructureT] {}
+object NewControlStructure             { def apply(): NewControlStructure = new NewControlStructure }
+class NewControlStructure extends NewNode(13.toShort) with ControlStructureBase {
+  type RelatedStored = ControlStructure
+  override def label: String                         = "CONTROL_STRUCTURE"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var controlStructureType: String                   = "<empty>": String
+  var depthFirstOrder: Int                           = -1: Int
+  var internalFlags: Int                             = 0: Int
+  var lineNumber: Option[Int]                        = None
+  var order: Int                                     = -1: Int
+  var parserTypeName: String                         = "<empty>": String
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def controlStructureType(value: String): this.type = { this.controlStructureType = value; this }
+  def depthFirstOrder(value: Int): this.type         = { this.depthFirstOrder = value; this }
+  def internalFlags(value: Int): this.type           = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
+  def parserTypeName(value: String): this.type       = { this.parserTypeName = value; this }
 }
 
-trait DependencyT extends AnyRef with HasDependencyGroupIdT with HasDependencyTypeT with HasNameT with HasVersionT
-class Dependency(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 14.toShort, seq_4762) with StaticType[DependencyT] {
-//{propAccess}
-
+trait DependencyT    extends AnyRef with HasDependencyGroupIdT with HasDependencyTypeT with HasNameT with HasVersionT
+trait DependencyBase extends AbstractNode with StaticType[DependencyT] {}
+class Dependency(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 14.toShort, seq_4762)
+    with DependencyBase
+    with StaticType[DependencyT] {}
+object NewDependency             { def apply(): NewDependency = new NewDependency }
+class NewDependency extends NewNode(14.toShort) with DependencyBase {
+  type RelatedStored = Dependency
+  override def label: String                              = "DEPENDENCY"
+  var dependencyGroupId: Option[String]                   = None
+  var dependencyType: String                              = "<empty>": String
+  var name: String                                        = "<empty>": String
+  var version: String                                     = "<empty>": String
+  def dependencyGroupId(value: Option[String]): this.type = { this.dependencyGroupId = value; this }
+  def dependencyGroupId(value: String): this.type         = { this.dependencyGroupId = Option(value); this }
+  def dependencyType(value: String): this.type            = { this.dependencyType = value; this }
+  def name(value: String): this.type                      = { this.name = value; this }
+  def version(value: String): this.type                   = { this.version = value; this }
 }
 
-trait DomAttributeT extends AnyRef with HasNameT with HasValueT
+trait DomAttributeT    extends AnyRef with HasNameT with HasValueT
+trait DomAttributeBase extends AbstractNode with StaticType[DomAttributeT] {}
 class DomAttribute(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 15.toShort, seq_4762)
-    with StaticType[DomAttributeT] {
-//{propAccess}
-
+    with DomAttributeBase
+    with StaticType[DomAttributeT] {}
+object NewDomAttribute             { def apply(): NewDomAttribute = new NewDomAttribute }
+class NewDomAttribute extends NewNode(15.toShort) with DomAttributeBase {
+  type RelatedStored = DomAttribute
+  override def label: String          = "DOM_ATTRIBUTE"
+  var name: String                    = "<empty>": String
+  var value: String                   = "": String
+  def name(value: String): this.type  = { this.name = value; this }
+  def value(value: String): this.type = { this.value = value; this }
 }
 
 trait DomNodeT extends AnyRef with TrackingPointT with HasColumnNumberT with HasLineNumberT with HasNameT
+trait DomNodeBase extends AbstractNode with TrackingPointBase with StaticType[DomNodeT] {
+  def attributes: IndexedSeq[DomAttributeBase]
+}
 class DomNode(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 16.toShort, seq_4762)
+    with DomNodeBase
     with TrackingPoint
     with StaticType[DomNodeT] {
-//{propAccess}
   def attributes: IndexedSeq[DomAttribute] = odb2.Accessors.getNodePropertyMulti[DomAttribute](graph, nodeKind, 84, seq)
 }
+object NewDomNode { def apply(): NewDomNode = new NewDomNode }
+class NewDomNode extends NewNode(16.toShort) with DomNodeBase {
+  type RelatedStored = DomNode
+  override def label: String                                       = "DOM_NODE"
+  var attributes: IndexedSeq[DomAttributeBase]                     = ArraySeq.empty
+  var code: String                                                 = "<empty>": String
+  var columnNumber: Option[Int]                                    = None
+  var lineNumber: Option[Int]                                      = None
+  var name: String                                                 = "<empty>": String
+  def attributes(value: IterableOnce[DomAttributeBase]): this.type = { this.attributes = value.iterator.to(ArraySeq); this }
+  def code(value: String): this.type                               = { this.code = value; this }
+  def columnNumber(value: Int): this.type                          = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                  = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type                            = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                    = { this.lineNumber = value; this }
+  def name(value: String): this.type                               = { this.name = value; this }
+}
 
-trait FieldIdentifierT extends AnyRef with ExpressionT with HasCanonicalNameT
+trait FieldIdentifierT    extends AnyRef with ExpressionT with HasCanonicalNameT
+trait FieldIdentifierBase extends AbstractNode with ExpressionBase with StaticType[FieldIdentifierT] {}
 class FieldIdentifier(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 17.toShort, seq_4762)
+    with FieldIdentifierBase
     with Expression
-    with StaticType[FieldIdentifierT] {
-//{propAccess}
-
+    with StaticType[FieldIdentifierT] {}
+object NewFieldIdentifier             { def apply(): NewFieldIdentifier = new NewFieldIdentifier }
+class NewFieldIdentifier extends NewNode(17.toShort) with FieldIdentifierBase {
+  type RelatedStored = FieldIdentifier
+  override def label: String                         = "FIELD_IDENTIFIER"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var canonicalName: String                          = "<empty>": String
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var depthFirstOrder: Int                           = -1: Int
+  var internalFlags: Int                             = 0: Int
+  var lineNumber: Option[Int]                        = None
+  var order: Int                                     = -1: Int
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def canonicalName(value: String): this.type        = { this.canonicalName = value; this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type         = { this.depthFirstOrder = value; this }
+  def internalFlags(value: Int): this.type           = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
 }
 
-trait FileT                                       extends AnyRef with AstNodeT with HasHashT with HasNameT
-class File(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 18.toShort, seq_4762) with AstNode with StaticType[FileT] {
-//{propAccess}
-
+trait FileT    extends AnyRef with AstNodeT with HasHashT with HasNameT
+trait FileBase extends AbstractNode with AstNodeBase with StaticType[FileT] {}
+class File(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 18.toShort, seq_4762)
+    with FileBase
+    with AstNode
+    with StaticType[FileT] {}
+object NewFile             { def apply(): NewFile = new NewFile }
+class NewFile extends NewNode(18.toShort) with FileBase {
+  type RelatedStored = File
+  override def label: String                      = "FILE"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var hash: Option[String]                        = None
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def hash(value: Option[String]): this.type      = { this.hash = value; this }
+  def hash(value: String): this.type              = { this.hash = Option(value); this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait FindingT                                       extends AnyRef with HasStructuredFingerprintT
-class Finding(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 19.toShort, seq_4762) with StaticType[FindingT] {
-//{propAccess}
+trait FindingT extends AnyRef with HasStructuredFingerprintT
+trait FindingBase extends AbstractNode with StaticType[FindingT] {
+  def evidence: IndexedSeq[AbstractNode]
+  def keyValuePairs: IndexedSeq[KeyValuePairBase]
+  def rootCauses: IndexedSeq[FindingBase]
+}
+class Finding(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 19.toShort, seq_4762)
+    with FindingBase
+    with StaticType[FindingT] {
   def evidence: IndexedSeq[StoredNode]        = odb2.Accessors.getNodePropertyMulti[StoredNode](graph, nodeKind, 84, seq)
   def keyValuePairs: IndexedSeq[KeyValuePair] = odb2.Accessors.getNodePropertyMulti[KeyValuePair](graph, nodeKind, 85, seq)
   def rootCauses: IndexedSeq[Finding]         = odb2.Accessors.getNodePropertyMulti[Finding](graph, nodeKind, 86, seq)
 }
+object NewFinding { def apply(): NewFinding = new NewFinding }
+class NewFinding extends NewNode(19.toShort) with FindingBase {
+  type RelatedStored = Finding
+  override def label: String                                          = "FINDING"
+  var evidence: IndexedSeq[AbstractNode]                              = ArraySeq.empty
+  var keyValuePairs: IndexedSeq[KeyValuePairBase]                     = ArraySeq.empty
+  var rootCauses: IndexedSeq[FindingBase]                             = ArraySeq.empty
+  var structuredFingerprint: String                                   = "null": String
+  def evidence(value: IterableOnce[AbstractNode]): this.type          = { this.evidence = value.iterator.to(ArraySeq); this }
+  def keyValuePairs(value: IterableOnce[KeyValuePairBase]): this.type = { this.keyValuePairs = value.iterator.to(ArraySeq); this }
+  def rootCauses(value: IterableOnce[FindingBase]): this.type         = { this.rootCauses = value.iterator.to(ArraySeq); this }
+  def structuredFingerprint(value: String): this.type                 = { this.structuredFingerprint = value; this }
+}
 
-trait FlowT                                       extends AnyRef
-class Flow(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 20.toShort, seq_4762) with StaticType[FlowT] {
-//{propAccess}
+trait FlowT extends AnyRef
+trait FlowBase extends AbstractNode with StaticType[FlowT] {
+  def branchPoints: IndexedSeq[TrackingPointBase]
+  def cfgNodes: IndexedSeq[CfgNodeBase]
+  def points: IndexedSeq[ProgramPointBase]
+  def sink: SinkBase
+  def source: SourceBase
+  def transformations: IndexedSeq[TransformationBase]
+}
+class Flow(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 20.toShort, seq_4762)
+    with FlowBase
+    with StaticType[FlowT] {
   def branchPoints: IndexedSeq[TrackingPoint]     = odb2.Accessors.getNodePropertyMulti[TrackingPoint](graph, nodeKind, 85, seq)
   def cfgNodes: IndexedSeq[CfgNode]               = odb2.Accessors.getNodePropertyMulti[CfgNode](graph, nodeKind, 87, seq)
   def points: IndexedSeq[ProgramPoint]            = odb2.Accessors.getNodePropertyMulti[ProgramPoint](graph, nodeKind, 88, seq)
@@ -187,38 +594,122 @@ class Flow(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762,
   def source: Source                              = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 86, seq, null: Source)
   def transformations: IndexedSeq[Transformation] = odb2.Accessors.getNodePropertyMulti[Transformation](graph, nodeKind, 89, seq)
 }
-
-trait FrameworkT                                       extends AnyRef with HasNameT
-class Framework(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 21.toShort, seq_4762) with StaticType[FrameworkT] {
-//{propAccess}
-
+object NewFlow { def apply(): NewFlow = new NewFlow }
+class NewFlow extends NewNode(20.toShort) with FlowBase {
+  type RelatedStored = Flow
+  override def label: String                                              = "FLOW"
+  var branchPoints: IndexedSeq[TrackingPointBase]                         = ArraySeq.empty
+  var cfgNodes: IndexedSeq[CfgNodeBase]                                   = ArraySeq.empty
+  var points: IndexedSeq[ProgramPointBase]                                = ArraySeq.empty
+  var sink: SinkBase                                                      = null
+  var source: SourceBase                                                  = null
+  var transformations: IndexedSeq[TransformationBase]                     = ArraySeq.empty
+  def branchPoints(value: IterableOnce[TrackingPointBase]): this.type     = { this.branchPoints = value.iterator.to(ArraySeq); this }
+  def cfgNodes(value: IterableOnce[CfgNodeBase]): this.type               = { this.cfgNodes = value.iterator.to(ArraySeq); this }
+  def points(value: IterableOnce[ProgramPointBase]): this.type            = { this.points = value.iterator.to(ArraySeq); this }
+  def sink(value: SinkBase): this.type                                    = { this.sink = value; this }
+  def source(value: SourceBase): this.type                                = { this.source = value; this }
+  def transformations(value: IterableOnce[TransformationBase]): this.type = { this.transformations = value.iterator.to(ArraySeq); this }
 }
 
-trait FrameworkDataT extends AnyRef with HasContentT with HasNameT
+trait FrameworkT    extends AnyRef with HasNameT
+trait FrameworkBase extends AbstractNode with StaticType[FrameworkT] {}
+class Framework(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 21.toShort, seq_4762)
+    with FrameworkBase
+    with StaticType[FrameworkT] {}
+object NewFramework             { def apply(): NewFramework = new NewFramework }
+class NewFramework extends NewNode(21.toShort) with FrameworkBase {
+  type RelatedStored = Framework
+  override def label: String         = "FRAMEWORK"
+  var name: String                   = "<empty>": String
+  def name(value: String): this.type = { this.name = value; this }
+}
+
+trait FrameworkDataT    extends AnyRef with HasContentT with HasNameT
+trait FrameworkDataBase extends AbstractNode with StaticType[FrameworkDataT] {}
 class FrameworkData(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 22.toShort, seq_4762)
-    with StaticType[FrameworkDataT] {
-//{propAccess}
-
+    with FrameworkDataBase
+    with StaticType[FrameworkDataT] {}
+object NewFrameworkData             { def apply(): NewFrameworkData = new NewFrameworkData }
+class NewFrameworkData extends NewNode(22.toShort) with FrameworkDataBase {
+  type RelatedStored = FrameworkData
+  override def label: String            = "FRAMEWORK_DATA"
+  var content: String                   = "<empty>": String
+  var name: String                      = "<empty>": String
+  def content(value: String): this.type = { this.content = value; this }
+  def name(value: String): this.type    = { this.name = value; this }
 }
 
-trait IdentifierT extends AnyRef with ExpressionT with LocalLikeT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait IdentifierT    extends AnyRef with ExpressionT with LocalLikeT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait IdentifierBase extends AbstractNode with ExpressionBase with LocalLikeBase with StaticType[IdentifierT] {}
 class Identifier(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 23.toShort, seq_4762)
+    with IdentifierBase
     with Expression
     with LocalLike
-    with StaticType[IdentifierT] {
-//{propAccess}
-
+    with StaticType[IdentifierT] {}
+object NewIdentifier             { def apply(): NewIdentifier = new NewIdentifier }
+class NewIdentifier extends NewNode(23.toShort) with IdentifierBase {
+  type RelatedStored = Identifier
+  override def label: String                                          = "IDENTIFIER"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var depthFirstOrder: Int                                            = -1: Int
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var internalFlags: Int                                              = 0: Int
+  var lineNumber: Option[Int]                                         = None
+  var name: String                                                    = "<empty>": String
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type                          = { this.depthFirstOrder = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def internalFlags(value: Int): this.type                            = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def name(value: String): this.type                                  = { this.name = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
-trait ImplicitCallT extends AnyRef with CallReprT
+trait ImplicitCallT    extends AnyRef with CallReprT
+trait ImplicitCallBase extends AbstractNode with CallReprBase with StaticType[ImplicitCallT] {}
 class ImplicitCall(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 24.toShort, seq_4762)
+    with ImplicitCallBase
     with CallRepr
-    with StaticType[ImplicitCallT] {
-//{propAccess}
-
+    with StaticType[ImplicitCallT] {}
+object NewImplicitCall             { def apply(): NewImplicitCall = new NewImplicitCall }
+class NewImplicitCall extends NewNode(24.toShort) with ImplicitCallBase {
+  type RelatedStored = ImplicitCall
+  override def label: String                      = "IMPLICIT_CALL"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var depthFirstOrder: Int                        = -1: Int
+  var internalFlags: Int                          = 0: Int
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  var signature: String                           = "": String
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type      = { this.depthFirstOrder = value; this }
+  def internalFlags(value: Int): this.type        = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
+  def signature(value: String): this.type         = { this.signature = value; this }
 }
 
 trait ImportT
@@ -229,17 +720,62 @@ trait ImportT
     with HasImportedEntityT
     with HasIsExplicitT
     with HasIsWildcardT
+trait ImportBase extends AbstractNode with AstNodeBase with StaticType[ImportT] {}
 class Import(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 25.toShort, seq_4762)
+    with ImportBase
     with AstNode
-    with StaticType[ImportT] {
-//{propAccess}
-
+    with StaticType[ImportT] {}
+object NewImport             { def apply(): NewImport = new NewImport }
+class NewImport extends NewNode(25.toShort) with ImportBase {
+  type RelatedStored = Import
+  override def label: String                           = "IMPORT"
+  var code: String                                     = "<empty>": String
+  var columnNumber: Option[Int]                        = None
+  var explicitAs: Option[Boolean]                      = None
+  var importedAs: Option[String]                       = None
+  var importedEntity: Option[String]                   = None
+  var isExplicit: Option[Boolean]                      = None
+  var isWildcard: Option[Boolean]                      = None
+  var lineNumber: Option[Int]                          = None
+  var order: Int                                       = -1: Int
+  def code(value: String): this.type                   = { this.code = value; this }
+  def columnNumber(value: Int): this.type              = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type      = { this.columnNumber = value; this }
+  def explicitAs(value: Boolean): this.type            = { this.explicitAs = Option(value); this }
+  def explicitAs(value: Option[Boolean]): this.type    = { this.explicitAs = value; this }
+  def importedAs(value: Option[String]): this.type     = { this.importedAs = value; this }
+  def importedAs(value: String): this.type             = { this.importedAs = Option(value); this }
+  def importedEntity(value: Option[String]): this.type = { this.importedEntity = value; this }
+  def importedEntity(value: String): this.type         = { this.importedEntity = Option(value); this }
+  def isExplicit(value: Boolean): this.type            = { this.isExplicit = Option(value); this }
+  def isExplicit(value: Option[Boolean]): this.type    = { this.isExplicit = value; this }
+  def isWildcard(value: Boolean): this.type            = { this.isWildcard = Option(value); this }
+  def isWildcard(value: Option[Boolean]): this.type    = { this.isWildcard = value; this }
+  def lineNumber(value: Int): this.type                = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type        = { this.lineNumber = value; this }
+  def order(value: Int): this.type                     = { this.order = value; this }
 }
 
-trait IoflowT                                       extends AnyRef with HasFingerprintT with HasLiteralsToSinkT with HasMlAssistedT
-class Ioflow(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 26.toShort, seq_4762) with StaticType[IoflowT] {
-//{propAccess}
+trait IoflowT extends AnyRef with HasFingerprintT with HasLiteralsToSinkT with HasMlAssistedT
+trait IoflowBase extends AbstractNode with StaticType[IoflowT] {
+  def dataTags: IndexedSeq[TagBase]
+  def dstTags: IndexedSeq[TagBase]
+  def primaryFlow: FlowBase
+  def sink: SinkBase
+  def sinkDescriptorFlows: IndexedSeq[FlowBase]
+  def sinkDescriptorTags: IndexedSeq[TagBase]
+  def source: SourceBase
+  def sourceDescriptorFlows: IndexedSeq[FlowBase]
+  def sourceDescriptorTags: IndexedSeq[TagBase]
+  def sourceTags: IndexedSeq[TagBase]
+  def transforms: IndexedSeq[TransformBase]
+  def triggerMethods: IndexedSeq[MethodBase]
+}
+class Ioflow(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 26.toShort, seq_4762)
+    with IoflowBase
+    with StaticType[IoflowT] {
   def dataTags: IndexedSeq[Tag]               = odb2.Accessors.getNodePropertyMulti[Tag](graph, nodeKind, 85, seq)
   def dstTags: IndexedSeq[Tag]                = odb2.Accessors.getNodePropertyMulti[Tag](graph, nodeKind, 87, seq)
   def primaryFlow: Flow                       = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 88, seq, null: Flow)
@@ -253,40 +789,152 @@ class Ioflow(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_476
   def transforms: IndexedSeq[Transform]       = odb2.Accessors.getNodePropertyMulti[Transform](graph, nodeKind, 94, seq)
   def triggerMethods: IndexedSeq[Method]      = odb2.Accessors.getNodePropertyMulti[Method](graph, nodeKind, 95, seq)
 }
+object NewIoflow { def apply(): NewIoflow = new NewIoflow }
+class NewIoflow extends NewNode(26.toShort) with IoflowBase {
+  type RelatedStored = Ioflow
+  override def label: String                                          = "IOFLOW"
+  var dataTags: IndexedSeq[TagBase]                                   = ArraySeq.empty
+  var dstTags: IndexedSeq[TagBase]                                    = ArraySeq.empty
+  var fingerprint: String                                             = "<empty>": String
+  var literalsToSink: IndexedSeq[String]                              = ArraySeq.empty
+  var mlAssisted: Boolean                                             = false: Boolean
+  var primaryFlow: FlowBase                                           = null
+  var sink: SinkBase                                                  = null
+  var sinkDescriptorFlows: IndexedSeq[FlowBase]                       = ArraySeq.empty
+  var sinkDescriptorTags: IndexedSeq[TagBase]                         = ArraySeq.empty
+  var source: SourceBase                                              = null
+  var sourceDescriptorFlows: IndexedSeq[FlowBase]                     = ArraySeq.empty
+  var sourceDescriptorTags: IndexedSeq[TagBase]                       = ArraySeq.empty
+  var sourceTags: IndexedSeq[TagBase]                                 = ArraySeq.empty
+  var transforms: IndexedSeq[TransformBase]                           = ArraySeq.empty
+  var triggerMethods: IndexedSeq[MethodBase]                          = ArraySeq.empty
+  def dataTags(value: IterableOnce[TagBase]): this.type               = { this.dataTags = value.iterator.to(ArraySeq); this }
+  def dstTags(value: IterableOnce[TagBase]): this.type                = { this.dstTags = value.iterator.to(ArraySeq); this }
+  def fingerprint(value: String): this.type                           = { this.fingerprint = value; this }
+  def literalsToSink(value: IterableOnce[String]): this.type          = { this.literalsToSink = value.iterator.to(ArraySeq); this }
+  def mlAssisted(value: Boolean): this.type                           = { this.mlAssisted = value; this }
+  def primaryFlow(value: FlowBase): this.type                         = { this.primaryFlow = value; this }
+  def sink(value: SinkBase): this.type                                = { this.sink = value; this }
+  def sinkDescriptorFlows(value: IterableOnce[FlowBase]): this.type   = { this.sinkDescriptorFlows = value.iterator.to(ArraySeq); this }
+  def sinkDescriptorTags(value: IterableOnce[TagBase]): this.type     = { this.sinkDescriptorTags = value.iterator.to(ArraySeq); this }
+  def source(value: SourceBase): this.type                            = { this.source = value; this }
+  def sourceDescriptorFlows(value: IterableOnce[FlowBase]): this.type = { this.sourceDescriptorFlows = value.iterator.to(ArraySeq); this }
+  def sourceDescriptorTags(value: IterableOnce[TagBase]): this.type   = { this.sourceDescriptorTags = value.iterator.to(ArraySeq); this }
+  def sourceTags(value: IterableOnce[TagBase]): this.type             = { this.sourceTags = value.iterator.to(ArraySeq); this }
+  def transforms(value: IterableOnce[TransformBase]): this.type       = { this.transforms = value.iterator.to(ArraySeq); this }
+  def triggerMethods(value: IterableOnce[MethodBase]): this.type      = { this.triggerMethods = value.iterator.to(ArraySeq); this }
+}
 
-trait JumpLabelT extends AnyRef with AstNodeT with HasNameT with HasParserTypeNameT
+trait JumpLabelT    extends AnyRef with AstNodeT with HasNameT with HasParserTypeNameT
+trait JumpLabelBase extends AbstractNode with AstNodeBase with StaticType[JumpLabelT] {}
 class JumpLabel(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 27.toShort, seq_4762)
+    with JumpLabelBase
     with AstNode
-    with StaticType[JumpLabelT] {
-//{propAccess}
-
+    with StaticType[JumpLabelT] {}
+object NewJumpLabel             { def apply(): NewJumpLabel = new NewJumpLabel }
+class NewJumpLabel extends NewNode(27.toShort) with JumpLabelBase {
+  type RelatedStored = JumpLabel
+  override def label: String                      = "JUMP_LABEL"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  var parserTypeName: String                      = "<empty>": String
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
+  def parserTypeName(value: String): this.type    = { this.parserTypeName = value; this }
 }
 
-trait JumpTargetT extends AnyRef with CfgNodeT with HasArgumentIndexT with HasNameT with HasParserTypeNameT
+trait JumpTargetT    extends AnyRef with CfgNodeT with HasArgumentIndexT with HasNameT with HasParserTypeNameT
+trait JumpTargetBase extends AbstractNode with CfgNodeBase with StaticType[JumpTargetT] {}
 class JumpTarget(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 28.toShort, seq_4762)
+    with JumpTargetBase
     with CfgNode
-    with StaticType[JumpTargetT] {
-//{propAccess}
-
+    with StaticType[JumpTargetT] {}
+object NewJumpTarget             { def apply(): NewJumpTarget = new NewJumpTarget }
+class NewJumpTarget extends NewNode(28.toShort) with JumpTargetBase {
+  type RelatedStored = JumpTarget
+  override def label: String                      = "JUMP_TARGET"
+  var argumentIndex: Int                          = -1: Int
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var depthFirstOrder: Int                        = -1: Int
+  var internalFlags: Int                          = 0: Int
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  var parserTypeName: String                      = "<empty>": String
+  def argumentIndex(value: Int): this.type        = { this.argumentIndex = value; this }
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type      = { this.depthFirstOrder = value; this }
+  def internalFlags(value: Int): this.type        = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
+  def parserTypeName(value: String): this.type    = { this.parserTypeName = value; this }
 }
 
-trait KeyValuePairT extends AnyRef with HasKeyT with HasValueT
+trait KeyValuePairT    extends AnyRef with HasKeyT with HasValueT
+trait KeyValuePairBase extends AbstractNode with StaticType[KeyValuePairT] {}
 class KeyValuePair(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 29.toShort, seq_4762)
-    with StaticType[KeyValuePairT] {
-//{propAccess}
-
+    with KeyValuePairBase
+    with StaticType[KeyValuePairT] {}
+object NewKeyValuePair             { def apply(): NewKeyValuePair = new NewKeyValuePair }
+class NewKeyValuePair extends NewNode(29.toShort) with KeyValuePairBase {
+  type RelatedStored = KeyValuePair
+  override def label: String          = "KEY_VALUE_PAIR"
+  var key: String                     = "<empty>": String
+  var value: String                   = "": String
+  def key(value: String): this.type   = { this.key = value; this }
+  def value(value: String): this.type = { this.value = value; this }
 }
 
-trait LiteralT extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait LiteralT    extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait LiteralBase extends AbstractNode with ExpressionBase with StaticType[LiteralT] {}
 class Literal(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 30.toShort, seq_4762)
+    with LiteralBase
     with Expression
-    with StaticType[LiteralT] {
-//{propAccess}
-
+    with StaticType[LiteralT] {}
+object NewLiteral             { def apply(): NewLiteral = new NewLiteral }
+class NewLiteral extends NewNode(30.toShort) with LiteralBase {
+  type RelatedStored = Literal
+  override def label: String                                          = "LITERAL"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var depthFirstOrder: Int                                            = -1: Int
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var internalFlags: Int                                              = 0: Int
+  var lineNumber: Option[Int]                                         = None
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type                          = { this.depthFirstOrder = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def internalFlags(value: Int): this.type                            = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
 trait LocalT
@@ -297,14 +945,37 @@ trait LocalT
     with HasClosureBindingIdT
     with HasDynamicTypeHintFullNameT
     with HasTypeFullNameT
+trait LocalBase extends AbstractNode with AstNodeBase with DeclarationBase with LocalLikeBase with StaticType[LocalT] {}
 class Local(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 31.toShort, seq_4762)
+    with LocalBase
     with AstNode
     with Declaration
     with LocalLike
-    with StaticType[LocalT] {
-//{propAccess}
-
+    with StaticType[LocalT] {}
+object NewLocal             { def apply(): NewLocal = new NewLocal }
+class NewLocal extends NewNode(31.toShort) with LocalBase {
+  type RelatedStored = Local
+  override def label: String                                          = "LOCAL"
+  var closureBindingId: Option[String]                                = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var lineNumber: Option[Int]                                         = None
+  var name: String                                                    = "<empty>": String
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def closureBindingId(value: Option[String]): this.type              = { this.closureBindingId = value; this }
+  def closureBindingId(value: String): this.type                      = { this.closureBindingId = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def name(value: String): this.type                                  = { this.name = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
 trait LocationT
@@ -318,25 +989,87 @@ trait LocationT
     with HasNodeLabelT
     with HasPackageNameT
     with HasSymbolT
-class Location(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 32.toShort, seq_4762) with StaticType[LocationT] {
-//{propAccess}
+trait LocationBase extends AbstractNode with StaticType[LocationT] {
+  def node: Option[AbstractNode]
+}
+class Location(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 32.toShort, seq_4762)
+    with LocationBase
+    with StaticType[LocationT] {
   def node: Option[StoredNode] = odb2.Accessors.getNodePropertyOption[StoredNode](graph, nodeKind, 84, seq)
 }
-
-trait MatchInfoT                                       extends AnyRef with HasCategoryT with HasPatternT
-class MatchInfo(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 33.toShort, seq_4762) with StaticType[MatchInfoT] {
-//{propAccess}
-
+object NewLocation { def apply(): NewLocation = new NewLocation }
+class NewLocation extends NewNode(32.toShort) with LocationBase {
+  type RelatedStored = Location
+  override def label: String                       = "LOCATION"
+  var className: String                            = "<empty>": String
+  var classShortName: String                       = "<empty>": String
+  var filename: String                             = "<empty>": String
+  var lineNumber: Option[Int]                      = None
+  var methodFullName: String                       = "<empty>": String
+  var methodShortName: String                      = "<empty>": String
+  var node: Option[AbstractNode]                   = None
+  var nodeLabel: String                            = "<empty>": String
+  var packageName: String                          = "<empty>": String
+  var symbol: String                               = "<empty>": String
+  def className(value: String): this.type          = { this.className = value; this }
+  def classShortName(value: String): this.type     = { this.classShortName = value; this }
+  def filename(value: String): this.type           = { this.filename = value; this }
+  def lineNumber(value: Int): this.type            = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type    = { this.lineNumber = value; this }
+  def methodFullName(value: String): this.type     = { this.methodFullName = value; this }
+  def methodShortName(value: String): this.type    = { this.methodShortName = value; this }
+  def node(value: AbstractNode): this.type         = { this.node = Option(value); this }
+  def node(value: Option[AbstractNode]): this.type = { this.node = value; this }
+  def nodeLabel(value: String): this.type          = { this.nodeLabel = value; this }
+  def packageName(value: String): this.type        = { this.packageName = value; this }
+  def symbol(value: String): this.type             = { this.symbol = value; this }
 }
 
-trait MemberT extends AnyRef with AstNodeT with DeclarationT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait MatchInfoT    extends AnyRef with HasCategoryT with HasPatternT
+trait MatchInfoBase extends AbstractNode with StaticType[MatchInfoT] {}
+class MatchInfo(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 33.toShort, seq_4762)
+    with MatchInfoBase
+    with StaticType[MatchInfoT] {}
+object NewMatchInfo             { def apply(): NewMatchInfo = new NewMatchInfo }
+class NewMatchInfo extends NewNode(33.toShort) with MatchInfoBase {
+  type RelatedStored = MatchInfo
+  override def label: String             = "MATCH_INFO"
+  var category: String                   = "<empty>": String
+  var pattern: String                    = "<empty>": String
+  def category(value: String): this.type = { this.category = value; this }
+  def pattern(value: String): this.type  = { this.pattern = value; this }
+}
+
+trait MemberT    extends AnyRef with AstNodeT with DeclarationT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait MemberBase extends AbstractNode with AstNodeBase with DeclarationBase with StaticType[MemberT] {}
 class Member(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 34.toShort, seq_4762)
+    with MemberBase
     with AstNode
     with Declaration
-    with StaticType[MemberT] {
-//{propAccess}
-
+    with StaticType[MemberT] {}
+object NewMember             { def apply(): NewMember = new NewMember }
+class NewMember extends NewNode(34.toShort) with MemberBase {
+  type RelatedStored = Member
+  override def label: String                                          = "MEMBER"
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var lineNumber: Option[Int]                                         = None
+  var name: String                                                    = "<empty>": String
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def name(value: String): this.type                                  = { this.name = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
 trait MetaDataT
@@ -348,9 +1081,31 @@ trait MetaDataT
     with HasRootT
     with HasSpidT
     with HasVersionT
-class MetaData(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 35.toShort, seq_4762) with StaticType[MetaDataT] {
-//{propAccess}
-
+trait MetaDataBase extends AbstractNode with StaticType[MetaDataT] {}
+class MetaData(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 35.toShort, seq_4762)
+    with MetaDataBase
+    with StaticType[MetaDataT] {}
+object NewMetaData             { def apply(): NewMetaData = new NewMetaData }
+class NewMetaData extends NewNode(35.toShort) with MetaDataBase {
+  type RelatedStored = MetaData
+  override def label: String                                    = "META_DATA"
+  var hash: Option[String]                                      = None
+  var language: String                                          = "<empty>": String
+  var overlays: IndexedSeq[String]                              = ArraySeq.empty
+  var policyDirectories: IndexedSeq[String]                     = ArraySeq.empty
+  var root: String                                              = "<empty>": String
+  var spid: Option[String]                                      = None
+  var version: String                                           = "<empty>": String
+  def hash(value: Option[String]): this.type                    = { this.hash = value; this }
+  def hash(value: String): this.type                            = { this.hash = Option(value); this }
+  def language(value: String): this.type                        = { this.language = value; this }
+  def overlays(value: IterableOnce[String]): this.type          = { this.overlays = value.iterator.to(ArraySeq); this }
+  def policyDirectories(value: IterableOnce[String]): this.type = { this.policyDirectories = value.iterator.to(ArraySeq); this }
+  def root(value: String): this.type                            = { this.root = value; this }
+  def spid(value: Option[String]): this.type                    = { this.spid = value; this }
+  def spid(value: String): this.type                            = { this.spid = Option(value); this }
+  def version(value: String): this.type                         = { this.version = value; this }
 }
 
 trait MethodT
@@ -369,22 +1124,93 @@ trait MethodT
     with HasLineNumberEndT
     with HasSignatureT
     with HasVarargParameterT
+trait MethodBase extends AbstractNode with CfgNodeBase with DeclarationBase with StaticType[MethodT] {}
 class Method(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 36.toShort, seq_4762)
+    with MethodBase
     with CfgNode
     with Declaration
-    with StaticType[MethodT] {
-//{propAccess}
-
+    with StaticType[MethodT] {}
+object NewMethod             { def apply(): NewMethod = new NewMethod }
+class NewMethod extends NewNode(36.toShort) with MethodBase {
+  type RelatedStored = Method
+  override def label: String                            = "METHOD"
+  var astParentFullName: String                         = "<empty>": String
+  var astParentType: String                             = "<empty>": String
+  var binarySignature: Option[String]                   = None
+  var code: String                                      = "<empty>": String
+  var columnNumber: Option[Int]                         = None
+  var columnNumberEnd: Option[Int]                      = None
+  var depthFirstOrder: Int                              = -1: Int
+  var filename: String                                  = "<empty>": String
+  var fullName: String                                  = "<empty>": String
+  var hasMapping: Option[Boolean]                       = None
+  var hash: Option[String]                              = None
+  var internalFlags: Int                                = 0: Int
+  var isExternal: Boolean                               = false: Boolean
+  var lineNumber: Option[Int]                           = None
+  var lineNumberEnd: Option[Int]                        = None
+  var name: String                                      = "<empty>": String
+  var order: Int                                        = -1: Int
+  var signature: String                                 = "": String
+  var varargParameter: Int                              = -1: Int
+  def astParentFullName(value: String): this.type       = { this.astParentFullName = value; this }
+  def astParentType(value: String): this.type           = { this.astParentType = value; this }
+  def binarySignature(value: Option[String]): this.type = { this.binarySignature = value; this }
+  def binarySignature(value: String): this.type         = { this.binarySignature = Option(value); this }
+  def code(value: String): this.type                    = { this.code = value; this }
+  def columnNumber(value: Int): this.type               = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type       = { this.columnNumber = value; this }
+  def columnNumberEnd(value: Int): this.type            = { this.columnNumberEnd = Option(value); this }
+  def columnNumberEnd(value: Option[Int]): this.type    = { this.columnNumberEnd = value; this }
+  def depthFirstOrder(value: Int): this.type            = { this.depthFirstOrder = value; this }
+  def filename(value: String): this.type                = { this.filename = value; this }
+  def fullName(value: String): this.type                = { this.fullName = value; this }
+  def hasMapping(value: Boolean): this.type             = { this.hasMapping = Option(value); this }
+  def hasMapping(value: Option[Boolean]): this.type     = { this.hasMapping = value; this }
+  def hash(value: Option[String]): this.type            = { this.hash = value; this }
+  def hash(value: String): this.type                    = { this.hash = Option(value); this }
+  def internalFlags(value: Int): this.type              = { this.internalFlags = value; this }
+  def isExternal(value: Boolean): this.type             = { this.isExternal = value; this }
+  def lineNumber(value: Int): this.type                 = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type         = { this.lineNumber = value; this }
+  def lineNumberEnd(value: Int): this.type              = { this.lineNumberEnd = Option(value); this }
+  def lineNumberEnd(value: Option[Int]): this.type      = { this.lineNumberEnd = value; this }
+  def name(value: String): this.type                    = { this.name = value; this }
+  def order(value: Int): this.type                      = { this.order = value; this }
+  def signature(value: String): this.type               = { this.signature = value; this }
+  def varargParameter(value: Int): this.type            = { this.varargParameter = value; this }
 }
 
-trait MethodInstT extends AnyRef with AstNodeT with HasFullNameT with HasMethodFullNameT with HasNameT with HasSignatureT
+trait MethodInstT    extends AnyRef with AstNodeT with HasFullNameT with HasMethodFullNameT with HasNameT with HasSignatureT
+trait MethodInstBase extends AbstractNode with AstNodeBase with StaticType[MethodInstT] {}
 class MethodInst(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 37.toShort, seq_4762)
+    with MethodInstBase
     with AstNode
-    with StaticType[MethodInstT] {
-//{propAccess}
-
+    with StaticType[MethodInstT] {}
+object NewMethodInst             { def apply(): NewMethodInst = new NewMethodInst }
+class NewMethodInst extends NewNode(37.toShort) with MethodInstBase {
+  type RelatedStored = MethodInst
+  override def label: String                      = "METHOD_INST"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var fullName: String                            = "<empty>": String
+  var lineNumber: Option[Int]                     = None
+  var methodFullName: String                      = "<empty>": String
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  var signature: String                           = "": String
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def fullName(value: String): this.type          = { this.fullName = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def methodFullName(value: String): this.type    = { this.methodFullName = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
+  def signature(value: String): this.type         = { this.signature = value; this }
 }
 
 trait MethodParameterInT
@@ -397,14 +1223,49 @@ trait MethodParameterInT
     with HasIndexT
     with HasIsVariadicT
     with HasTypeFullNameT
+trait MethodParameterInBase
+    extends AbstractNode
+    with CfgNodeBase
+    with DeclarationBase
+    with LocalLikeBase
+    with StaticType[MethodParameterInT] {}
 class MethodParameterIn(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 38.toShort, seq_4762)
+    with MethodParameterInBase
     with CfgNode
     with Declaration
     with LocalLike
-    with StaticType[MethodParameterInT] {
-//{propAccess}
-
+    with StaticType[MethodParameterInT] {}
+object NewMethodParameterIn             { def apply(): NewMethodParameterIn = new NewMethodParameterIn }
+class NewMethodParameterIn extends NewNode(38.toShort) with MethodParameterInBase {
+  type RelatedStored = MethodParameterIn
+  override def label: String                                          = "METHOD_PARAMETER_IN"
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var depthFirstOrder: Int                                            = -1: Int
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var evaluationStrategy: String                                      = "<empty>": String
+  var index: Int                                                      = -1: Int
+  var internalFlags: Int                                              = 0: Int
+  var isVariadic: Boolean                                             = false: Boolean
+  var lineNumber: Option[Int]                                         = None
+  var name: String                                                    = "<empty>": String
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type                          = { this.depthFirstOrder = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def evaluationStrategy(value: String): this.type                    = { this.evaluationStrategy = value; this }
+  def index(value: Int): this.type                                    = { this.index = value; this }
+  def internalFlags(value: Int): this.type                            = { this.internalFlags = value; this }
+  def isVariadic(value: Boolean): this.type                           = { this.isVariadic = value; this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def name(value: String): this.type                                  = { this.name = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
 trait MethodParameterOutT
@@ -415,13 +1276,41 @@ trait MethodParameterOutT
     with HasIndexT
     with HasIsVariadicT
     with HasTypeFullNameT
+trait MethodParameterOutBase extends AbstractNode with CfgNodeBase with DeclarationBase with StaticType[MethodParameterOutT] {}
 class MethodParameterOut(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 39.toShort, seq_4762)
+    with MethodParameterOutBase
     with CfgNode
     with Declaration
-    with StaticType[MethodParameterOutT] {
-//{propAccess}
-
+    with StaticType[MethodParameterOutT] {}
+object NewMethodParameterOut             { def apply(): NewMethodParameterOut = new NewMethodParameterOut }
+class NewMethodParameterOut extends NewNode(39.toShort) with MethodParameterOutBase {
+  type RelatedStored = MethodParameterOut
+  override def label: String                       = "METHOD_PARAMETER_OUT"
+  var code: String                                 = "<empty>": String
+  var columnNumber: Option[Int]                    = None
+  var depthFirstOrder: Int                         = -1: Int
+  var evaluationStrategy: String                   = "<empty>": String
+  var index: Int                                   = -1: Int
+  var internalFlags: Int                           = 0: Int
+  var isVariadic: Boolean                          = false: Boolean
+  var lineNumber: Option[Int]                      = None
+  var name: String                                 = "<empty>": String
+  var order: Int                                   = -1: Int
+  var typeFullName: String                         = "<empty>": String
+  def code(value: String): this.type               = { this.code = value; this }
+  def columnNumber(value: Int): this.type          = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type  = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type       = { this.depthFirstOrder = value; this }
+  def evaluationStrategy(value: String): this.type = { this.evaluationStrategy = value; this }
+  def index(value: Int): this.type                 = { this.index = value; this }
+  def internalFlags(value: Int): this.type         = { this.internalFlags = value; this }
+  def isVariadic(value: Boolean): this.type        = { this.isVariadic = value; this }
+  def lineNumber(value: Int): this.type            = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type    = { this.lineNumber = value; this }
+  def name(value: String): this.type               = { this.name = value; this }
+  def order(value: Int): this.type                 = { this.order = value; this }
+  def typeFullName(value: String): this.type       = { this.typeFullName = value; this }
 }
 
 trait MethodRefT
@@ -431,28 +1320,99 @@ trait MethodRefT
     with HasMethodFullNameT
     with HasMethodInstFullNameT
     with HasTypeFullNameT
+trait MethodRefBase extends AbstractNode with ExpressionBase with StaticType[MethodRefT] {}
 class MethodRef(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 40.toShort, seq_4762)
+    with MethodRefBase
     with Expression
-    with StaticType[MethodRefT] {
-//{propAccess}
-
+    with StaticType[MethodRefT] {}
+object NewMethodRef             { def apply(): NewMethodRef = new NewMethodRef }
+class NewMethodRef extends NewNode(40.toShort) with MethodRefBase {
+  type RelatedStored = MethodRef
+  override def label: String                                          = "METHOD_REF"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var depthFirstOrder: Int                                            = -1: Int
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var internalFlags: Int                                              = 0: Int
+  var lineNumber: Option[Int]                                         = None
+  var methodFullName: String                                          = "<empty>": String
+  var methodInstFullName: Option[String]                              = None
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type                          = { this.depthFirstOrder = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def internalFlags(value: Int): this.type                            = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def methodFullName(value: String): this.type                        = { this.methodFullName = value; this }
+  def methodInstFullName(value: Option[String]): this.type            = { this.methodInstFullName = value; this }
+  def methodInstFullName(value: String): this.type                    = { this.methodInstFullName = Option(value); this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
-trait MethodReturnT extends AnyRef with CfgNodeT with HasDynamicTypeHintFullNameT with HasEvaluationStrategyT with HasTypeFullNameT
+trait MethodReturnT    extends AnyRef with CfgNodeT with HasDynamicTypeHintFullNameT with HasEvaluationStrategyT with HasTypeFullNameT
+trait MethodReturnBase extends AbstractNode with CfgNodeBase with StaticType[MethodReturnT] {}
 class MethodReturn(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 41.toShort, seq_4762)
+    with MethodReturnBase
     with CfgNode
-    with StaticType[MethodReturnT] {
-//{propAccess}
-
+    with StaticType[MethodReturnT] {}
+object NewMethodReturn             { def apply(): NewMethodReturn = new NewMethodReturn }
+class NewMethodReturn extends NewNode(41.toShort) with MethodReturnBase {
+  type RelatedStored = MethodReturn
+  override def label: String                                          = "METHOD_RETURN"
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var depthFirstOrder: Int                                            = -1: Int
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var evaluationStrategy: String                                      = "<empty>": String
+  var internalFlags: Int                                              = 0: Int
+  var lineNumber: Option[Int]                                         = None
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type                          = { this.depthFirstOrder = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def evaluationStrategy(value: String): this.type                    = { this.evaluationStrategy = value; this }
+  def internalFlags(value: Int): this.type                            = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
 trait MethodSummaryT extends AnyRef with HasBinarySignatureT with HasIsExternalT with HasIsStaticT
+trait MethodSummaryBase extends AbstractNode with StaticType[MethodSummaryT] {
+  def annotationParameters: IndexedSeq[SpAnnotationParameterBase]
+  def method: MethodBase
+  def modifiers: IndexedSeq[ModifierBase]
+  def outParameters: IndexedSeq[MethodParameterOutBase]
+  def outParamTags: IndexedSeq[TagsBase]
+  def parameters: IndexedSeq[MethodParameterInBase]
+  def paramTags: IndexedSeq[TagsBase]
+  def paramTypes: IndexedSeq[TypeBase]
+  def returnParameter: MethodReturnBase
+  def returnParameterType: TypeBase
+  def returnParamTags: IndexedSeq[TagBase]
+  def routes: IndexedSeq[RouteBase]
+  def tags: IndexedSeq[TagBase]
+}
 class MethodSummary(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 42.toShort, seq_4762)
+    with MethodSummaryBase
     with StaticType[MethodSummaryT] {
-//{propAccess}
   def annotationParameters: IndexedSeq[SpAnnotationParameter] =
     odb2.Accessors.getNodePropertyMulti[SpAnnotationParameter](graph, nodeKind, 87, seq)
   def method: Method                                = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 85, seq, null: Method)
@@ -468,121 +1428,375 @@ class MethodSummary(graph_4762: odb2.Graph, seq_4762: Int)
   def routes: IndexedSeq[Route]                     = odb2.Accessors.getNodePropertyMulti[Route](graph, nodeKind, 96, seq)
   def tags: IndexedSeq[Tag]                         = odb2.Accessors.getNodePropertyMulti[Tag](graph, nodeKind, 86, seq)
 }
+object NewMethodSummary { def apply(): NewMethodSummary = new NewMethodSummary }
+class NewMethodSummary extends NewNode(42.toShort) with MethodSummaryBase {
+  type RelatedStored = MethodSummary
+  override def label: String                                      = "METHOD_SUMMARY"
+  var annotationParameters: IndexedSeq[SpAnnotationParameterBase] = ArraySeq.empty
+  var binarySignature: Option[String]                             = None
+  var isExternal: Boolean                                         = false: Boolean
+  var isStatic: Boolean                                           = false: Boolean
+  var method: MethodBase                                          = null
+  var modifiers: IndexedSeq[ModifierBase]                         = ArraySeq.empty
+  var outParamTags: IndexedSeq[TagsBase]                          = ArraySeq.empty
+  var outParameters: IndexedSeq[MethodParameterOutBase]           = ArraySeq.empty
+  var paramTags: IndexedSeq[TagsBase]                             = ArraySeq.empty
+  var paramTypes: IndexedSeq[TypeBase]                            = ArraySeq.empty
+  var parameters: IndexedSeq[MethodParameterInBase]               = ArraySeq.empty
+  var returnParamTags: IndexedSeq[TagBase]                        = ArraySeq.empty
+  var returnParameter: MethodReturnBase                           = null
+  var returnParameterType: TypeBase                               = null
+  var routes: IndexedSeq[RouteBase]                               = ArraySeq.empty
+  var tags: IndexedSeq[TagBase]                                   = ArraySeq.empty
+  def annotationParameters(value: IterableOnce[SpAnnotationParameterBase]): this.type = {
+    this.annotationParameters = value.iterator.to(ArraySeq); this
+  }
+  def binarySignature(value: Option[String]): this.type                     = { this.binarySignature = value; this }
+  def binarySignature(value: String): this.type                             = { this.binarySignature = Option(value); this }
+  def isExternal(value: Boolean): this.type                                 = { this.isExternal = value; this }
+  def isStatic(value: Boolean): this.type                                   = { this.isStatic = value; this }
+  def method(value: MethodBase): this.type                                  = { this.method = value; this }
+  def modifiers(value: IterableOnce[ModifierBase]): this.type               = { this.modifiers = value.iterator.to(ArraySeq); this }
+  def outParamTags(value: IterableOnce[TagsBase]): this.type                = { this.outParamTags = value.iterator.to(ArraySeq); this }
+  def outParameters(value: IterableOnce[MethodParameterOutBase]): this.type = { this.outParameters = value.iterator.to(ArraySeq); this }
+  def paramTags(value: IterableOnce[TagsBase]): this.type                   = { this.paramTags = value.iterator.to(ArraySeq); this }
+  def paramTypes(value: IterableOnce[TypeBase]): this.type                  = { this.paramTypes = value.iterator.to(ArraySeq); this }
+  def parameters(value: IterableOnce[MethodParameterInBase]): this.type     = { this.parameters = value.iterator.to(ArraySeq); this }
+  def returnParamTags(value: IterableOnce[TagBase]): this.type              = { this.returnParamTags = value.iterator.to(ArraySeq); this }
+  def returnParameter(value: MethodReturnBase): this.type                   = { this.returnParameter = value; this }
+  def returnParameterType(value: TypeBase): this.type                       = { this.returnParameterType = value; this }
+  def routes(value: IterableOnce[RouteBase]): this.type                     = { this.routes = value.iterator.to(ArraySeq); this }
+  def tags(value: IterableOnce[TagBase]): this.type                         = { this.tags = value.iterator.to(ArraySeq); this }
+}
 
-trait ModifierT extends AnyRef with AstNodeT with HasModifierTypeT
+trait ModifierT    extends AnyRef with AstNodeT with HasModifierTypeT
+trait ModifierBase extends AbstractNode with AstNodeBase with StaticType[ModifierT] {}
 class Modifier(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 43.toShort, seq_4762)
+    with ModifierBase
     with AstNode
-    with StaticType[ModifierT] {
-//{propAccess}
-
+    with StaticType[ModifierT] {}
+object NewModifier             { def apply(): NewModifier = new NewModifier }
+class NewModifier extends NewNode(43.toShort) with ModifierBase {
+  type RelatedStored = Modifier
+  override def label: String                      = "MODIFIER"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var modifierType: String                        = "<empty>": String
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def modifierType(value: String): this.type      = { this.modifierType = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait NamespaceT extends AnyRef with AstNodeT with HasNameT
+trait NamespaceT    extends AnyRef with AstNodeT with HasNameT
+trait NamespaceBase extends AbstractNode with AstNodeBase with StaticType[NamespaceT] {}
 class Namespace(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 44.toShort, seq_4762)
+    with NamespaceBase
     with AstNode
-    with StaticType[NamespaceT] {
-//{propAccess}
-
+    with StaticType[NamespaceT] {}
+object NewNamespace             { def apply(): NewNamespace = new NewNamespace }
+class NewNamespace extends NewNode(44.toShort) with NamespaceBase {
+  type RelatedStored = Namespace
+  override def label: String                      = "NAMESPACE"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait NamespaceBlockT extends AnyRef with AstNodeT with HasFilenameT with HasFullNameT with HasNameT
+trait NamespaceBlockT    extends AnyRef with AstNodeT with HasFilenameT with HasFullNameT with HasNameT
+trait NamespaceBlockBase extends AbstractNode with AstNodeBase with StaticType[NamespaceBlockT] {}
 class NamespaceBlock(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 45.toShort, seq_4762)
+    with NamespaceBlockBase
     with AstNode
-    with StaticType[NamespaceBlockT] {
-//{propAccess}
-
+    with StaticType[NamespaceBlockT] {}
+object NewNamespaceBlock             { def apply(): NewNamespaceBlock = new NewNamespaceBlock }
+class NewNamespaceBlock extends NewNode(45.toShort) with NamespaceBlockBase {
+  type RelatedStored = NamespaceBlock
+  override def label: String                      = "NAMESPACE_BLOCK"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var filename: String                            = "<empty>": String
+  var fullName: String                            = "<empty>": String
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def filename(value: String): this.type          = { this.filename = value; this }
+  def fullName(value: String): this.type          = { this.fullName = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait PackagePrefixT extends AnyRef with HasValueT
+trait PackagePrefixT    extends AnyRef with HasValueT
+trait PackagePrefixBase extends AbstractNode with StaticType[PackagePrefixT] {}
 class PackagePrefix(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 46.toShort, seq_4762)
-    with StaticType[PackagePrefixT] {
-//{propAccess}
-
+    with PackagePrefixBase
+    with StaticType[PackagePrefixT] {}
+object NewPackagePrefix             { def apply(): NewPackagePrefix = new NewPackagePrefix }
+class NewPackagePrefix extends NewNode(46.toShort) with PackagePrefixBase {
+  type RelatedStored = PackagePrefix
+  override def label: String          = "PACKAGE_PREFIX"
+  var value: String                   = "": String
+  def value(value: String): this.type = { this.value = value; this }
 }
 
-trait PostExecutionCallT extends AnyRef with CallReprT
+trait PostExecutionCallT    extends AnyRef with CallReprT
+trait PostExecutionCallBase extends AbstractNode with CallReprBase with StaticType[PostExecutionCallT] {}
 class PostExecutionCall(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 47.toShort, seq_4762)
+    with PostExecutionCallBase
     with CallRepr
-    with StaticType[PostExecutionCallT] {
-//{propAccess}
-
+    with StaticType[PostExecutionCallT] {}
+object NewPostExecutionCall             { def apply(): NewPostExecutionCall = new NewPostExecutionCall }
+class NewPostExecutionCall extends NewNode(47.toShort) with PostExecutionCallBase {
+  type RelatedStored = PostExecutionCall
+  override def label: String                      = "POST_EXECUTION_CALL"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var depthFirstOrder: Int                        = -1: Int
+  var internalFlags: Int                          = 0: Int
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  var signature: String                           = "": String
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type      = { this.depthFirstOrder = value; this }
+  def internalFlags(value: Int): this.type        = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
+  def signature(value: String): this.type         = { this.signature = value; this }
 }
 
 trait ProgramPointT extends AnyRef
+trait ProgramPointBase extends AbstractNode with StaticType[ProgramPointT] {
+  def elem: TrackingPointBase
+  def method: Option[MethodBase]
+  def methodTags: IndexedSeq[TagBase]
+  def paramTags: IndexedSeq[TagBase]
+}
 class ProgramPoint(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 48.toShort, seq_4762)
+    with ProgramPointBase
     with StaticType[ProgramPointT] {
-//{propAccess}
   def elem: TrackingPoint         = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 86, seq, null: TrackingPoint)
   def method: Option[Method]      = odb2.Accessors.getNodePropertyOption[Method](graph, nodeKind, 85, seq)
   def methodTags: IndexedSeq[Tag] = odb2.Accessors.getNodePropertyMulti[Tag](graph, nodeKind, 87, seq)
   def paramTags: IndexedSeq[Tag]  = odb2.Accessors.getNodePropertyMulti[Tag](graph, nodeKind, 84, seq)
 }
+object NewProgramPoint { def apply(): NewProgramPoint = new NewProgramPoint }
+class NewProgramPoint extends NewNode(48.toShort) with ProgramPointBase {
+  type RelatedStored = ProgramPoint
+  override def label: String                              = "PROGRAM_POINT"
+  var elem: TrackingPointBase                             = null
+  var method: Option[MethodBase]                          = None
+  var methodTags: IndexedSeq[TagBase]                     = ArraySeq.empty
+  var paramTags: IndexedSeq[TagBase]                      = ArraySeq.empty
+  def elem(value: TrackingPointBase): this.type           = { this.elem = value; this }
+  def method(value: MethodBase): this.type                = { this.method = Option(value); this }
+  def method(value: Option[MethodBase]): this.type        = { this.method = value; this }
+  def methodTags(value: IterableOnce[TagBase]): this.type = { this.methodTags = value.iterator.to(ArraySeq); this }
+  def paramTags(value: IterableOnce[TagBase]): this.type  = { this.paramTags = value.iterator.to(ArraySeq); this }
+}
 
-trait ReadT                                       extends AnyRef
-class Read(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 49.toShort, seq_4762) with StaticType[ReadT] {
-//{propAccess}
+trait ReadT extends AnyRef
+trait ReadBase extends AbstractNode with StaticType[ReadT] {
+  def descriptorFlows: IndexedSeq[FlowBase]
+  def source: SourceBase
+  def triggerCallChains: IndexedSeq[CallChainBase]
+}
+class Read(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 49.toShort, seq_4762)
+    with ReadBase
+    with StaticType[ReadT] {
   def descriptorFlows: IndexedSeq[Flow]        = odb2.Accessors.getNodePropertyMulti[Flow](graph, nodeKind, 85, seq)
   def source: Source                           = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 86, seq, null: Source)
   def triggerCallChains: IndexedSeq[CallChain] = odb2.Accessors.getNodePropertyMulti[CallChain](graph, nodeKind, 87, seq)
 }
-
-trait ReturnT extends AnyRef with ExpressionT
-class Return(graph_4762: odb2.Graph, seq_4762: Int)
-    extends StoredNode(graph_4762, 50.toShort, seq_4762)
-    with Expression
-    with StaticType[ReturnT] {
-//{propAccess}
-
+object NewRead { def apply(): NewRead = new NewRead }
+class NewRead extends NewNode(49.toShort) with ReadBase {
+  type RelatedStored = Read
+  override def label: String                                           = "READ"
+  var descriptorFlows: IndexedSeq[FlowBase]                            = ArraySeq.empty
+  var source: SourceBase                                               = null
+  var triggerCallChains: IndexedSeq[CallChainBase]                     = ArraySeq.empty
+  def descriptorFlows(value: IterableOnce[FlowBase]): this.type        = { this.descriptorFlows = value.iterator.to(ArraySeq); this }
+  def source(value: SourceBase): this.type                             = { this.source = value; this }
+  def triggerCallChains(value: IterableOnce[CallChainBase]): this.type = { this.triggerCallChains = value.iterator.to(ArraySeq); this }
 }
 
-trait RouteT                                       extends AnyRef with HasPathT
-class Route(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 51.toShort, seq_4762) with StaticType[RouteT] {
-//{propAccess}
+trait ReturnT    extends AnyRef with ExpressionT
+trait ReturnBase extends AbstractNode with ExpressionBase with StaticType[ReturnT] {}
+class Return(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 50.toShort, seq_4762)
+    with ReturnBase
+    with Expression
+    with StaticType[ReturnT] {}
+object NewReturn             { def apply(): NewReturn = new NewReturn }
+class NewReturn extends NewNode(50.toShort) with ReturnBase {
+  type RelatedStored = Return
+  override def label: String                         = "RETURN"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var depthFirstOrder: Int                           = -1: Int
+  var internalFlags: Int                             = 0: Int
+  var lineNumber: Option[Int]                        = None
+  var order: Int                                     = -1: Int
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type         = { this.depthFirstOrder = value; this }
+  def internalFlags(value: Int): this.type           = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
+}
 
+trait RouteT    extends AnyRef with HasPathT
+trait RouteBase extends AbstractNode with StaticType[RouteT] {}
+class Route(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 51.toShort, seq_4762)
+    with RouteBase
+    with StaticType[RouteT] {}
+object NewRoute             { def apply(): NewRoute = new NewRoute }
+class NewRoute extends NewNode(51.toShort) with RouteBase {
+  type RelatedStored = Route
+  override def label: String         = "ROUTE"
+  var path: String                   = "<empty>": String
+  def path(value: String): this.type = { this.path = value; this }
 }
 
 trait SensitiveDataTypeT extends AnyRef with HasFullNameT
+trait SensitiveDataTypeBase extends AbstractNode with StaticType[SensitiveDataTypeT] {
+  def members: IndexedSeq[SensitiveMemberBase]
+  def names: IndexedSeq[MatchInfoBase]
+}
 class SensitiveDataType(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 52.toShort, seq_4762)
+    with SensitiveDataTypeBase
     with StaticType[SensitiveDataTypeT] {
-//{propAccess}
   def members: IndexedSeq[SensitiveMember] = odb2.Accessors.getNodePropertyMulti[SensitiveMember](graph, nodeKind, 85, seq)
   def names: IndexedSeq[MatchInfo]         = odb2.Accessors.getNodePropertyMulti[MatchInfo](graph, nodeKind, 84, seq)
 }
+object NewSensitiveDataType { def apply(): NewSensitiveDataType = new NewSensitiveDataType }
+class NewSensitiveDataType extends NewNode(52.toShort) with SensitiveDataTypeBase {
+  type RelatedStored = SensitiveDataType
+  override def label: String                                       = "SENSITIVE_DATA_TYPE"
+  var fullName: String                                             = "<empty>": String
+  var members: IndexedSeq[SensitiveMemberBase]                     = ArraySeq.empty
+  var names: IndexedSeq[MatchInfoBase]                             = ArraySeq.empty
+  def fullName(value: String): this.type                           = { this.fullName = value; this }
+  def members(value: IterableOnce[SensitiveMemberBase]): this.type = { this.members = value.iterator.to(ArraySeq); this }
+  def names(value: IterableOnce[MatchInfoBase]): this.type         = { this.names = value.iterator.to(ArraySeq); this }
+}
 
 trait SensitiveMemberT extends AnyRef with HasNameT
+trait SensitiveMemberBase extends AbstractNode with StaticType[SensitiveMemberT] {
+  def names: IndexedSeq[MatchInfoBase]
+}
 class SensitiveMember(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 53.toShort, seq_4762)
+    with SensitiveMemberBase
     with StaticType[SensitiveMemberT] {
-//{propAccess}
   def names: IndexedSeq[MatchInfo] = odb2.Accessors.getNodePropertyMulti[MatchInfo](graph, nodeKind, 84, seq)
+}
+object NewSensitiveMember { def apply(): NewSensitiveMember = new NewSensitiveMember }
+class NewSensitiveMember extends NewNode(53.toShort) with SensitiveMemberBase {
+  type RelatedStored = SensitiveMember
+  override def label: String                               = "SENSITIVE_MEMBER"
+  var name: String                                         = "<empty>": String
+  var names: IndexedSeq[MatchInfoBase]                     = ArraySeq.empty
+  def name(value: String): this.type                       = { this.name = value; this }
+  def names(value: IterableOnce[MatchInfoBase]): this.type = { this.names = value.iterator.to(ArraySeq); this }
 }
 
 trait SensitiveReferenceT extends AnyRef
+trait SensitiveReferenceBase extends AbstractNode with StaticType[SensitiveReferenceT] {
+  def ioflows: IndexedSeq[IoflowBase]
+}
 class SensitiveReference(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 54.toShort, seq_4762)
+    with SensitiveReferenceBase
     with StaticType[SensitiveReferenceT] {
-//{propAccess}
   def ioflows: IndexedSeq[Ioflow] = odb2.Accessors.getNodePropertyMulti[Ioflow](graph, nodeKind, 84, seq)
+}
+object NewSensitiveReference { def apply(): NewSensitiveReference = new NewSensitiveReference }
+class NewSensitiveReference extends NewNode(54.toShort) with SensitiveReferenceBase {
+  type RelatedStored = SensitiveReference
+  override def label: String                              = "SENSITIVE_REFERENCE"
+  var ioflows: IndexedSeq[IoflowBase]                     = ArraySeq.empty
+  def ioflows(value: IterableOnce[IoflowBase]): this.type = { this.ioflows = value.iterator.to(ArraySeq); this }
 }
 
 trait SensitiveVariableT extends AnyRef with HasCategoriesT with HasEvalTypeT with HasNameT
+trait SensitiveVariableBase extends AbstractNode with StaticType[SensitiveVariableT] {
+  def node: LocalLikeBase
+}
 class SensitiveVariable(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 55.toShort, seq_4762)
+    with SensitiveVariableBase
     with StaticType[SensitiveVariableT] {
-//{propAccess}
   def node: LocalLike = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 84, seq, null: LocalLike)
 }
+object NewSensitiveVariable { def apply(): NewSensitiveVariable = new NewSensitiveVariable }
+class NewSensitiveVariable extends NewNode(55.toShort) with SensitiveVariableBase {
+  type RelatedStored = SensitiveVariable
+  override def label: String                             = "SENSITIVE_VARIABLE"
+  var categories: IndexedSeq[String]                     = ArraySeq.empty
+  var evalType: String                                   = "<empty>": String
+  var name: String                                       = "<empty>": String
+  var node: LocalLikeBase                                = null
+  def categories(value: IterableOnce[String]): this.type = { this.categories = value.iterator.to(ArraySeq); this }
+  def evalType(value: String): this.type                 = { this.evalType = value; this }
+  def name(value: String): this.type                     = { this.name = value; this }
+  def node(value: LocalLikeBase): this.type              = { this.node = value; this }
+}
 
-trait SinkT                                       extends AnyRef with HasSinkTypeT with HasStructuredFingerprintT
-class Sink(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 56.toShort, seq_4762) with StaticType[SinkT] {
-//{propAccess}
+trait SinkT extends AnyRef with HasSinkTypeT with HasStructuredFingerprintT
+trait SinkBase extends AbstractNode with StaticType[SinkT] {
+  def callingMethod: Option[MethodBase]
+  def callsite: Option[CallBase]
+  def method: MethodBase
+  def methodTags: IndexedSeq[TagBase]
+  def node: TrackingPointBase
+  def nodeType: TypeBase
+  def parameterIn: Option[MethodParameterInBase]
+  def parameterInTags: IndexedSeq[TagBase]
+}
+class Sink(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 56.toShort, seq_4762)
+    with SinkBase
+    with StaticType[SinkT] {
   def callingMethod: Option[Method]          = odb2.Accessors.getNodePropertyOption[Method](graph, nodeKind, 88, seq)
   def callsite: Option[Call]                 = odb2.Accessors.getNodePropertyOption[Call](graph, nodeKind, 89, seq)
   def method: Method                         = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 85, seq, null: Method)
@@ -592,10 +1806,49 @@ class Sink(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762,
   def parameterIn: Option[MethodParameterIn] = odb2.Accessors.getNodePropertyOption[MethodParameterIn](graph, nodeKind, 86, seq)
   def parameterInTags: IndexedSeq[Tag]       = odb2.Accessors.getNodePropertyMulti[Tag](graph, nodeKind, 91, seq)
 }
+object NewSink { def apply(): NewSink = new NewSink }
+class NewSink extends NewNode(56.toShort) with SinkBase {
+  type RelatedStored = Sink
+  override def label: String                                       = "SINK"
+  var callingMethod: Option[MethodBase]                            = None
+  var callsite: Option[CallBase]                                   = None
+  var method: MethodBase                                           = null
+  var methodTags: IndexedSeq[TagBase]                              = ArraySeq.empty
+  var node: TrackingPointBase                                      = null
+  var nodeType: TypeBase                                           = null
+  var parameterIn: Option[MethodParameterInBase]                   = None
+  var parameterInTags: IndexedSeq[TagBase]                         = ArraySeq.empty
+  var sinkType: String                                             = "<empty>": String
+  var structuredFingerprint: String                                = "null": String
+  def callingMethod(value: MethodBase): this.type                  = { this.callingMethod = Option(value); this }
+  def callingMethod(value: Option[MethodBase]): this.type          = { this.callingMethod = value; this }
+  def callsite(value: CallBase): this.type                         = { this.callsite = Option(value); this }
+  def callsite(value: Option[CallBase]): this.type                 = { this.callsite = value; this }
+  def method(value: MethodBase): this.type                         = { this.method = value; this }
+  def methodTags(value: IterableOnce[TagBase]): this.type          = { this.methodTags = value.iterator.to(ArraySeq); this }
+  def node(value: TrackingPointBase): this.type                    = { this.node = value; this }
+  def nodeType(value: TypeBase): this.type                         = { this.nodeType = value; this }
+  def parameterIn(value: MethodParameterInBase): this.type         = { this.parameterIn = Option(value); this }
+  def parameterIn(value: Option[MethodParameterInBase]): this.type = { this.parameterIn = value; this }
+  def parameterInTags(value: IterableOnce[TagBase]): this.type     = { this.parameterInTags = value.iterator.to(ArraySeq); this }
+  def sinkType(value: String): this.type                           = { this.sinkType = value; this }
+  def structuredFingerprint(value: String): this.type              = { this.structuredFingerprint = value; this }
+}
 
-trait SourceT                                       extends AnyRef with HasSourceTypeT with HasStructuredFingerprintT
-class Source(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 57.toShort, seq_4762) with StaticType[SourceT] {
-//{propAccess}
+trait SourceT extends AnyRef with HasSourceTypeT with HasStructuredFingerprintT
+trait SourceBase extends AbstractNode with StaticType[SourceT] {
+  def callingMethod: Option[MethodBase]
+  def callsite: Option[CallBase]
+  def method: MethodBase
+  def methodTags: IndexedSeq[TagBase]
+  def node: TrackingPointBase
+  def nodeType: TypeBase
+  def tags: IndexedSeq[TagBase]
+}
+class Source(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 57.toShort, seq_4762)
+    with SourceBase
+    with StaticType[SourceT] {
   def callingMethod: Option[Method] = odb2.Accessors.getNodePropertyOption[Method](graph, nodeKind, 88, seq)
   def callsite: Option[Call]        = odb2.Accessors.getNodePropertyOption[Call](graph, nodeKind, 89, seq)
   def method: Method                = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 85, seq, null: Method)
@@ -604,83 +1857,244 @@ class Source(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_476
   def nodeType: Type                = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 90, seq, null: Type)
   def tags: IndexedSeq[Tag]         = odb2.Accessors.getNodePropertyMulti[Tag](graph, nodeKind, 86, seq)
 }
+object NewSource { def apply(): NewSource = new NewSource }
+class NewSource extends NewNode(57.toShort) with SourceBase {
+  type RelatedStored = Source
+  override def label: String                              = "SOURCE"
+  var callingMethod: Option[MethodBase]                   = None
+  var callsite: Option[CallBase]                          = None
+  var method: MethodBase                                  = null
+  var methodTags: IndexedSeq[TagBase]                     = ArraySeq.empty
+  var node: TrackingPointBase                             = null
+  var nodeType: TypeBase                                  = null
+  var sourceType: String                                  = "<empty>": String
+  var structuredFingerprint: String                       = "null": String
+  var tags: IndexedSeq[TagBase]                           = ArraySeq.empty
+  def callingMethod(value: MethodBase): this.type         = { this.callingMethod = Option(value); this }
+  def callingMethod(value: Option[MethodBase]): this.type = { this.callingMethod = value; this }
+  def callsite(value: CallBase): this.type                = { this.callsite = Option(value); this }
+  def callsite(value: Option[CallBase]): this.type        = { this.callsite = value; this }
+  def method(value: MethodBase): this.type                = { this.method = value; this }
+  def methodTags(value: IterableOnce[TagBase]): this.type = { this.methodTags = value.iterator.to(ArraySeq); this }
+  def node(value: TrackingPointBase): this.type           = { this.node = value; this }
+  def nodeType(value: TypeBase): this.type                = { this.nodeType = value; this }
+  def sourceType(value: String): this.type                = { this.sourceType = value; this }
+  def structuredFingerprint(value: String): this.type     = { this.structuredFingerprint = value; this }
+  def tags(value: IterableOnce[TagBase]): this.type       = { this.tags = value.iterator.to(ArraySeq); this }
+}
 
-trait SpAnnotationParameterT extends AnyRef with HasAnnotationFullNameT with HasAnnotationNameT with HasNameT with HasValueT
+trait SpAnnotationParameterT    extends AnyRef with HasAnnotationFullNameT with HasAnnotationNameT with HasNameT with HasValueT
+trait SpAnnotationParameterBase extends AbstractNode with StaticType[SpAnnotationParameterT] {}
 class SpAnnotationParameter(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 58.toShort, seq_4762)
-    with StaticType[SpAnnotationParameterT] {
-//{propAccess}
-
+    with SpAnnotationParameterBase
+    with StaticType[SpAnnotationParameterT] {}
+object NewSpAnnotationParameter             { def apply(): NewSpAnnotationParameter = new NewSpAnnotationParameter }
+class NewSpAnnotationParameter extends NewNode(58.toShort) with SpAnnotationParameterBase {
+  type RelatedStored = SpAnnotationParameter
+  override def label: String                       = "SP_ANNOTATION_PARAMETER"
+  var annotationFullName: String                   = "<empty>": String
+  var annotationName: String                       = "<empty>": String
+  var name: String                                 = "<empty>": String
+  var value: String                                = "": String
+  def annotationFullName(value: String): this.type = { this.annotationFullName = value; this }
+  def annotationName(value: String): this.type     = { this.annotationName = value; this }
+  def name(value: String): this.type               = { this.name = value; this }
+  def value(value: String): this.type              = { this.value = value; this }
 }
 
 trait SpBlacklistT extends AnyRef
+trait SpBlacklistBase extends AbstractNode with StaticType[SpBlacklistT] {
+  def tags: IndexedSeq[TagBase]
+}
 class SpBlacklist(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 59.toShort, seq_4762)
+    with SpBlacklistBase
     with StaticType[SpBlacklistT] {
-//{propAccess}
   def tags: IndexedSeq[Tag] = odb2.Accessors.getNodePropertyMulti[Tag](graph, nodeKind, 86, seq)
+}
+object NewSpBlacklist { def apply(): NewSpBlacklist = new NewSpBlacklist }
+class NewSpBlacklist extends NewNode(59.toShort) with SpBlacklistBase {
+  type RelatedStored = SpBlacklist
+  override def label: String                        = "SP_BLACKLIST"
+  var tags: IndexedSeq[TagBase]                     = ArraySeq.empty
+  def tags(value: IterableOnce[TagBase]): this.type = { this.tags = value.iterator.to(ArraySeq); this }
 }
 
 trait TagT                                       extends AnyRef with HasNameT with HasValueT
-class Tag(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 60.toShort, seq_4762) with StaticType[TagT] {
-//{propAccess}
-
+trait TagBase                                    extends AbstractNode with StaticType[TagT]                                              {}
+class Tag(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 60.toShort, seq_4762) with TagBase with StaticType[TagT] {}
+object NewTag { def apply(): NewTag = new NewTag }
+class NewTag extends NewNode(60.toShort) with TagBase {
+  type RelatedStored = Tag
+  override def label: String          = "TAG"
+  var name: String                    = "<empty>": String
+  var value: String                   = "": String
+  def name(value: String): this.type  = { this.name = value; this }
+  def value(value: String): this.type = { this.value = value; this }
 }
 
-trait TagsT                                       extends AnyRef
-class Tags(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 61.toShort, seq_4762) with StaticType[TagsT] {
-//{propAccess}
+trait TagsT extends AnyRef
+trait TagsBase extends AbstractNode with StaticType[TagsT] {
+  def tags: IndexedSeq[TagBase]
+}
+class Tags(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 61.toShort, seq_4762)
+    with TagsBase
+    with StaticType[TagsT] {
   def tags: IndexedSeq[Tag] = odb2.Accessors.getNodePropertyMulti[Tag](graph, nodeKind, 86, seq)
+}
+object NewTags { def apply(): NewTags = new NewTags }
+class NewTags extends NewNode(61.toShort) with TagsBase {
+  type RelatedStored = Tags
+  override def label: String                        = "TAGS"
+  var tags: IndexedSeq[TagBase]                     = ArraySeq.empty
+  def tags(value: IterableOnce[TagBase]): this.type = { this.tags = value.iterator.to(ArraySeq); this }
 }
 
 trait TagNodePairT extends AnyRef
+trait TagNodePairBase extends AbstractNode with StaticType[TagNodePairT] {
+  def node: AbstractNode
+  def tag: TagBase
+}
 class TagNodePair(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 62.toShort, seq_4762)
+    with TagNodePairBase
     with StaticType[TagNodePairT] {
-//{propAccess}
   def node: StoredNode = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 84, seq, null: StoredNode)
   def tag: Tag         = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 85, seq, null: Tag)
 }
-
-trait TemplateDomT extends AnyRef with ExpressionT with HasNameT
-class TemplateDom(graph_4762: odb2.Graph, seq_4762: Int)
-    extends StoredNode(graph_4762, 63.toShort, seq_4762)
-    with Expression
-    with StaticType[TemplateDomT] {
-//{propAccess}
-
+object NewTagNodePair { def apply(): NewTagNodePair = new NewTagNodePair }
+class NewTagNodePair extends NewNode(62.toShort) with TagNodePairBase {
+  type RelatedStored = TagNodePair
+  override def label: String               = "TAG_NODE_PAIR"
+  var node: AbstractNode                   = null
+  var tag: TagBase                         = null
+  def node(value: AbstractNode): this.type = { this.node = value; this }
+  def tag(value: TagBase): this.type       = { this.tag = value; this }
 }
 
-trait TransformT                                       extends AnyRef
-class Transform(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 64.toShort, seq_4762) with StaticType[TransformT] {
-//{propAccess}
+trait TemplateDomT    extends AnyRef with ExpressionT with HasNameT
+trait TemplateDomBase extends AbstractNode with ExpressionBase with StaticType[TemplateDomT] {}
+class TemplateDom(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 63.toShort, seq_4762)
+    with TemplateDomBase
+    with Expression
+    with StaticType[TemplateDomT] {}
+object NewTemplateDom             { def apply(): NewTemplateDom = new NewTemplateDom }
+class NewTemplateDom extends NewNode(63.toShort) with TemplateDomBase {
+  type RelatedStored = TemplateDom
+  override def label: String                         = "TEMPLATE_DOM"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var depthFirstOrder: Int                           = -1: Int
+  var internalFlags: Int                             = 0: Int
+  var lineNumber: Option[Int]                        = None
+  var name: String                                   = "<empty>": String
+  var order: Int                                     = -1: Int
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type         = { this.depthFirstOrder = value; this }
+  def internalFlags(value: Int): this.type           = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def name(value: String): this.type                 = { this.name = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
+}
+
+trait TransformT extends AnyRef
+trait TransformBase extends AbstractNode with StaticType[TransformT] {
+  def call: CallBase
+  def descriptorFlows: IndexedSeq[FlowBase]
+  def sink: SinkBase
+  def triggerCallChains: IndexedSeq[CallChainBase]
+}
+class Transform(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 64.toShort, seq_4762)
+    with TransformBase
+    with StaticType[TransformT] {
   def call: Call                               = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 86, seq, null: Call)
   def descriptorFlows: IndexedSeq[Flow]        = odb2.Accessors.getNodePropertyMulti[Flow](graph, nodeKind, 85, seq)
   def sink: Sink                               = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 84, seq, null: Sink)
   def triggerCallChains: IndexedSeq[CallChain] = odb2.Accessors.getNodePropertyMulti[CallChain](graph, nodeKind, 87, seq)
 }
+object NewTransform { def apply(): NewTransform = new NewTransform }
+class NewTransform extends NewNode(64.toShort) with TransformBase {
+  type RelatedStored = Transform
+  override def label: String                                           = "TRANSFORM"
+  var call: CallBase                                                   = null
+  var descriptorFlows: IndexedSeq[FlowBase]                            = ArraySeq.empty
+  var sink: SinkBase                                                   = null
+  var triggerCallChains: IndexedSeq[CallChainBase]                     = ArraySeq.empty
+  def call(value: CallBase): this.type                                 = { this.call = value; this }
+  def descriptorFlows(value: IterableOnce[FlowBase]): this.type        = { this.descriptorFlows = value.iterator.to(ArraySeq); this }
+  def sink(value: SinkBase): this.type                                 = { this.sink = value; this }
+  def triggerCallChains(value: IterableOnce[CallChainBase]): this.type = { this.triggerCallChains = value.iterator.to(ArraySeq); this }
+}
 
 trait TransformationT extends AnyRef
+trait TransformationBase extends AbstractNode with StaticType[TransformationT] {
+  def node: TrackingPointBase
+}
 class Transformation(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 65.toShort, seq_4762)
+    with TransformationBase
     with StaticType[TransformationT] {
-//{propAccess}
   def node: TrackingPoint = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 84, seq, null: TrackingPoint)
 }
-
-trait TypeT                                       extends AnyRef with HasFullNameT with HasNameT with HasTypeDeclFullNameT
-class Type(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 66.toShort, seq_4762) with StaticType[TypeT] {
-//{propAccess}
-
+object NewTransformation { def apply(): NewTransformation = new NewTransformation }
+class NewTransformation extends NewNode(65.toShort) with TransformationBase {
+  type RelatedStored = Transformation
+  override def label: String                    = "TRANSFORMATION"
+  var node: TrackingPointBase                   = null
+  def node(value: TrackingPointBase): this.type = { this.node = value; this }
 }
 
-trait TypeArgumentT extends AnyRef with AstNodeT
+trait TypeT    extends AnyRef with HasFullNameT with HasNameT with HasTypeDeclFullNameT
+trait TypeBase extends AbstractNode with StaticType[TypeT] {}
+class Type(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 66.toShort, seq_4762)
+    with TypeBase
+    with StaticType[TypeT] {}
+object NewType             { def apply(): NewType = new NewType }
+class NewType extends NewNode(66.toShort) with TypeBase {
+  type RelatedStored = Type
+  override def label: String                     = "TYPE"
+  var fullName: String                           = "<empty>": String
+  var name: String                               = "<empty>": String
+  var typeDeclFullName: String                   = "<empty>": String
+  def fullName(value: String): this.type         = { this.fullName = value; this }
+  def name(value: String): this.type             = { this.name = value; this }
+  def typeDeclFullName(value: String): this.type = { this.typeDeclFullName = value; this }
+}
+
+trait TypeArgumentT    extends AnyRef with AstNodeT
+trait TypeArgumentBase extends AbstractNode with AstNodeBase with StaticType[TypeArgumentT] {}
 class TypeArgument(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 67.toShort, seq_4762)
+    with TypeArgumentBase
     with AstNode
-    with StaticType[TypeArgumentT] {
-//{propAccess}
-
+    with StaticType[TypeArgumentT] {}
+object NewTypeArgument             { def apply(): NewTypeArgument = new NewTypeArgument }
+class NewTypeArgument extends NewNode(67.toShort) with TypeArgumentBase {
+  type RelatedStored = TypeArgument
+  override def label: String                      = "TYPE_ARGUMENT"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
 trait TypeDeclT
@@ -694,30 +2108,106 @@ trait TypeDeclT
     with HasInheritsFromTypeFullNameT
     with HasIsExternalT
     with HasNameT
+trait TypeDeclBase extends AbstractNode with AstNodeBase with StaticType[TypeDeclT] {}
 class TypeDecl(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 68.toShort, seq_4762)
+    with TypeDeclBase
     with AstNode
-    with StaticType[TypeDeclT] {
-//{propAccess}
-
+    with StaticType[TypeDeclT] {}
+object NewTypeDecl             { def apply(): NewTypeDecl = new NewTypeDecl }
+class NewTypeDecl extends NewNode(68.toShort) with TypeDeclBase {
+  type RelatedStored = TypeDecl
+  override def label: String                              = "TYPE_DECL"
+  var aliasTypeFullName: Option[String]                   = None
+  var astParentFullName: String                           = "<empty>": String
+  var astParentType: String                               = "<empty>": String
+  var code: String                                        = "<empty>": String
+  var columnNumber: Option[Int]                           = None
+  var filename: String                                    = "<empty>": String
+  var fullName: String                                    = "<empty>": String
+  var inheritsFromTypeFullName: IndexedSeq[String]        = ArraySeq.empty
+  var isExternal: Boolean                                 = false: Boolean
+  var lineNumber: Option[Int]                             = None
+  var name: String                                        = "<empty>": String
+  var order: Int                                          = -1: Int
+  def aliasTypeFullName(value: Option[String]): this.type = { this.aliasTypeFullName = value; this }
+  def aliasTypeFullName(value: String): this.type         = { this.aliasTypeFullName = Option(value); this }
+  def astParentFullName(value: String): this.type         = { this.astParentFullName = value; this }
+  def astParentType(value: String): this.type             = { this.astParentType = value; this }
+  def code(value: String): this.type                      = { this.code = value; this }
+  def columnNumber(value: Int): this.type                 = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type         = { this.columnNumber = value; this }
+  def filename(value: String): this.type                  = { this.filename = value; this }
+  def fullName(value: String): this.type                  = { this.fullName = value; this }
+  def inheritsFromTypeFullName(value: IterableOnce[String]): this.type = {
+    this.inheritsFromTypeFullName = value.iterator.to(ArraySeq); this
+  }
+  def isExternal(value: Boolean): this.type     = { this.isExternal = value; this }
+  def lineNumber(value: Int): this.type         = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type = { this.lineNumber = value; this }
+  def name(value: String): this.type            = { this.name = value; this }
+  def order(value: Int): this.type              = { this.order = value; this }
 }
 
-trait TypeParameterT extends AnyRef with AstNodeT with HasNameT
+trait TypeParameterT    extends AnyRef with AstNodeT with HasNameT
+trait TypeParameterBase extends AbstractNode with AstNodeBase with StaticType[TypeParameterT] {}
 class TypeParameter(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 69.toShort, seq_4762)
+    with TypeParameterBase
     with AstNode
-    with StaticType[TypeParameterT] {
-//{propAccess}
-
+    with StaticType[TypeParameterT] {}
+object NewTypeParameter             { def apply(): NewTypeParameter = new NewTypeParameter }
+class NewTypeParameter extends NewNode(69.toShort) with TypeParameterBase {
+  type RelatedStored = TypeParameter
+  override def label: String                      = "TYPE_PARAMETER"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait TypeRefT extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait TypeRefT    extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait TypeRefBase extends AbstractNode with ExpressionBase with StaticType[TypeRefT] {}
 class TypeRef(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 70.toShort, seq_4762)
+    with TypeRefBase
     with Expression
-    with StaticType[TypeRefT] {
-//{propAccess}
-
+    with StaticType[TypeRefT] {}
+object NewTypeRef             { def apply(): NewTypeRef = new NewTypeRef }
+class NewTypeRef extends NewNode(70.toShort) with TypeRefBase {
+  type RelatedStored = TypeRef
+  override def label: String                                          = "TYPE_REF"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var depthFirstOrder: Int                                            = -1: Int
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var internalFlags: Int                                              = 0: Int
+  var lineNumber: Option[Int]                                         = None
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def depthFirstOrder(value: Int): this.type                          = { this.depthFirstOrder = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def internalFlags(value: Int): this.type                            = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
 trait UnknownT
@@ -727,35 +2217,110 @@ trait UnknownT
     with HasDynamicTypeHintFullNameT
     with HasParserTypeNameT
     with HasTypeFullNameT
+trait UnknownBase extends AbstractNode with ExpressionBase with StaticType[UnknownT] {}
 class Unknown(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 71.toShort, seq_4762)
+    with UnknownBase
     with Expression
-    with StaticType[UnknownT] {
-//{propAccess}
-
+    with StaticType[UnknownT] {}
+object NewUnknown             { def apply(): NewUnknown = new NewUnknown }
+class NewUnknown extends NewNode(71.toShort) with UnknownBase {
+  type RelatedStored = Unknown
+  override def label: String                                          = "UNKNOWN"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var containedRef: String                                            = "<empty>": String
+  var depthFirstOrder: Int                                            = -1: Int
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var internalFlags: Int                                              = 0: Int
+  var lineNumber: Option[Int]                                         = None
+  var order: Int                                                      = -1: Int
+  var parserTypeName: String                                          = "<empty>": String
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def containedRef(value: String): this.type                          = { this.containedRef = value; this }
+  def depthFirstOrder(value: Int): this.type                          = { this.depthFirstOrder = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def internalFlags(value: Int): this.type                            = { this.internalFlags = value; this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def parserTypeName(value: String): this.type                        = { this.parserTypeName = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
-trait VariableInfoT extends AnyRef with HasEvaluationTypeT with HasParameterIndexT with HasVarTypeT
+trait VariableInfoT    extends AnyRef with HasEvaluationTypeT with HasParameterIndexT with HasVarTypeT
+trait VariableInfoBase extends AbstractNode with StaticType[VariableInfoT] {}
 class VariableInfo(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 72.toShort, seq_4762)
-    with StaticType[VariableInfoT] {
-//{propAccess}
-
+    with VariableInfoBase
+    with StaticType[VariableInfoT] {}
+object NewVariableInfo             { def apply(): NewVariableInfo = new NewVariableInfo }
+class NewVariableInfo extends NewNode(72.toShort) with VariableInfoBase {
+  type RelatedStored = VariableInfo
+  override def label: String                        = "VARIABLE_INFO"
+  var evaluationType: String                        = "<empty>": String
+  var parameterIndex: Option[Int]                   = None
+  var varType: String                               = "<empty>": String
+  def evaluationType(value: String): this.type      = { this.evaluationType = value; this }
+  def parameterIndex(value: Int): this.type         = { this.parameterIndex = Option(value); this }
+  def parameterIndex(value: Option[Int]): this.type = { this.parameterIndex = value; this }
+  def varType(value: String): this.type             = { this.varType = value; this }
 }
 
-trait VulnerabilityT extends AnyRef with HasDescriptionT with HasNameT with HasScoreT with HasUrlT
+trait VulnerabilityT    extends AnyRef with HasDescriptionT with HasNameT with HasScoreT with HasUrlT
+trait VulnerabilityBase extends AbstractNode with StaticType[VulnerabilityT] {}
 class Vulnerability(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 73.toShort, seq_4762)
-    with StaticType[VulnerabilityT] {
-//{propAccess}
-
+    with VulnerabilityBase
+    with StaticType[VulnerabilityT] {}
+object NewVulnerability             { def apply(): NewVulnerability = new NewVulnerability }
+class NewVulnerability extends NewNode(73.toShort) with VulnerabilityBase {
+  type RelatedStored = Vulnerability
+  override def label: String                = "VULNERABILITY"
+  var description: String                   = "<empty>": String
+  var name: String                          = "<empty>": String
+  var score: String                         = "<empty>": String
+  var url: String                           = "<empty>": String
+  def description(value: String): this.type = { this.description = value; this }
+  def name(value: String): this.type        = { this.name = value; this }
+  def score(value: String): this.type       = { this.score = value; this }
+  def url(value: String): this.type         = { this.url = value; this }
 }
 
-trait WriteT                                       extends AnyRef
-class Write(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 74.toShort, seq_4762) with StaticType[WriteT] {
-//{propAccess}
+trait WriteT extends AnyRef
+trait WriteBase extends AbstractNode with StaticType[WriteT] {
+  def descriptorFlows: IndexedSeq[FlowBase]
+  def flows: IndexedSeq[FlowBase]
+  def sink: SinkBase
+  def triggerCallChains: IndexedSeq[CallChainBase]
+}
+class Write(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 74.toShort, seq_4762)
+    with WriteBase
+    with StaticType[WriteT] {
   def descriptorFlows: IndexedSeq[Flow]        = odb2.Accessors.getNodePropertyMulti[Flow](graph, nodeKind, 85, seq)
   def flows: IndexedSeq[Flow]                  = odb2.Accessors.getNodePropertyMulti[Flow](graph, nodeKind, 86, seq)
   def sink: Sink                               = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 84, seq, null: Sink)
   def triggerCallChains: IndexedSeq[CallChain] = odb2.Accessors.getNodePropertyMulti[CallChain](graph, nodeKind, 87, seq)
+}
+object NewWrite { def apply(): NewWrite = new NewWrite }
+class NewWrite extends NewNode(74.toShort) with WriteBase {
+  type RelatedStored = Write
+  override def label: String                                           = "WRITE"
+  var descriptorFlows: IndexedSeq[FlowBase]                            = ArraySeq.empty
+  var flows: IndexedSeq[FlowBase]                                      = ArraySeq.empty
+  var sink: SinkBase                                                   = null
+  var triggerCallChains: IndexedSeq[CallChainBase]                     = ArraySeq.empty
+  def descriptorFlows(value: IterableOnce[FlowBase]): this.type        = { this.descriptorFlows = value.iterator.to(ArraySeq); this }
+  def flows(value: IterableOnce[FlowBase]): this.type                  = { this.flows = value.iterator.to(ArraySeq); this }
+  def sink(value: SinkBase): this.type                                 = { this.sink = value; this }
+  def triggerCallChains(value: IterableOnce[CallChainBase]): this.type = { this.triggerCallChains = value.iterator.to(ArraySeq); this }
 }

--- a/codescienceGenerated/src/main/scala/generated/RootTypes.scala
+++ b/codescienceGenerated/src/main/scala/generated/RootTypes.scala
@@ -3,7 +3,9 @@ import io.joern.odb2
 
 trait StaticType[+T]
 
-trait AbstractNode extends odb2.DNodeOrNode with StaticType[AnyRef]
+trait AbstractNode extends odb2.DNodeOrNode with StaticType[AnyRef] {
+  def label: String
+}
 
 abstract class StoredNode(graph_4762: odb2.Graph, kind_4762: Short, seq_4762: Int)
     extends odb2.GNode(graph_4762, kind_4762, seq_4762)
@@ -175,4 +177,10 @@ abstract class StoredNode(graph_4762: odb2.Graph, kind_4762: Short, seq_4762: In
 
 }
 
-abstract class NewNode extends AbstractNode with odb2.DNode
+abstract class NewNode(val nodeKind: Short) extends AbstractNode with odb2.DNode {
+  type RelatedStored <: StoredNode
+  private /* volatile? */ var _storedRef: RelatedStored               = null.asInstanceOf[RelatedStored]
+  override def storedRef: Option[RelatedStored]                       = Option(this._storedRef)
+  override def storedRef_=(stored: Option[odb2.GNode]): Unit          = this._storedRef = stored.orNull.asInstanceOf[RelatedStored]
+  def flattenProperties(interface: odb2.BatchedUpdateInterface): Unit = ???
+}

--- a/joernGenerated/src/main/scala/generated/Accessors.scala
+++ b/joernGenerated/src/main/scala/generated/Accessors.scala
@@ -4,399 +4,944 @@ import io.shiftleft.codepropertygraph.generated.v2.nodes
 import scala.collection.immutable.IndexedSeq
 
 object Accessors {
-  class Access_property_ALIAS_TYPE_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def aliasTypeFullName: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 0, node.seq)
+  final class Access_Property_ALIAS_TYPE_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def aliasTypeFullName: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 0, node.seq)
   }
-
-  class Access_property_ARGUMENT_INDEX(val node: nodes.StoredNode) extends AnyVal {
-    def argumentIndex: Int =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 1, node.seq(), -1: Int)
+  final class Access_Property_ARGUMENT_INDEX(val node: nodes.StoredNode) extends AnyVal {
+    def argumentIndex: Int = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 1, node.seq(), -1: Int)
   }
-
-  class Access_property_ARGUMENT_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def argumentName: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 2, node.seq)
+  final class Access_Property_ARGUMENT_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def argumentName: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 2, node.seq)
   }
-
-  class Access_property_AST_PARENT_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def astParentFullName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 3, node.seq(), "<empty>": String)
+  final class Access_Property_AST_PARENT_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def astParentFullName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 3, node.seq(), "<empty>": String)
   }
-
-  class Access_property_AST_PARENT_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def astParentType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 4, node.seq(), "<empty>": String)
+  final class Access_Property_AST_PARENT_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def astParentType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 4, node.seq(), "<empty>": String)
   }
-
-  class Access_property_CANONICAL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def canonicalName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 5, node.seq(), "<empty>": String)
+  final class Access_Property_CANONICAL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def canonicalName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 5, node.seq(), "<empty>": String)
   }
-
-  class Access_property_CLASS_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def className: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 6, node.seq(), "<empty>": String)
+  final class Access_Property_CLASS_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def className: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 6, node.seq(), "<empty>": String)
   }
-
-  class Access_property_CLASS_SHORT_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def classShortName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 7, node.seq(), "<empty>": String)
+  final class Access_Property_CLASS_SHORT_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def classShortName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 7, node.seq(), "<empty>": String)
   }
-
-  class Access_property_CLOSURE_BINDING_ID(val node: nodes.StoredNode) extends AnyVal {
-    def closureBindingId: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 8, node.seq)
+  final class Access_Property_CLOSURE_BINDING_ID(val node: nodes.StoredNode) extends AnyVal {
+    def closureBindingId: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 8, node.seq)
   }
-
-  class Access_property_CLOSURE_ORIGINAL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def closureOriginalName: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 9, node.seq)
+  final class Access_Property_CLOSURE_ORIGINAL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def closureOriginalName: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 9, node.seq)
   }
-
-  class Access_property_CODE(val node: nodes.StoredNode) extends AnyVal {
-    def code: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 10, node.seq(), "<empty>": String)
+  final class Access_Property_CODE(val node: nodes.StoredNode) extends AnyVal {
+    def code: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 10, node.seq(), "<empty>": String)
   }
-
-  class Access_property_COLUMN_NUMBER(val node: nodes.StoredNode) extends AnyVal {
-    def columnNumber: Option[Int] =
-      odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 11, node.seq)
+  final class Access_Property_COLUMN_NUMBER(val node: nodes.StoredNode) extends AnyVal {
+    def columnNumber: Option[Int] = odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 11, node.seq)
   }
-
-  class Access_property_COLUMN_NUMBER_END(val node: nodes.StoredNode) extends AnyVal {
-    def columnNumberEnd: Option[Int] =
-      odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 12, node.seq)
+  final class Access_Property_COLUMN_NUMBER_END(val node: nodes.StoredNode) extends AnyVal {
+    def columnNumberEnd: Option[Int] = odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 12, node.seq)
   }
-
-  class Access_property_CONTAINED_REF(val node: nodes.StoredNode) extends AnyVal {
-    def containedRef: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 13, node.seq(), "<empty>": String)
+  final class Access_Property_CONTAINED_REF(val node: nodes.StoredNode) extends AnyVal {
+    def containedRef: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 13, node.seq(), "<empty>": String)
   }
-
-  class Access_property_CONTENT(val node: nodes.StoredNode) extends AnyVal {
-    def content: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 14, node.seq(), "<empty>": String)
+  final class Access_Property_CONTENT(val node: nodes.StoredNode) extends AnyVal {
+    def content: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 14, node.seq(), "<empty>": String)
   }
-
-  class Access_property_CONTROL_STRUCTURE_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def controlStructureType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 15, node.seq(), "<empty>": String)
+  final class Access_Property_CONTROL_STRUCTURE_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def controlStructureType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 15, node.seq(), "<empty>": String)
   }
-
-  class Access_property_DEPENDENCY_GROUP_ID(val node: nodes.StoredNode) extends AnyVal {
-    def dependencyGroupId: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 16, node.seq)
+  final class Access_Property_DEPENDENCY_GROUP_ID(val node: nodes.StoredNode) extends AnyVal {
+    def dependencyGroupId: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 16, node.seq)
   }
-
-  class Access_property_DISPATCH_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def dispatchType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 17, node.seq(), "<empty>": String)
+  final class Access_Property_DISPATCH_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def dispatchType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 17, node.seq(), "<empty>": String)
   }
-
-  class Access_property_DYNAMIC_TYPE_HINT_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def dynamicTypeHintFullName: IndexedSeq[String] =
-      odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 18, node.seq)
+  final class Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 18, node.seq)
   }
-
-  class Access_property_EVALUATION_STRATEGY(val node: nodes.StoredNode) extends AnyVal {
-    def evaluationStrategy: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 19, node.seq(), "<empty>": String)
+  final class Access_Property_EVALUATION_STRATEGY(val node: nodes.StoredNode) extends AnyVal {
+    def evaluationStrategy: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 19, node.seq(), "<empty>": String)
   }
-
-  class Access_property_EXPLICIT_AS(val node: nodes.StoredNode) extends AnyVal {
-    def explicitAs: Option[Boolean] =
-      odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 20, node.seq)
+  final class Access_Property_EXPLICIT_AS(val node: nodes.StoredNode) extends AnyVal {
+    def explicitAs: Option[Boolean] = odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 20, node.seq)
   }
-
-  class Access_property_FILENAME(val node: nodes.StoredNode) extends AnyVal {
-    def filename: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 21, node.seq(), "<empty>": String)
+  final class Access_Property_FILENAME(val node: nodes.StoredNode) extends AnyVal {
+    def filename: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 21, node.seq(), "<empty>": String)
   }
-
-  class Access_property_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def fullName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 22, node.seq(), "<empty>": String)
+  final class Access_Property_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def fullName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 22, node.seq(), "<empty>": String)
   }
-
-  class Access_property_HASH(val node: nodes.StoredNode) extends AnyVal {
-    def hash: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 23, node.seq)
+  final class Access_Property_HASH(val node: nodes.StoredNode) extends AnyVal {
+    def hash: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 23, node.seq)
   }
-
-  class Access_property_IMPORTED_AS(val node: nodes.StoredNode) extends AnyVal {
-    def importedAs: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 24, node.seq)
+  final class Access_Property_IMPORTED_AS(val node: nodes.StoredNode) extends AnyVal {
+    def importedAs: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 24, node.seq)
   }
-
-  class Access_property_IMPORTED_ENTITY(val node: nodes.StoredNode) extends AnyVal {
-    def importedEntity: Option[String] =
-      odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 25, node.seq)
+  final class Access_Property_IMPORTED_ENTITY(val node: nodes.StoredNode) extends AnyVal {
+    def importedEntity: Option[String] = odb2.Accessors.getNodePropertyOption[String](node.graph, node.nodeKind, 25, node.seq)
   }
-
-  class Access_property_INDEX(val node: nodes.StoredNode) extends AnyVal {
-    def index: Int =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 26, node.seq(), -1: Int)
+  final class Access_Property_INDEX(val node: nodes.StoredNode) extends AnyVal {
+    def index: Int = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 26, node.seq(), -1: Int)
   }
-
-  class Access_property_INHERITS_FROM_TYPE_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def inheritsFromTypeFullName: IndexedSeq[String] =
-      odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 27, node.seq)
+  final class Access_Property_INHERITS_FROM_TYPE_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def inheritsFromTypeFullName: IndexedSeq[String] = odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 27, node.seq)
   }
-
-  class Access_property_IS_EXPLICIT(val node: nodes.StoredNode) extends AnyVal {
-    def isExplicit: Option[Boolean] =
-      odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 28, node.seq)
+  final class Access_Property_IS_EXPLICIT(val node: nodes.StoredNode) extends AnyVal {
+    def isExplicit: Option[Boolean] = odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 28, node.seq)
   }
-
-  class Access_property_IS_EXTERNAL(val node: nodes.StoredNode) extends AnyVal {
-    def isExternal: Boolean =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 29, node.seq(), false: Boolean)
+  final class Access_Property_IS_EXTERNAL(val node: nodes.StoredNode) extends AnyVal {
+    def isExternal: Boolean = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 29, node.seq(), false: Boolean)
   }
-
-  class Access_property_IS_VARIADIC(val node: nodes.StoredNode) extends AnyVal {
-    def isVariadic: Boolean =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 30, node.seq(), false: Boolean)
+  final class Access_Property_IS_VARIADIC(val node: nodes.StoredNode) extends AnyVal {
+    def isVariadic: Boolean = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 30, node.seq(), false: Boolean)
   }
-
-  class Access_property_IS_WILDCARD(val node: nodes.StoredNode) extends AnyVal {
-    def isWildcard: Option[Boolean] =
-      odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 31, node.seq)
+  final class Access_Property_IS_WILDCARD(val node: nodes.StoredNode) extends AnyVal {
+    def isWildcard: Option[Boolean] = odb2.Accessors.getNodePropertyOption[Boolean](node.graph, node.nodeKind, 31, node.seq)
   }
-
-  class Access_property_KEY(val node: nodes.StoredNode) extends AnyVal {
-    def key: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 32, node.seq(), "<empty>": String)
+  final class Access_Property_KEY(val node: nodes.StoredNode) extends AnyVal {
+    def key: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 32, node.seq(), "<empty>": String)
   }
-
-  class Access_property_LANGUAGE(val node: nodes.StoredNode) extends AnyVal {
-    def language: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 33, node.seq(), "<empty>": String)
+  final class Access_Property_LANGUAGE(val node: nodes.StoredNode) extends AnyVal {
+    def language: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 33, node.seq(), "<empty>": String)
   }
-
-  class Access_property_LINE_NUMBER(val node: nodes.StoredNode) extends AnyVal {
-    def lineNumber: Option[Int] =
-      odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 34, node.seq)
+  final class Access_Property_LINE_NUMBER(val node: nodes.StoredNode) extends AnyVal {
+    def lineNumber: Option[Int] = odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 34, node.seq)
   }
-
-  class Access_property_LINE_NUMBER_END(val node: nodes.StoredNode) extends AnyVal {
-    def lineNumberEnd: Option[Int] =
-      odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 35, node.seq)
+  final class Access_Property_LINE_NUMBER_END(val node: nodes.StoredNode) extends AnyVal {
+    def lineNumberEnd: Option[Int] = odb2.Accessors.getNodePropertyOption[Int](node.graph, node.nodeKind, 35, node.seq)
   }
-
-  class Access_property_METHOD_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def methodFullName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 36, node.seq(), "<empty>": String)
+  final class Access_Property_METHOD_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def methodFullName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 36, node.seq(), "<empty>": String)
   }
-
-  class Access_property_METHOD_SHORT_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def methodShortName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 37, node.seq(), "<empty>": String)
+  final class Access_Property_METHOD_SHORT_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def methodShortName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 37, node.seq(), "<empty>": String)
   }
-
-  class Access_property_MODIFIER_TYPE(val node: nodes.StoredNode) extends AnyVal {
-    def modifierType: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 38, node.seq(), "<empty>": String)
+  final class Access_Property_MODIFIER_TYPE(val node: nodes.StoredNode) extends AnyVal {
+    def modifierType: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 38, node.seq(), "<empty>": String)
   }
-
-  class Access_property_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def name: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 39, node.seq(), "<empty>": String)
+  final class Access_Property_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def name: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 39, node.seq(), "<empty>": String)
   }
-
-  class Access_property_NODE_LABEL(val node: nodes.StoredNode) extends AnyVal {
-    def nodeLabel: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 40, node.seq(), "<empty>": String)
+  final class Access_Property_NODE_LABEL(val node: nodes.StoredNode) extends AnyVal {
+    def nodeLabel: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 40, node.seq(), "<empty>": String)
   }
-
-  class Access_property_ORDER(val node: nodes.StoredNode) extends AnyVal {
-    def order: Int =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 41, node.seq(), -1: Int)
+  final class Access_Property_ORDER(val node: nodes.StoredNode) extends AnyVal {
+    def order: Int = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 41, node.seq(), -1: Int)
   }
-
-  class Access_property_OVERLAYS(val node: nodes.StoredNode) extends AnyVal {
-    def overlays: IndexedSeq[String] =
-      odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 42, node.seq)
+  final class Access_Property_OVERLAYS(val node: nodes.StoredNode) extends AnyVal {
+    def overlays: IndexedSeq[String] = odb2.Accessors.getNodePropertyMulti[String](node.graph, node.nodeKind, 42, node.seq)
   }
-
-  class Access_property_PACKAGE_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def packageName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 43, node.seq(), "<empty>": String)
+  final class Access_Property_PACKAGE_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def packageName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 43, node.seq(), "<empty>": String)
   }
-
-  class Access_property_PARSER_TYPE_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def parserTypeName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 44, node.seq(), "<empty>": String)
+  final class Access_Property_PARSER_TYPE_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def parserTypeName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 44, node.seq(), "<empty>": String)
   }
-
-  class Access_property_ROOT(val node: nodes.StoredNode) extends AnyVal {
-    def root: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 45, node.seq(), "<empty>": String)
+  final class Access_Property_ROOT(val node: nodes.StoredNode) extends AnyVal {
+    def root: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 45, node.seq(), "<empty>": String)
   }
-
-  class Access_property_SIGNATURE(val node: nodes.StoredNode) extends AnyVal {
-    def signature: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 46, node.seq(), "": String)
+  final class Access_Property_SIGNATURE(val node: nodes.StoredNode) extends AnyVal {
+    def signature: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 46, node.seq(), "": String)
   }
-
-  class Access_property_SYMBOL(val node: nodes.StoredNode) extends AnyVal {
-    def symbol: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 47, node.seq(), "<empty>": String)
+  final class Access_Property_SYMBOL(val node: nodes.StoredNode) extends AnyVal {
+    def symbol: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 47, node.seq(), "<empty>": String)
   }
-
-  class Access_property_TYPE_DECL_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def typeDeclFullName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 48, node.seq(), "<empty>": String)
+  final class Access_Property_TYPE_DECL_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def typeDeclFullName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 48, node.seq(), "<empty>": String)
   }
-
-  class Access_property_TYPE_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
-    def typeFullName: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 49, node.seq(), "<empty>": String)
+  final class Access_Property_TYPE_FULL_NAME(val node: nodes.StoredNode) extends AnyVal {
+    def typeFullName: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 49, node.seq(), "<empty>": String)
   }
-
-  class Access_property_VALUE(val node: nodes.StoredNode) extends AnyVal {
-    def value: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 50, node.seq(), "": String)
+  final class Access_Property_VALUE(val node: nodes.StoredNode) extends AnyVal {
+    def value: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 50, node.seq(), "": String)
   }
-
-  class Access_property_VERSION(val node: nodes.StoredNode) extends AnyVal {
-    def version: String =
-      odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 51, node.seq(), "<empty>": String)
+  final class Access_Property_VERSION(val node: nodes.StoredNode) extends AnyVal {
+    def version: String = odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, 51, node.seq(), "<empty>": String)
+  }
+  //
+  final class Access_AnnotationBase(val node: nodes.AnnotationBase) extends AnyVal {
+    def fullName: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_FULL_NAME(stored).fullName
+      case newNode: nodes.NewAnnotation => newNode.fullName
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewAnnotation => newNode.name
+    }
+  }
+  final class Access_AnnotationLiteralBase(val node: nodes.AnnotationLiteralBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode            => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewAnnotationLiteral => newNode.name
+    }
+  }
+  final class Access_AnnotationParameterBase(val node: nodes.AnnotationParameterBase)             extends AnyVal {}
+  final class Access_AnnotationParameterAssignBase(val node: nodes.AnnotationParameterAssignBase) extends AnyVal {}
+  final class Access_ArrayInitializerBase(val node: nodes.ArrayInitializerBase)                   extends AnyVal {}
+  final class Access_BindingBase(val node: nodes.BindingBase) extends AnyVal {
+    def methodFullName: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_METHOD_FULL_NAME(stored).methodFullName
+      case newNode: nodes.NewBinding => newNode.methodFullName
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewBinding => newNode.name
+    }
+    def signature: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_SIGNATURE(stored).signature
+      case newNode: nodes.NewBinding => newNode.signature
+    }
+  }
+  final class Access_BlockBase(val node: nodes.BlockBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewBlock  => newNode.dynamicTypeHintFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewBlock  => newNode.typeFullName
+    }
+  }
+  final class Access_CallBase(val node: nodes.CallBase) extends AnyVal {
+    def dispatchType: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_DISPATCH_TYPE(stored).dispatchType
+      case newNode: nodes.NewCall   => newNode.dispatchType
+    }
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewCall   => newNode.dynamicTypeHintFullName
+    }
+    def methodFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_METHOD_FULL_NAME(stored).methodFullName
+      case newNode: nodes.NewCall   => newNode.methodFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewCall   => newNode.typeFullName
+    }
+  }
+  final class Access_ClosureBindingBase(val node: nodes.ClosureBindingBase) extends AnyVal {
+    def closureBindingId: Option[String] = node match {
+      case stored: nodes.StoredNode         => new Access_Property_CLOSURE_BINDING_ID(stored).closureBindingId
+      case newNode: nodes.NewClosureBinding => newNode.closureBindingId
+    }
+    def closureOriginalName: Option[String] = node match {
+      case stored: nodes.StoredNode         => new Access_Property_CLOSURE_ORIGINAL_NAME(stored).closureOriginalName
+      case newNode: nodes.NewClosureBinding => newNode.closureOriginalName
+    }
+    def evaluationStrategy: String = node match {
+      case stored: nodes.StoredNode         => new Access_Property_EVALUATION_STRATEGY(stored).evaluationStrategy
+      case newNode: nodes.NewClosureBinding => newNode.evaluationStrategy
+    }
+  }
+  final class Access_CommentBase(val node: nodes.CommentBase) extends AnyVal {
+    def filename: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_FILENAME(stored).filename
+      case newNode: nodes.NewComment => newNode.filename
+    }
+  }
+  final class Access_ConfigFileBase(val node: nodes.ConfigFileBase) extends AnyVal {
+    def content: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_CONTENT(stored).content
+      case newNode: nodes.NewConfigFile => newNode.content
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewConfigFile => newNode.name
+    }
+  }
+  final class Access_ControlStructureBase(val node: nodes.ControlStructureBase) extends AnyVal {
+    def controlStructureType: String = node match {
+      case stored: nodes.StoredNode           => new Access_Property_CONTROL_STRUCTURE_TYPE(stored).controlStructureType
+      case newNode: nodes.NewControlStructure => newNode.controlStructureType
+    }
+    def parserTypeName: String = node match {
+      case stored: nodes.StoredNode           => new Access_Property_PARSER_TYPE_NAME(stored).parserTypeName
+      case newNode: nodes.NewControlStructure => newNode.parserTypeName
+    }
+  }
+  final class Access_DependencyBase(val node: nodes.DependencyBase) extends AnyVal {
+    def dependencyGroupId: Option[String] = node match {
+      case stored: nodes.StoredNode     => new Access_Property_DEPENDENCY_GROUP_ID(stored).dependencyGroupId
+      case newNode: nodes.NewDependency => newNode.dependencyGroupId
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewDependency => newNode.name
+    }
+    def version: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_VERSION(stored).version
+      case newNode: nodes.NewDependency => newNode.version
+    }
+  }
+  final class Access_FieldIdentifierBase(val node: nodes.FieldIdentifierBase) extends AnyVal {
+    def canonicalName: String = node match {
+      case stored: nodes.StoredNode          => new Access_Property_CANONICAL_NAME(stored).canonicalName
+      case newNode: nodes.NewFieldIdentifier => newNode.canonicalName
+    }
+  }
+  final class Access_FileBase(val node: nodes.FileBase) extends AnyVal {
+    def hash: Option[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_HASH(stored).hash
+      case newNode: nodes.NewFile   => newNode.hash
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewFile   => newNode.name
+    }
+  }
+  final class Access_FindingBase(val node: nodes.FindingBase) extends AnyVal {}
+  final class Access_IdentifierBase(val node: nodes.IdentifierBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode     => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewIdentifier => newNode.dynamicTypeHintFullName
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewIdentifier => newNode.name
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewIdentifier => newNode.typeFullName
+    }
+  }
+  final class Access_ImportBase(val node: nodes.ImportBase) extends AnyVal {
+    def explicitAs: Option[Boolean] = node match {
+      case stored: nodes.StoredNode => new Access_Property_EXPLICIT_AS(stored).explicitAs
+      case newNode: nodes.NewImport => newNode.explicitAs
+    }
+    def importedAs: Option[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_IMPORTED_AS(stored).importedAs
+      case newNode: nodes.NewImport => newNode.importedAs
+    }
+    def importedEntity: Option[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_IMPORTED_ENTITY(stored).importedEntity
+      case newNode: nodes.NewImport => newNode.importedEntity
+    }
+    def isExplicit: Option[Boolean] = node match {
+      case stored: nodes.StoredNode => new Access_Property_IS_EXPLICIT(stored).isExplicit
+      case newNode: nodes.NewImport => newNode.isExplicit
+    }
+    def isWildcard: Option[Boolean] = node match {
+      case stored: nodes.StoredNode => new Access_Property_IS_WILDCARD(stored).isWildcard
+      case newNode: nodes.NewImport => newNode.isWildcard
+    }
+  }
+  final class Access_JumpLabelBase(val node: nodes.JumpLabelBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewJumpLabel => newNode.name
+    }
+    def parserTypeName: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_PARSER_TYPE_NAME(stored).parserTypeName
+      case newNode: nodes.NewJumpLabel => newNode.parserTypeName
+    }
+  }
+  final class Access_JumpTargetBase(val node: nodes.JumpTargetBase) extends AnyVal {
+    def argumentIndex: Int = node match {
+      case stored: nodes.StoredNode     => new Access_Property_ARGUMENT_INDEX(stored).argumentIndex
+      case newNode: nodes.NewJumpTarget => newNode.argumentIndex
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewJumpTarget => newNode.name
+    }
+    def parserTypeName: String = node match {
+      case stored: nodes.StoredNode     => new Access_Property_PARSER_TYPE_NAME(stored).parserTypeName
+      case newNode: nodes.NewJumpTarget => newNode.parserTypeName
+    }
+  }
+  final class Access_KeyValuePairBase(val node: nodes.KeyValuePairBase) extends AnyVal {
+    def key: String = node match {
+      case stored: nodes.StoredNode       => new Access_Property_KEY(stored).key
+      case newNode: nodes.NewKeyValuePair => newNode.key
+    }
+    def value: String = node match {
+      case stored: nodes.StoredNode       => new Access_Property_VALUE(stored).value
+      case newNode: nodes.NewKeyValuePair => newNode.value
+    }
+  }
+  final class Access_LiteralBase(val node: nodes.LiteralBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode  => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewLiteral => newNode.dynamicTypeHintFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewLiteral => newNode.typeFullName
+    }
+  }
+  final class Access_LocalBase(val node: nodes.LocalBase) extends AnyVal {
+    def closureBindingId: Option[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_CLOSURE_BINDING_ID(stored).closureBindingId
+      case newNode: nodes.NewLocal  => newNode.closureBindingId
+    }
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewLocal  => newNode.dynamicTypeHintFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewLocal  => newNode.typeFullName
+    }
+  }
+  final class Access_LocationBase(val node: nodes.LocationBase) extends AnyVal {
+    def className: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_CLASS_NAME(stored).className
+      case newNode: nodes.NewLocation => newNode.className
+    }
+    def classShortName: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_CLASS_SHORT_NAME(stored).classShortName
+      case newNode: nodes.NewLocation => newNode.classShortName
+    }
+    def filename: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_FILENAME(stored).filename
+      case newNode: nodes.NewLocation => newNode.filename
+    }
+    def lineNumber: Option[Int] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_LINE_NUMBER(stored).lineNumber
+      case newNode: nodes.NewLocation => newNode.lineNumber
+    }
+    def methodFullName: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_METHOD_FULL_NAME(stored).methodFullName
+      case newNode: nodes.NewLocation => newNode.methodFullName
+    }
+    def methodShortName: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_METHOD_SHORT_NAME(stored).methodShortName
+      case newNode: nodes.NewLocation => newNode.methodShortName
+    }
+    def nodeLabel: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_NODE_LABEL(stored).nodeLabel
+      case newNode: nodes.NewLocation => newNode.nodeLabel
+    }
+    def packageName: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_PACKAGE_NAME(stored).packageName
+      case newNode: nodes.NewLocation => newNode.packageName
+    }
+    def symbol: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_SYMBOL(stored).symbol
+      case newNode: nodes.NewLocation => newNode.symbol
+    }
+  }
+  final class Access_MemberBase(val node: nodes.MemberBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewMember => newNode.dynamicTypeHintFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewMember => newNode.typeFullName
+    }
+  }
+  final class Access_MetaDataBase(val node: nodes.MetaDataBase) extends AnyVal {
+    def hash: Option[String] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_HASH(stored).hash
+      case newNode: nodes.NewMetaData => newNode.hash
+    }
+    def language: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_LANGUAGE(stored).language
+      case newNode: nodes.NewMetaData => newNode.language
+    }
+    def overlays: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_OVERLAYS(stored).overlays
+      case newNode: nodes.NewMetaData => newNode.overlays
+    }
+    def root: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_ROOT(stored).root
+      case newNode: nodes.NewMetaData => newNode.root
+    }
+    def version: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_VERSION(stored).version
+      case newNode: nodes.NewMetaData => newNode.version
+    }
+  }
+  final class Access_MethodBase(val node: nodes.MethodBase) extends AnyVal {
+    def astParentFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_AST_PARENT_FULL_NAME(stored).astParentFullName
+      case newNode: nodes.NewMethod => newNode.astParentFullName
+    }
+    def astParentType: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_AST_PARENT_TYPE(stored).astParentType
+      case newNode: nodes.NewMethod => newNode.astParentType
+    }
+    def columnNumberEnd: Option[Int] = node match {
+      case stored: nodes.StoredNode => new Access_Property_COLUMN_NUMBER_END(stored).columnNumberEnd
+      case newNode: nodes.NewMethod => newNode.columnNumberEnd
+    }
+    def filename: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_FILENAME(stored).filename
+      case newNode: nodes.NewMethod => newNode.filename
+    }
+    def fullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_FULL_NAME(stored).fullName
+      case newNode: nodes.NewMethod => newNode.fullName
+    }
+    def hash: Option[String] = node match {
+      case stored: nodes.StoredNode => new Access_Property_HASH(stored).hash
+      case newNode: nodes.NewMethod => newNode.hash
+    }
+    def isExternal: Boolean = node match {
+      case stored: nodes.StoredNode => new Access_Property_IS_EXTERNAL(stored).isExternal
+      case newNode: nodes.NewMethod => newNode.isExternal
+    }
+    def lineNumberEnd: Option[Int] = node match {
+      case stored: nodes.StoredNode => new Access_Property_LINE_NUMBER_END(stored).lineNumberEnd
+      case newNode: nodes.NewMethod => newNode.lineNumberEnd
+    }
+    def signature: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_SIGNATURE(stored).signature
+      case newNode: nodes.NewMethod => newNode.signature
+    }
+  }
+  final class Access_MethodParameterInBase(val node: nodes.MethodParameterInBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode            => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewMethodParameterIn => newNode.dynamicTypeHintFullName
+    }
+    def evaluationStrategy: String = node match {
+      case stored: nodes.StoredNode            => new Access_Property_EVALUATION_STRATEGY(stored).evaluationStrategy
+      case newNode: nodes.NewMethodParameterIn => newNode.evaluationStrategy
+    }
+    def index: Int = node match {
+      case stored: nodes.StoredNode            => new Access_Property_INDEX(stored).index
+      case newNode: nodes.NewMethodParameterIn => newNode.index
+    }
+    def isVariadic: Boolean = node match {
+      case stored: nodes.StoredNode            => new Access_Property_IS_VARIADIC(stored).isVariadic
+      case newNode: nodes.NewMethodParameterIn => newNode.isVariadic
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode            => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewMethodParameterIn => newNode.typeFullName
+    }
+  }
+  final class Access_MethodParameterOutBase(val node: nodes.MethodParameterOutBase) extends AnyVal {
+    def evaluationStrategy: String = node match {
+      case stored: nodes.StoredNode             => new Access_Property_EVALUATION_STRATEGY(stored).evaluationStrategy
+      case newNode: nodes.NewMethodParameterOut => newNode.evaluationStrategy
+    }
+    def index: Int = node match {
+      case stored: nodes.StoredNode             => new Access_Property_INDEX(stored).index
+      case newNode: nodes.NewMethodParameterOut => newNode.index
+    }
+    def isVariadic: Boolean = node match {
+      case stored: nodes.StoredNode             => new Access_Property_IS_VARIADIC(stored).isVariadic
+      case newNode: nodes.NewMethodParameterOut => newNode.isVariadic
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode             => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewMethodParameterOut => newNode.typeFullName
+    }
+  }
+  final class Access_MethodRefBase(val node: nodes.MethodRefBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode    => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewMethodRef => newNode.dynamicTypeHintFullName
+    }
+    def methodFullName: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_METHOD_FULL_NAME(stored).methodFullName
+      case newNode: nodes.NewMethodRef => newNode.methodFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewMethodRef => newNode.typeFullName
+    }
+  }
+  final class Access_MethodReturnBase(val node: nodes.MethodReturnBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode       => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewMethodReturn => newNode.dynamicTypeHintFullName
+    }
+    def evaluationStrategy: String = node match {
+      case stored: nodes.StoredNode       => new Access_Property_EVALUATION_STRATEGY(stored).evaluationStrategy
+      case newNode: nodes.NewMethodReturn => newNode.evaluationStrategy
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode       => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewMethodReturn => newNode.typeFullName
+    }
+  }
+  final class Access_ModifierBase(val node: nodes.ModifierBase) extends AnyVal {
+    def modifierType: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_MODIFIER_TYPE(stored).modifierType
+      case newNode: nodes.NewModifier => newNode.modifierType
+    }
+  }
+  final class Access_NamespaceBase(val node: nodes.NamespaceBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode    => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewNamespace => newNode.name
+    }
+  }
+  final class Access_NamespaceBlockBase(val node: nodes.NamespaceBlockBase) extends AnyVal {
+    def filename: String = node match {
+      case stored: nodes.StoredNode         => new Access_Property_FILENAME(stored).filename
+      case newNode: nodes.NewNamespaceBlock => newNode.filename
+    }
+    def fullName: String = node match {
+      case stored: nodes.StoredNode         => new Access_Property_FULL_NAME(stored).fullName
+      case newNode: nodes.NewNamespaceBlock => newNode.fullName
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode         => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewNamespaceBlock => newNode.name
+    }
+  }
+  final class Access_ReturnBase(val node: nodes.ReturnBase) extends AnyVal {}
+  final class Access_TagBase(val node: nodes.TagBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewTag    => newNode.name
+    }
+    def value: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_VALUE(stored).value
+      case newNode: nodes.NewTag    => newNode.value
+    }
+  }
+  final class Access_TagNodePairBase(val node: nodes.TagNodePairBase) extends AnyVal {}
+  final class Access_TemplateDomBase(val node: nodes.TemplateDomBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode      => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewTemplateDom => newNode.name
+    }
+  }
+  final class Access_TypeBase(val node: nodes.TypeBase) extends AnyVal {
+    def fullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_FULL_NAME(stored).fullName
+      case newNode: nodes.NewType   => newNode.fullName
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewType   => newNode.name
+    }
+    def typeDeclFullName: String = node match {
+      case stored: nodes.StoredNode => new Access_Property_TYPE_DECL_FULL_NAME(stored).typeDeclFullName
+      case newNode: nodes.NewType   => newNode.typeDeclFullName
+    }
+  }
+  final class Access_TypeArgumentBase(val node: nodes.TypeArgumentBase) extends AnyVal {}
+  final class Access_TypeDeclBase(val node: nodes.TypeDeclBase) extends AnyVal {
+    def aliasTypeFullName: Option[String] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_ALIAS_TYPE_FULL_NAME(stored).aliasTypeFullName
+      case newNode: nodes.NewTypeDecl => newNode.aliasTypeFullName
+    }
+    def astParentFullName: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_AST_PARENT_FULL_NAME(stored).astParentFullName
+      case newNode: nodes.NewTypeDecl => newNode.astParentFullName
+    }
+    def astParentType: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_AST_PARENT_TYPE(stored).astParentType
+      case newNode: nodes.NewTypeDecl => newNode.astParentType
+    }
+    def filename: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_FILENAME(stored).filename
+      case newNode: nodes.NewTypeDecl => newNode.filename
+    }
+    def fullName: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_FULL_NAME(stored).fullName
+      case newNode: nodes.NewTypeDecl => newNode.fullName
+    }
+    def inheritsFromTypeFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_INHERITS_FROM_TYPE_FULL_NAME(stored).inheritsFromTypeFullName
+      case newNode: nodes.NewTypeDecl => newNode.inheritsFromTypeFullName
+    }
+    def isExternal: Boolean = node match {
+      case stored: nodes.StoredNode   => new Access_Property_IS_EXTERNAL(stored).isExternal
+      case newNode: nodes.NewTypeDecl => newNode.isExternal
+    }
+    def name: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewTypeDecl => newNode.name
+    }
+  }
+  final class Access_TypeParameterBase(val node: nodes.TypeParameterBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode        => new Access_Property_NAME(stored).name
+      case newNode: nodes.NewTypeParameter => newNode.name
+    }
+  }
+  final class Access_TypeRefBase(val node: nodes.TypeRefBase) extends AnyVal {
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode  => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewTypeRef => newNode.dynamicTypeHintFullName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewTypeRef => newNode.typeFullName
+    }
+  }
+  final class Access_UnknownBase(val node: nodes.UnknownBase) extends AnyVal {
+    def containedRef: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_CONTAINED_REF(stored).containedRef
+      case newNode: nodes.NewUnknown => newNode.containedRef
+    }
+    def dynamicTypeHintFullName: IndexedSeq[String] = node match {
+      case stored: nodes.StoredNode  => new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(stored).dynamicTypeHintFullName
+      case newNode: nodes.NewUnknown => newNode.dynamicTypeHintFullName
+    }
+    def parserTypeName: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_PARSER_TYPE_NAME(stored).parserTypeName
+      case newNode: nodes.NewUnknown => newNode.parserTypeName
+    }
+    def typeFullName: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_TYPE_FULL_NAME(stored).typeFullName
+      case newNode: nodes.NewUnknown => newNode.typeFullName
+    }
+  }
+  final class Access_AstNodeBase(val node: nodes.AstNodeBase) extends AnyVal {
+    def code: String = node match {
+      case stored: nodes.StoredNode  => new Access_Property_CODE(stored).code
+      case newNode: nodes.AstNodeNew => newNode.code
+    }
+    def columnNumber: Option[Int] = node match {
+      case stored: nodes.StoredNode  => new Access_Property_COLUMN_NUMBER(stored).columnNumber
+      case newNode: nodes.AstNodeNew => newNode.columnNumber
+    }
+    def lineNumber: Option[Int] = node match {
+      case stored: nodes.StoredNode  => new Access_Property_LINE_NUMBER(stored).lineNumber
+      case newNode: nodes.AstNodeNew => newNode.lineNumber
+    }
+    def order: Int = node match {
+      case stored: nodes.StoredNode  => new Access_Property_ORDER(stored).order
+      case newNode: nodes.AstNodeNew => newNode.order
+    }
+  }
+  final class Access_CallReprBase(val node: nodes.CallReprBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_NAME(stored).name
+      case newNode: nodes.CallReprNew => newNode.name
+    }
+    def signature: String = node match {
+      case stored: nodes.StoredNode   => new Access_Property_SIGNATURE(stored).signature
+      case newNode: nodes.CallReprNew => newNode.signature
+    }
+  }
+  final class Access_CfgNodeBase(val node: nodes.CfgNodeBase) extends AnyVal {}
+  final class Access_ExpressionBase(val node: nodes.ExpressionBase) extends AnyVal {
+    def argumentIndex: Int = node match {
+      case stored: nodes.StoredNode     => new Access_Property_ARGUMENT_INDEX(stored).argumentIndex
+      case newNode: nodes.ExpressionNew => newNode.argumentIndex
+    }
+    def argumentName: Option[String] = node match {
+      case stored: nodes.StoredNode     => new Access_Property_ARGUMENT_NAME(stored).argumentName
+      case newNode: nodes.ExpressionNew => newNode.argumentName
+    }
+  }
+  final class Access_DeclarationBase(val node: nodes.DeclarationBase) extends AnyVal {
+    def name: String = node match {
+      case stored: nodes.StoredNode      => new Access_Property_NAME(stored).name
+      case newNode: nodes.DeclarationNew => newNode.name
+    }
   }
 }
 
-object Lang extends ImplicitAccessors
-trait ImplicitAccessors {
+object Lang extends ConcreteStoredConversions {}
+
+trait ConcreteStoredConversions extends ConcreteBaseConversions {
   import Accessors._
   implicit def accessPropertyAliasTypeFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasAliasTypeFullNameT]
-  ): Access_property_ALIAS_TYPE_FULL_NAME = new Access_property_ALIAS_TYPE_FULL_NAME(node)
+  ): Access_Property_ALIAS_TYPE_FULL_NAME = new Access_Property_ALIAS_TYPE_FULL_NAME(node)
   implicit def accessPropertyArgumentIndex(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasArgumentIndexT]
-  ): Access_property_ARGUMENT_INDEX = new Access_property_ARGUMENT_INDEX(node)
+  ): Access_Property_ARGUMENT_INDEX = new Access_Property_ARGUMENT_INDEX(node)
   implicit def accessPropertyArgumentName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasArgumentNameT]
-  ): Access_property_ARGUMENT_NAME = new Access_property_ARGUMENT_NAME(node)
+  ): Access_Property_ARGUMENT_NAME = new Access_Property_ARGUMENT_NAME(node)
   implicit def accessPropertyAstParentFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasAstParentFullNameT]
-  ): Access_property_AST_PARENT_FULL_NAME = new Access_property_AST_PARENT_FULL_NAME(node)
+  ): Access_Property_AST_PARENT_FULL_NAME = new Access_Property_AST_PARENT_FULL_NAME(node)
   implicit def accessPropertyAstParentType(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasAstParentTypeT]
-  ): Access_property_AST_PARENT_TYPE = new Access_property_AST_PARENT_TYPE(node)
+  ): Access_Property_AST_PARENT_TYPE = new Access_Property_AST_PARENT_TYPE(node)
   implicit def accessPropertyCanonicalName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasCanonicalNameT]
-  ): Access_property_CANONICAL_NAME = new Access_property_CANONICAL_NAME(node)
-  implicit def accessPropertyClassName(node: nodes.StoredNode with nodes.StaticType[nodes.HasClassNameT]): Access_property_CLASS_NAME =
-    new Access_property_CLASS_NAME(node)
+  ): Access_Property_CANONICAL_NAME = new Access_Property_CANONICAL_NAME(node)
+  implicit def accessPropertyClassName(node: nodes.StoredNode with nodes.StaticType[nodes.HasClassNameT]): Access_Property_CLASS_NAME =
+    new Access_Property_CLASS_NAME(node)
   implicit def accessPropertyClassShortName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasClassShortNameT]
-  ): Access_property_CLASS_SHORT_NAME = new Access_property_CLASS_SHORT_NAME(node)
+  ): Access_Property_CLASS_SHORT_NAME = new Access_Property_CLASS_SHORT_NAME(node)
   implicit def accessPropertyClosureBindingId(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasClosureBindingIdT]
-  ): Access_property_CLOSURE_BINDING_ID = new Access_property_CLOSURE_BINDING_ID(node)
+  ): Access_Property_CLOSURE_BINDING_ID = new Access_Property_CLOSURE_BINDING_ID(node)
   implicit def accessPropertyClosureOriginalName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasClosureOriginalNameT]
-  ): Access_property_CLOSURE_ORIGINAL_NAME = new Access_property_CLOSURE_ORIGINAL_NAME(node)
-  implicit def accessPropertyCode(node: nodes.StoredNode with nodes.StaticType[nodes.HasCodeT]): Access_property_CODE =
-    new Access_property_CODE(node)
+  ): Access_Property_CLOSURE_ORIGINAL_NAME = new Access_Property_CLOSURE_ORIGINAL_NAME(node)
+  implicit def accessPropertyCode(node: nodes.StoredNode with nodes.StaticType[nodes.HasCodeT]): Access_Property_CODE =
+    new Access_Property_CODE(node)
   implicit def accessPropertyColumnNumber(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasColumnNumberT]
-  ): Access_property_COLUMN_NUMBER = new Access_property_COLUMN_NUMBER(node)
+  ): Access_Property_COLUMN_NUMBER = new Access_Property_COLUMN_NUMBER(node)
   implicit def accessPropertyColumnNumberEnd(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasColumnNumberEndT]
-  ): Access_property_COLUMN_NUMBER_END = new Access_property_COLUMN_NUMBER_END(node)
+  ): Access_Property_COLUMN_NUMBER_END = new Access_Property_COLUMN_NUMBER_END(node)
   implicit def accessPropertyContainedRef(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasContainedRefT]
-  ): Access_property_CONTAINED_REF = new Access_property_CONTAINED_REF(node)
-  implicit def accessPropertyContent(node: nodes.StoredNode with nodes.StaticType[nodes.HasContentT]): Access_property_CONTENT =
-    new Access_property_CONTENT(node)
+  ): Access_Property_CONTAINED_REF = new Access_Property_CONTAINED_REF(node)
+  implicit def accessPropertyContent(node: nodes.StoredNode with nodes.StaticType[nodes.HasContentT]): Access_Property_CONTENT =
+    new Access_Property_CONTENT(node)
   implicit def accessPropertyControlStructureType(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasControlStructureTypeT]
-  ): Access_property_CONTROL_STRUCTURE_TYPE = new Access_property_CONTROL_STRUCTURE_TYPE(node)
+  ): Access_Property_CONTROL_STRUCTURE_TYPE = new Access_Property_CONTROL_STRUCTURE_TYPE(node)
   implicit def accessPropertyDependencyGroupId(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasDependencyGroupIdT]
-  ): Access_property_DEPENDENCY_GROUP_ID = new Access_property_DEPENDENCY_GROUP_ID(node)
+  ): Access_Property_DEPENDENCY_GROUP_ID = new Access_Property_DEPENDENCY_GROUP_ID(node)
   implicit def accessPropertyDispatchType(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasDispatchTypeT]
-  ): Access_property_DISPATCH_TYPE = new Access_property_DISPATCH_TYPE(node)
+  ): Access_Property_DISPATCH_TYPE = new Access_Property_DISPATCH_TYPE(node)
   implicit def accessPropertyDynamicTypeHintFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasDynamicTypeHintFullNameT]
-  ): Access_property_DYNAMIC_TYPE_HINT_FULL_NAME = new Access_property_DYNAMIC_TYPE_HINT_FULL_NAME(node)
+  ): Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME = new Access_Property_DYNAMIC_TYPE_HINT_FULL_NAME(node)
   implicit def accessPropertyEvaluationStrategy(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasEvaluationStrategyT]
-  ): Access_property_EVALUATION_STRATEGY = new Access_property_EVALUATION_STRATEGY(node)
-  implicit def accessPropertyExplicitAs(node: nodes.StoredNode with nodes.StaticType[nodes.HasExplicitAsT]): Access_property_EXPLICIT_AS =
-    new Access_property_EXPLICIT_AS(node)
-  implicit def accessPropertyFilename(node: nodes.StoredNode with nodes.StaticType[nodes.HasFilenameT]): Access_property_FILENAME =
-    new Access_property_FILENAME(node)
-  implicit def accessPropertyFullName(node: nodes.StoredNode with nodes.StaticType[nodes.HasFullNameT]): Access_property_FULL_NAME =
-    new Access_property_FULL_NAME(node)
-  implicit def accessPropertyHash(node: nodes.StoredNode with nodes.StaticType[nodes.HasHashT]): Access_property_HASH =
-    new Access_property_HASH(node)
-  implicit def accessPropertyImportedAs(node: nodes.StoredNode with nodes.StaticType[nodes.HasImportedAsT]): Access_property_IMPORTED_AS =
-    new Access_property_IMPORTED_AS(node)
+  ): Access_Property_EVALUATION_STRATEGY = new Access_Property_EVALUATION_STRATEGY(node)
+  implicit def accessPropertyExplicitAs(node: nodes.StoredNode with nodes.StaticType[nodes.HasExplicitAsT]): Access_Property_EXPLICIT_AS =
+    new Access_Property_EXPLICIT_AS(node)
+  implicit def accessPropertyFilename(node: nodes.StoredNode with nodes.StaticType[nodes.HasFilenameT]): Access_Property_FILENAME =
+    new Access_Property_FILENAME(node)
+  implicit def accessPropertyFullName(node: nodes.StoredNode with nodes.StaticType[nodes.HasFullNameT]): Access_Property_FULL_NAME =
+    new Access_Property_FULL_NAME(node)
+  implicit def accessPropertyHash(node: nodes.StoredNode with nodes.StaticType[nodes.HasHashT]): Access_Property_HASH =
+    new Access_Property_HASH(node)
+  implicit def accessPropertyImportedAs(node: nodes.StoredNode with nodes.StaticType[nodes.HasImportedAsT]): Access_Property_IMPORTED_AS =
+    new Access_Property_IMPORTED_AS(node)
   implicit def accessPropertyImportedEntity(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasImportedEntityT]
-  ): Access_property_IMPORTED_ENTITY = new Access_property_IMPORTED_ENTITY(node)
-  implicit def accessPropertyIndex(node: nodes.StoredNode with nodes.StaticType[nodes.HasIndexT]): Access_property_INDEX =
-    new Access_property_INDEX(node)
+  ): Access_Property_IMPORTED_ENTITY = new Access_Property_IMPORTED_ENTITY(node)
+  implicit def accessPropertyIndex(node: nodes.StoredNode with nodes.StaticType[nodes.HasIndexT]): Access_Property_INDEX =
+    new Access_Property_INDEX(node)
   implicit def accessPropertyInheritsFromTypeFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasInheritsFromTypeFullNameT]
-  ): Access_property_INHERITS_FROM_TYPE_FULL_NAME = new Access_property_INHERITS_FROM_TYPE_FULL_NAME(node)
-  implicit def accessPropertyIsExplicit(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsExplicitT]): Access_property_IS_EXPLICIT =
-    new Access_property_IS_EXPLICIT(node)
-  implicit def accessPropertyIsExternal(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsExternalT]): Access_property_IS_EXTERNAL =
-    new Access_property_IS_EXTERNAL(node)
-  implicit def accessPropertyIsVariadic(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsVariadicT]): Access_property_IS_VARIADIC =
-    new Access_property_IS_VARIADIC(node)
-  implicit def accessPropertyIsWildcard(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsWildcardT]): Access_property_IS_WILDCARD =
-    new Access_property_IS_WILDCARD(node)
-  implicit def accessPropertyKey(node: nodes.StoredNode with nodes.StaticType[nodes.HasKeyT]): Access_property_KEY =
-    new Access_property_KEY(node)
-  implicit def accessPropertyLanguage(node: nodes.StoredNode with nodes.StaticType[nodes.HasLanguageT]): Access_property_LANGUAGE =
-    new Access_property_LANGUAGE(node)
-  implicit def accessPropertyLineNumber(node: nodes.StoredNode with nodes.StaticType[nodes.HasLineNumberT]): Access_property_LINE_NUMBER =
-    new Access_property_LINE_NUMBER(node)
+  ): Access_Property_INHERITS_FROM_TYPE_FULL_NAME = new Access_Property_INHERITS_FROM_TYPE_FULL_NAME(node)
+  implicit def accessPropertyIsExplicit(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsExplicitT]): Access_Property_IS_EXPLICIT =
+    new Access_Property_IS_EXPLICIT(node)
+  implicit def accessPropertyIsExternal(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsExternalT]): Access_Property_IS_EXTERNAL =
+    new Access_Property_IS_EXTERNAL(node)
+  implicit def accessPropertyIsVariadic(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsVariadicT]): Access_Property_IS_VARIADIC =
+    new Access_Property_IS_VARIADIC(node)
+  implicit def accessPropertyIsWildcard(node: nodes.StoredNode with nodes.StaticType[nodes.HasIsWildcardT]): Access_Property_IS_WILDCARD =
+    new Access_Property_IS_WILDCARD(node)
+  implicit def accessPropertyKey(node: nodes.StoredNode with nodes.StaticType[nodes.HasKeyT]): Access_Property_KEY =
+    new Access_Property_KEY(node)
+  implicit def accessPropertyLanguage(node: nodes.StoredNode with nodes.StaticType[nodes.HasLanguageT]): Access_Property_LANGUAGE =
+    new Access_Property_LANGUAGE(node)
+  implicit def accessPropertyLineNumber(node: nodes.StoredNode with nodes.StaticType[nodes.HasLineNumberT]): Access_Property_LINE_NUMBER =
+    new Access_Property_LINE_NUMBER(node)
   implicit def accessPropertyLineNumberEnd(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasLineNumberEndT]
-  ): Access_property_LINE_NUMBER_END = new Access_property_LINE_NUMBER_END(node)
+  ): Access_Property_LINE_NUMBER_END = new Access_Property_LINE_NUMBER_END(node)
   implicit def accessPropertyMethodFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasMethodFullNameT]
-  ): Access_property_METHOD_FULL_NAME = new Access_property_METHOD_FULL_NAME(node)
+  ): Access_Property_METHOD_FULL_NAME = new Access_Property_METHOD_FULL_NAME(node)
   implicit def accessPropertyMethodShortName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasMethodShortNameT]
-  ): Access_property_METHOD_SHORT_NAME = new Access_property_METHOD_SHORT_NAME(node)
+  ): Access_Property_METHOD_SHORT_NAME = new Access_Property_METHOD_SHORT_NAME(node)
   implicit def accessPropertyModifierType(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasModifierTypeT]
-  ): Access_property_MODIFIER_TYPE = new Access_property_MODIFIER_TYPE(node)
-  implicit def accessPropertyName(node: nodes.StoredNode with nodes.StaticType[nodes.HasNameT]): Access_property_NAME =
-    new Access_property_NAME(node)
-  implicit def accessPropertyNodeLabel(node: nodes.StoredNode with nodes.StaticType[nodes.HasNodeLabelT]): Access_property_NODE_LABEL =
-    new Access_property_NODE_LABEL(node)
-  implicit def accessPropertyOrder(node: nodes.StoredNode with nodes.StaticType[nodes.HasOrderT]): Access_property_ORDER =
-    new Access_property_ORDER(node)
-  implicit def accessPropertyOverlays(node: nodes.StoredNode with nodes.StaticType[nodes.HasOverlaysT]): Access_property_OVERLAYS =
-    new Access_property_OVERLAYS(node)
+  ): Access_Property_MODIFIER_TYPE = new Access_Property_MODIFIER_TYPE(node)
+  implicit def accessPropertyName(node: nodes.StoredNode with nodes.StaticType[nodes.HasNameT]): Access_Property_NAME =
+    new Access_Property_NAME(node)
+  implicit def accessPropertyNodeLabel(node: nodes.StoredNode with nodes.StaticType[nodes.HasNodeLabelT]): Access_Property_NODE_LABEL =
+    new Access_Property_NODE_LABEL(node)
+  implicit def accessPropertyOrder(node: nodes.StoredNode with nodes.StaticType[nodes.HasOrderT]): Access_Property_ORDER =
+    new Access_Property_ORDER(node)
+  implicit def accessPropertyOverlays(node: nodes.StoredNode with nodes.StaticType[nodes.HasOverlaysT]): Access_Property_OVERLAYS =
+    new Access_Property_OVERLAYS(node)
   implicit def accessPropertyPackageName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasPackageNameT]
-  ): Access_property_PACKAGE_NAME = new Access_property_PACKAGE_NAME(node)
+  ): Access_Property_PACKAGE_NAME = new Access_Property_PACKAGE_NAME(node)
   implicit def accessPropertyParserTypeName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasParserTypeNameT]
-  ): Access_property_PARSER_TYPE_NAME = new Access_property_PARSER_TYPE_NAME(node)
-  implicit def accessPropertyRoot(node: nodes.StoredNode with nodes.StaticType[nodes.HasRootT]): Access_property_ROOT =
-    new Access_property_ROOT(node)
-  implicit def accessPropertySignature(node: nodes.StoredNode with nodes.StaticType[nodes.HasSignatureT]): Access_property_SIGNATURE =
-    new Access_property_SIGNATURE(node)
-  implicit def accessPropertySymbol(node: nodes.StoredNode with nodes.StaticType[nodes.HasSymbolT]): Access_property_SYMBOL =
-    new Access_property_SYMBOL(node)
+  ): Access_Property_PARSER_TYPE_NAME = new Access_Property_PARSER_TYPE_NAME(node)
+  implicit def accessPropertyRoot(node: nodes.StoredNode with nodes.StaticType[nodes.HasRootT]): Access_Property_ROOT =
+    new Access_Property_ROOT(node)
+  implicit def accessPropertySignature(node: nodes.StoredNode with nodes.StaticType[nodes.HasSignatureT]): Access_Property_SIGNATURE =
+    new Access_Property_SIGNATURE(node)
+  implicit def accessPropertySymbol(node: nodes.StoredNode with nodes.StaticType[nodes.HasSymbolT]): Access_Property_SYMBOL =
+    new Access_Property_SYMBOL(node)
   implicit def accessPropertyTypeDeclFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasTypeDeclFullNameT]
-  ): Access_property_TYPE_DECL_FULL_NAME = new Access_property_TYPE_DECL_FULL_NAME(node)
+  ): Access_Property_TYPE_DECL_FULL_NAME = new Access_Property_TYPE_DECL_FULL_NAME(node)
   implicit def accessPropertyTypeFullName(
     node: nodes.StoredNode with nodes.StaticType[nodes.HasTypeFullNameT]
-  ): Access_property_TYPE_FULL_NAME = new Access_property_TYPE_FULL_NAME(node)
-  implicit def accessPropertyValue(node: nodes.StoredNode with nodes.StaticType[nodes.HasValueT]): Access_property_VALUE =
-    new Access_property_VALUE(node)
-  implicit def accessPropertyVersion(node: nodes.StoredNode with nodes.StaticType[nodes.HasVersionT]): Access_property_VERSION =
-    new Access_property_VERSION(node)
+  ): Access_Property_TYPE_FULL_NAME = new Access_Property_TYPE_FULL_NAME(node)
+  implicit def accessPropertyValue(node: nodes.StoredNode with nodes.StaticType[nodes.HasValueT]): Access_Property_VALUE =
+    new Access_Property_VALUE(node)
+  implicit def accessPropertyVersion(node: nodes.StoredNode with nodes.StaticType[nodes.HasVersionT]): Access_Property_VERSION =
+    new Access_Property_VERSION(node)
+}
+
+trait ConcreteBaseConversions extends AbstractBaseConversions0 {
+  import Accessors._
+  implicit def access_AnnotationBase(node: nodes.AnnotationBase): Access_AnnotationBase = new Access_AnnotationBase(node)
+  implicit def access_AnnotationLiteralBase(node: nodes.AnnotationLiteralBase): Access_AnnotationLiteralBase =
+    new Access_AnnotationLiteralBase(node)
+  implicit def access_AnnotationParameterBase(node: nodes.AnnotationParameterBase): Access_AnnotationParameterBase =
+    new Access_AnnotationParameterBase(node)
+  implicit def access_AnnotationParameterAssignBase(node: nodes.AnnotationParameterAssignBase): Access_AnnotationParameterAssignBase =
+    new Access_AnnotationParameterAssignBase(node)
+  implicit def access_ArrayInitializerBase(node: nodes.ArrayInitializerBase): Access_ArrayInitializerBase = new Access_ArrayInitializerBase(
+    node
+  )
+  implicit def access_BindingBase(node: nodes.BindingBase): Access_BindingBase                      = new Access_BindingBase(node)
+  implicit def access_BlockBase(node: nodes.BlockBase): Access_BlockBase                            = new Access_BlockBase(node)
+  implicit def access_CallBase(node: nodes.CallBase): Access_CallBase                               = new Access_CallBase(node)
+  implicit def access_ClosureBindingBase(node: nodes.ClosureBindingBase): Access_ClosureBindingBase = new Access_ClosureBindingBase(node)
+  implicit def access_CommentBase(node: nodes.CommentBase): Access_CommentBase                      = new Access_CommentBase(node)
+  implicit def access_ConfigFileBase(node: nodes.ConfigFileBase): Access_ConfigFileBase             = new Access_ConfigFileBase(node)
+  implicit def access_ControlStructureBase(node: nodes.ControlStructureBase): Access_ControlStructureBase = new Access_ControlStructureBase(
+    node
+  )
+  implicit def access_DependencyBase(node: nodes.DependencyBase): Access_DependencyBase = new Access_DependencyBase(node)
+  implicit def access_FieldIdentifierBase(node: nodes.FieldIdentifierBase): Access_FieldIdentifierBase = new Access_FieldIdentifierBase(
+    node
+  )
+  implicit def access_FileBase(node: nodes.FileBase): Access_FileBase                         = new Access_FileBase(node)
+  implicit def access_FindingBase(node: nodes.FindingBase): Access_FindingBase                = new Access_FindingBase(node)
+  implicit def access_IdentifierBase(node: nodes.IdentifierBase): Access_IdentifierBase       = new Access_IdentifierBase(node)
+  implicit def access_ImportBase(node: nodes.ImportBase): Access_ImportBase                   = new Access_ImportBase(node)
+  implicit def access_JumpLabelBase(node: nodes.JumpLabelBase): Access_JumpLabelBase          = new Access_JumpLabelBase(node)
+  implicit def access_JumpTargetBase(node: nodes.JumpTargetBase): Access_JumpTargetBase       = new Access_JumpTargetBase(node)
+  implicit def access_KeyValuePairBase(node: nodes.KeyValuePairBase): Access_KeyValuePairBase = new Access_KeyValuePairBase(node)
+  implicit def access_LiteralBase(node: nodes.LiteralBase): Access_LiteralBase                = new Access_LiteralBase(node)
+  implicit def access_LocalBase(node: nodes.LocalBase): Access_LocalBase                      = new Access_LocalBase(node)
+  implicit def access_LocationBase(node: nodes.LocationBase): Access_LocationBase             = new Access_LocationBase(node)
+  implicit def access_MemberBase(node: nodes.MemberBase): Access_MemberBase                   = new Access_MemberBase(node)
+  implicit def access_MetaDataBase(node: nodes.MetaDataBase): Access_MetaDataBase             = new Access_MetaDataBase(node)
+  implicit def access_MethodBase(node: nodes.MethodBase): Access_MethodBase                   = new Access_MethodBase(node)
+  implicit def access_MethodParameterInBase(node: nodes.MethodParameterInBase): Access_MethodParameterInBase =
+    new Access_MethodParameterInBase(node)
+  implicit def access_MethodParameterOutBase(node: nodes.MethodParameterOutBase): Access_MethodParameterOutBase =
+    new Access_MethodParameterOutBase(node)
+  implicit def access_MethodRefBase(node: nodes.MethodRefBase): Access_MethodRefBase                = new Access_MethodRefBase(node)
+  implicit def access_MethodReturnBase(node: nodes.MethodReturnBase): Access_MethodReturnBase       = new Access_MethodReturnBase(node)
+  implicit def access_ModifierBase(node: nodes.ModifierBase): Access_ModifierBase                   = new Access_ModifierBase(node)
+  implicit def access_NamespaceBase(node: nodes.NamespaceBase): Access_NamespaceBase                = new Access_NamespaceBase(node)
+  implicit def access_NamespaceBlockBase(node: nodes.NamespaceBlockBase): Access_NamespaceBlockBase = new Access_NamespaceBlockBase(node)
+  implicit def access_ReturnBase(node: nodes.ReturnBase): Access_ReturnBase                         = new Access_ReturnBase(node)
+  implicit def access_TagBase(node: nodes.TagBase): Access_TagBase                                  = new Access_TagBase(node)
+  implicit def access_TagNodePairBase(node: nodes.TagNodePairBase): Access_TagNodePairBase          = new Access_TagNodePairBase(node)
+  implicit def access_TemplateDomBase(node: nodes.TemplateDomBase): Access_TemplateDomBase          = new Access_TemplateDomBase(node)
+  implicit def access_TypeBase(node: nodes.TypeBase): Access_TypeBase                               = new Access_TypeBase(node)
+  implicit def access_TypeArgumentBase(node: nodes.TypeArgumentBase): Access_TypeArgumentBase       = new Access_TypeArgumentBase(node)
+  implicit def access_TypeDeclBase(node: nodes.TypeDeclBase): Access_TypeDeclBase                   = new Access_TypeDeclBase(node)
+  implicit def access_TypeParameterBase(node: nodes.TypeParameterBase): Access_TypeParameterBase    = new Access_TypeParameterBase(node)
+  implicit def access_TypeRefBase(node: nodes.TypeRefBase): Access_TypeRefBase                      = new Access_TypeRefBase(node)
+  implicit def access_UnknownBase(node: nodes.UnknownBase): Access_UnknownBase                      = new Access_UnknownBase(node)
+}
+
+trait AbstractBaseConversions0 extends AbstractBaseConversions1 {
+  import Accessors._
+  implicit def access_AstNodeBase(node: nodes.AstNodeBase): Access_AstNodeBase          = new Access_AstNodeBase(node)
+  implicit def access_CallReprBase(node: nodes.CallReprBase): Access_CallReprBase       = new Access_CallReprBase(node)
+  implicit def access_CfgNodeBase(node: nodes.CfgNodeBase): Access_CfgNodeBase          = new Access_CfgNodeBase(node)
+  implicit def access_ExpressionBase(node: nodes.ExpressionBase): Access_ExpressionBase = new Access_ExpressionBase(node)
+}
+
+trait AbstractBaseConversions1 {
+  import Accessors._
+  implicit def access_DeclarationBase(node: nodes.DeclarationBase): Access_DeclarationBase = new Access_DeclarationBase(node)
 }

--- a/joernGenerated/src/main/scala/generated/BaseTypes.scala
+++ b/joernGenerated/src/main/scala/generated/BaseTypes.scala
@@ -8,11 +8,25 @@ trait AstNodeBase extends AbstractNode with StaticType[AstNodeT]
 // inherited properties:
 // inherited interfaces:
 // implementing nodes: ANNOTATION, ANNOTATION_LITERAL, ANNOTATION_PARAMETER, ANNOTATION_PARAMETER_ASSIGN, ARRAY_INITIALIZER, BLOCK, CALL, COMMENT, CONTROL_STRUCTURE, FIELD_IDENTIFIER, FILE, IDENTIFIER, IMPORT, JUMP_LABEL, JUMP_TARGET, LITERAL, LOCAL, MEMBER, METHOD, METHOD_PARAMETER_IN, METHOD_PARAMETER_OUT, METHOD_REF, METHOD_RETURN, MODIFIER, NAMESPACE, NAMESPACE_BLOCK, RETURN, TEMPLATE_DOM, TYPE_ARGUMENT, TYPE_DECL, TYPE_PARAMETER, TYPE_REF, UNKNOWN
-trait AstNode extends StoredNode with AstNodeBase with StaticType[AstNodeT] {
-//{accessors}
-}
+trait AstNode extends StoredNode with AstNodeBase with StaticType[AstNodeT]
 
-trait AstNodeNew extends NewNode with AstNodeBase with StaticType[AstNodeT]
+trait AstNodeNew extends NewNode with AstNodeBase with StaticType[AstNodeT] {
+  type RelatedStored <: AstNode
+  def code: String
+  def code_=(value: String): Unit
+  def code(value: String): this.type
+  def columnNumber: Option[Int]
+  def columnNumber_=(value: Option[Int]): Unit
+  def columnNumber(value: Option[Int]): this.type
+  def columnNumber(value: Int): this.type
+  def lineNumber: Option[Int]
+  def lineNumber_=(value: Option[Int]): Unit
+  def lineNumber(value: Option[Int]): this.type
+  def lineNumber(value: Int): this.type
+  def order: Int
+  def order_=(value: Int): Unit
+  def order(value: Int): this.type
+}
 
 trait CallReprT extends AnyRef with CfgNodeT with HasNameT with HasSignatureT
 
@@ -21,11 +35,17 @@ trait CallReprBase extends AbstractNode with CfgNodeBase with StaticType[CallRep
 // inherited properties: CODE, COLUMN_NUMBER, LINE_NUMBER, ORDER
 // inherited interfaces: AST_NODE
 // implementing nodes: CALL
-trait CallRepr extends StoredNode with CallReprBase with CfgNode with StaticType[CallReprT] {
-//{accessors}
-}
+trait CallRepr extends StoredNode with CallReprBase with CfgNode with StaticType[CallReprT]
 
-trait CallReprNew extends NewNode with CallReprBase with CfgNodeNew with StaticType[CallReprT]
+trait CallReprNew extends NewNode with CallReprBase with CfgNodeNew with StaticType[CallReprT] {
+  type RelatedStored <: CallRepr
+  def name: String
+  def name_=(value: String): Unit
+  def name(value: String): this.type
+  def signature: String
+  def signature_=(value: String): Unit
+  def signature(value: String): this.type
+}
 
 trait CfgNodeT extends AnyRef with AstNodeT
 
@@ -34,11 +54,12 @@ trait CfgNodeBase extends AbstractNode with AstNodeBase with StaticType[CfgNodeT
 // inherited properties: CODE, COLUMN_NUMBER, LINE_NUMBER, ORDER
 // inherited interfaces:
 // implementing nodes: ANNOTATION, ANNOTATION_LITERAL, ARRAY_INITIALIZER, BLOCK, CALL, CONTROL_STRUCTURE, FIELD_IDENTIFIER, IDENTIFIER, JUMP_TARGET, LITERAL, METHOD, METHOD_PARAMETER_IN, METHOD_PARAMETER_OUT, METHOD_REF, METHOD_RETURN, RETURN, TEMPLATE_DOM, TYPE_REF, UNKNOWN
-trait CfgNode extends StoredNode with CfgNodeBase with AstNode with StaticType[CfgNodeT] {
-//{accessors}
-}
+trait CfgNode extends StoredNode with CfgNodeBase with AstNode with StaticType[CfgNodeT]
 
-trait CfgNodeNew extends NewNode with CfgNodeBase with AstNodeNew with StaticType[CfgNodeT]
+trait CfgNodeNew extends NewNode with CfgNodeBase with AstNodeNew with StaticType[CfgNodeT] {
+  type RelatedStored <: CfgNode
+
+}
 
 trait DeclarationT extends AnyRef with HasNameT
 
@@ -47,11 +68,14 @@ trait DeclarationBase extends AbstractNode with StaticType[DeclarationT]
 // inherited properties:
 // inherited interfaces:
 // implementing nodes: LOCAL, MEMBER, METHOD, METHOD_PARAMETER_IN, METHOD_PARAMETER_OUT
-trait Declaration extends StoredNode with DeclarationBase with StaticType[DeclarationT] {
-//{accessors}
-}
+trait Declaration extends StoredNode with DeclarationBase with StaticType[DeclarationT]
 
-trait DeclarationNew extends NewNode with DeclarationBase with StaticType[DeclarationT]
+trait DeclarationNew extends NewNode with DeclarationBase with StaticType[DeclarationT] {
+  type RelatedStored <: Declaration
+  def name: String
+  def name_=(value: String): Unit
+  def name(value: String): this.type
+}
 
 trait ExpressionT extends AnyRef with CfgNodeT with HasArgumentIndexT with HasArgumentNameT
 
@@ -60,11 +84,18 @@ trait ExpressionBase extends AbstractNode with CfgNodeBase with StaticType[Expre
 // inherited properties: CODE, COLUMN_NUMBER, LINE_NUMBER, ORDER
 // inherited interfaces: AST_NODE
 // implementing nodes: ANNOTATION, ANNOTATION_LITERAL, ARRAY_INITIALIZER, BLOCK, CALL, CONTROL_STRUCTURE, FIELD_IDENTIFIER, IDENTIFIER, LITERAL, METHOD_REF, RETURN, TEMPLATE_DOM, TYPE_REF, UNKNOWN
-trait Expression extends StoredNode with ExpressionBase with CfgNode with StaticType[ExpressionT] {
-//{accessors}
-}
+trait Expression extends StoredNode with ExpressionBase with CfgNode with StaticType[ExpressionT]
 
-trait ExpressionNew extends NewNode with ExpressionBase with CfgNodeNew with AstNodeNew with StaticType[ExpressionT]
+trait ExpressionNew extends NewNode with ExpressionBase with CfgNodeNew with AstNodeNew with StaticType[ExpressionT] {
+  type RelatedStored <: Expression
+  def argumentIndex: Int
+  def argumentIndex_=(value: Int): Unit
+  def argumentIndex(value: Int): this.type
+  def argumentName: Option[String]
+  def argumentName_=(value: Option[String]): Unit
+  def argumentName(value: Option[String]): this.type
+  def argumentName(value: String): this.type
+}
 
 trait HasAliasTypeFullNameT
 trait HasArgumentIndexT

--- a/joernGenerated/src/main/scala/generated/NodeTypes.scala
+++ b/joernGenerated/src/main/scala/generated/NodeTypes.scala
@@ -1,64 +1,191 @@
 package io.shiftleft.codepropertygraph.generated.v2.nodes
 import io.joern.odb2
+import scala.collection.immutable.{IndexedSeq, ArraySeq}
 
-trait AnnotationT extends AnyRef with ExpressionT with HasFullNameT with HasNameT
+trait AnnotationT    extends AnyRef with ExpressionT with HasFullNameT with HasNameT
+trait AnnotationBase extends AbstractNode with ExpressionBase with StaticType[AnnotationT] {}
 class Annotation(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 0.toShort, seq_4762)
+    with AnnotationBase
     with Expression
-    with StaticType[AnnotationT] {
-//{propAccess}
-
+    with StaticType[AnnotationT] {}
+object NewAnnotation             { def apply(): NewAnnotation = new NewAnnotation }
+class NewAnnotation extends NewNode(0.toShort) with AnnotationBase {
+  type RelatedStored = Annotation
+  override def label: String                         = "ANNOTATION"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var fullName: String                               = "<empty>": String
+  var lineNumber: Option[Int]                        = None
+  var name: String                                   = "<empty>": String
+  var order: Int                                     = -1: Int
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def fullName(value: String): this.type             = { this.fullName = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def name(value: String): this.type                 = { this.name = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
 }
 
-trait AnnotationLiteralT extends AnyRef with ExpressionT with HasNameT
+trait AnnotationLiteralT    extends AnyRef with ExpressionT with HasNameT
+trait AnnotationLiteralBase extends AbstractNode with ExpressionBase with StaticType[AnnotationLiteralT] {}
 class AnnotationLiteral(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 1.toShort, seq_4762)
+    with AnnotationLiteralBase
     with Expression
-    with StaticType[AnnotationLiteralT] {
-//{propAccess}
-
+    with StaticType[AnnotationLiteralT] {}
+object NewAnnotationLiteral             { def apply(): NewAnnotationLiteral = new NewAnnotationLiteral }
+class NewAnnotationLiteral extends NewNode(1.toShort) with AnnotationLiteralBase {
+  type RelatedStored = AnnotationLiteral
+  override def label: String                         = "ANNOTATION_LITERAL"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var lineNumber: Option[Int]                        = None
+  var name: String                                   = "<empty>": String
+  var order: Int                                     = -1: Int
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def name(value: String): this.type                 = { this.name = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
 }
 
-trait AnnotationParameterT extends AnyRef with AstNodeT
+trait AnnotationParameterT    extends AnyRef with AstNodeT
+trait AnnotationParameterBase extends AbstractNode with AstNodeBase with StaticType[AnnotationParameterT] {}
 class AnnotationParameter(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 2.toShort, seq_4762)
+    with AnnotationParameterBase
     with AstNode
-    with StaticType[AnnotationParameterT] {
-//{propAccess}
-
+    with StaticType[AnnotationParameterT] {}
+object NewAnnotationParameter             { def apply(): NewAnnotationParameter = new NewAnnotationParameter }
+class NewAnnotationParameter extends NewNode(2.toShort) with AnnotationParameterBase {
+  type RelatedStored = AnnotationParameter
+  override def label: String                      = "ANNOTATION_PARAMETER"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait AnnotationParameterAssignT extends AnyRef with AstNodeT
+trait AnnotationParameterAssignT    extends AnyRef with AstNodeT
+trait AnnotationParameterAssignBase extends AbstractNode with AstNodeBase with StaticType[AnnotationParameterAssignT] {}
 class AnnotationParameterAssign(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 3.toShort, seq_4762)
+    with AnnotationParameterAssignBase
     with AstNode
-    with StaticType[AnnotationParameterAssignT] {
-//{propAccess}
-
+    with StaticType[AnnotationParameterAssignT] {}
+object NewAnnotationParameterAssign             { def apply(): NewAnnotationParameterAssign = new NewAnnotationParameterAssign }
+class NewAnnotationParameterAssign extends NewNode(3.toShort) with AnnotationParameterAssignBase {
+  type RelatedStored = AnnotationParameterAssign
+  override def label: String                      = "ANNOTATION_PARAMETER_ASSIGN"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait ArrayInitializerT extends AnyRef with ExpressionT
+trait ArrayInitializerT    extends AnyRef with ExpressionT
+trait ArrayInitializerBase extends AbstractNode with ExpressionBase with StaticType[ArrayInitializerT] {}
 class ArrayInitializer(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 4.toShort, seq_4762)
+    with ArrayInitializerBase
     with Expression
-    with StaticType[ArrayInitializerT] {
-//{propAccess}
-
+    with StaticType[ArrayInitializerT] {}
+object NewArrayInitializer             { def apply(): NewArrayInitializer = new NewArrayInitializer }
+class NewArrayInitializer extends NewNode(4.toShort) with ArrayInitializerBase {
+  type RelatedStored = ArrayInitializer
+  override def label: String                         = "ARRAY_INITIALIZER"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var lineNumber: Option[Int]                        = None
+  var order: Int                                     = -1: Int
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
 }
 
-trait BindingT                                       extends AnyRef with HasMethodFullNameT with HasNameT with HasSignatureT
-class Binding(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 5.toShort, seq_4762) with StaticType[BindingT] {
-//{propAccess}
-
+trait BindingT    extends AnyRef with HasMethodFullNameT with HasNameT with HasSignatureT
+trait BindingBase extends AbstractNode with StaticType[BindingT] {}
+class Binding(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 5.toShort, seq_4762)
+    with BindingBase
+    with StaticType[BindingT] {}
+object NewBinding             { def apply(): NewBinding = new NewBinding }
+class NewBinding extends NewNode(5.toShort) with BindingBase {
+  type RelatedStored = Binding
+  override def label: String                   = "BINDING"
+  var methodFullName: String                   = "<empty>": String
+  var name: String                             = "<empty>": String
+  var signature: String                        = "": String
+  def methodFullName(value: String): this.type = { this.methodFullName = value; this }
+  def name(value: String): this.type           = { this.name = value; this }
+  def signature(value: String): this.type      = { this.signature = value; this }
 }
 
-trait BlockT extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait BlockT    extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait BlockBase extends AbstractNode with ExpressionBase with StaticType[BlockT] {}
 class Block(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 6.toShort, seq_4762)
+    with BlockBase
     with Expression
-    with StaticType[BlockT] {
-//{propAccess}
-
+    with StaticType[BlockT] {}
+object NewBlock             { def apply(): NewBlock = new NewBlock }
+class NewBlock extends NewNode(6.toShort) with BlockBase {
+  type RelatedStored = Block
+  override def label: String                                          = "BLOCK"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var lineNumber: Option[Int]                                         = None
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
 trait CallT
@@ -69,82 +196,270 @@ trait CallT
     with HasDynamicTypeHintFullNameT
     with HasMethodFullNameT
     with HasTypeFullNameT
+trait CallBase extends AbstractNode with CallReprBase with ExpressionBase with StaticType[CallT] {}
 class Call(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 7.toShort, seq_4762)
+    with CallBase
     with CallRepr
     with Expression
-    with StaticType[CallT] {
-//{propAccess}
-
+    with StaticType[CallT] {}
+object NewCall             { def apply(): NewCall = new NewCall }
+class NewCall extends NewNode(7.toShort) with CallBase {
+  type RelatedStored = Call
+  override def label: String                                          = "CALL"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var dispatchType: String                                            = "<empty>": String
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var lineNumber: Option[Int]                                         = None
+  var methodFullName: String                                          = "<empty>": String
+  var name: String                                                    = "<empty>": String
+  var order: Int                                                      = -1: Int
+  var signature: String                                               = "": String
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def dispatchType(value: String): this.type                          = { this.dispatchType = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def methodFullName(value: String): this.type                        = { this.methodFullName = value; this }
+  def name(value: String): this.type                                  = { this.name = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def signature(value: String): this.type                             = { this.signature = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
-trait ClosureBindingT extends AnyRef with HasClosureBindingIdT with HasClosureOriginalNameT with HasEvaluationStrategyT
+trait ClosureBindingT    extends AnyRef with HasClosureBindingIdT with HasClosureOriginalNameT with HasEvaluationStrategyT
+trait ClosureBindingBase extends AbstractNode with StaticType[ClosureBindingT] {}
 class ClosureBinding(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 8.toShort, seq_4762)
-    with StaticType[ClosureBindingT] {
-//{propAccess}
-
+    with ClosureBindingBase
+    with StaticType[ClosureBindingT] {}
+object NewClosureBinding             { def apply(): NewClosureBinding = new NewClosureBinding }
+class NewClosureBinding extends NewNode(8.toShort) with ClosureBindingBase {
+  type RelatedStored = ClosureBinding
+  override def label: String                                = "CLOSURE_BINDING"
+  var closureBindingId: Option[String]                      = None
+  var closureOriginalName: Option[String]                   = None
+  var evaluationStrategy: String                            = "<empty>": String
+  def closureBindingId(value: Option[String]): this.type    = { this.closureBindingId = value; this }
+  def closureBindingId(value: String): this.type            = { this.closureBindingId = Option(value); this }
+  def closureOriginalName(value: Option[String]): this.type = { this.closureOriginalName = value; this }
+  def closureOriginalName(value: String): this.type         = { this.closureOriginalName = Option(value); this }
+  def evaluationStrategy(value: String): this.type          = { this.evaluationStrategy = value; this }
 }
 
-trait CommentT extends AnyRef with AstNodeT with HasFilenameT
+trait CommentT    extends AnyRef with AstNodeT with HasFilenameT
+trait CommentBase extends AbstractNode with AstNodeBase with StaticType[CommentT] {}
 class Comment(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 9.toShort, seq_4762)
+    with CommentBase
     with AstNode
-    with StaticType[CommentT] {
-//{propAccess}
-
+    with StaticType[CommentT] {}
+object NewComment             { def apply(): NewComment = new NewComment }
+class NewComment extends NewNode(9.toShort) with CommentBase {
+  type RelatedStored = Comment
+  override def label: String                      = "COMMENT"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var filename: String                            = "<empty>": String
+  var lineNumber: Option[Int]                     = None
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def filename(value: String): this.type          = { this.filename = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait ConfigFileT                                       extends AnyRef with HasContentT with HasNameT
-class ConfigFile(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 10.toShort, seq_4762) with StaticType[ConfigFileT] {
-//{propAccess}
-
+trait ConfigFileT    extends AnyRef with HasContentT with HasNameT
+trait ConfigFileBase extends AbstractNode with StaticType[ConfigFileT] {}
+class ConfigFile(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 10.toShort, seq_4762)
+    with ConfigFileBase
+    with StaticType[ConfigFileT] {}
+object NewConfigFile             { def apply(): NewConfigFile = new NewConfigFile }
+class NewConfigFile extends NewNode(10.toShort) with ConfigFileBase {
+  type RelatedStored = ConfigFile
+  override def label: String            = "CONFIG_FILE"
+  var content: String                   = "<empty>": String
+  var name: String                      = "<empty>": String
+  def content(value: String): this.type = { this.content = value; this }
+  def name(value: String): this.type    = { this.name = value; this }
 }
 
-trait ControlStructureT extends AnyRef with ExpressionT with HasControlStructureTypeT with HasParserTypeNameT
+trait ControlStructureT    extends AnyRef with ExpressionT with HasControlStructureTypeT with HasParserTypeNameT
+trait ControlStructureBase extends AbstractNode with ExpressionBase with StaticType[ControlStructureT] {}
 class ControlStructure(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 11.toShort, seq_4762)
+    with ControlStructureBase
     with Expression
-    with StaticType[ControlStructureT] {
-//{propAccess}
-
+    with StaticType[ControlStructureT] {}
+object NewControlStructure             { def apply(): NewControlStructure = new NewControlStructure }
+class NewControlStructure extends NewNode(11.toShort) with ControlStructureBase {
+  type RelatedStored = ControlStructure
+  override def label: String                         = "CONTROL_STRUCTURE"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var controlStructureType: String                   = "<empty>": String
+  var lineNumber: Option[Int]                        = None
+  var order: Int                                     = -1: Int
+  var parserTypeName: String                         = "<empty>": String
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def controlStructureType(value: String): this.type = { this.controlStructureType = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
+  def parserTypeName(value: String): this.type       = { this.parserTypeName = value; this }
 }
 
-trait DependencyT                                       extends AnyRef with HasDependencyGroupIdT with HasNameT with HasVersionT
-class Dependency(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 12.toShort, seq_4762) with StaticType[DependencyT] {
-//{propAccess}
-
+trait DependencyT    extends AnyRef with HasDependencyGroupIdT with HasNameT with HasVersionT
+trait DependencyBase extends AbstractNode with StaticType[DependencyT] {}
+class Dependency(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 12.toShort, seq_4762)
+    with DependencyBase
+    with StaticType[DependencyT] {}
+object NewDependency             { def apply(): NewDependency = new NewDependency }
+class NewDependency extends NewNode(12.toShort) with DependencyBase {
+  type RelatedStored = Dependency
+  override def label: String                              = "DEPENDENCY"
+  var dependencyGroupId: Option[String]                   = None
+  var name: String                                        = "<empty>": String
+  var version: String                                     = "<empty>": String
+  def dependencyGroupId(value: Option[String]): this.type = { this.dependencyGroupId = value; this }
+  def dependencyGroupId(value: String): this.type         = { this.dependencyGroupId = Option(value); this }
+  def name(value: String): this.type                      = { this.name = value; this }
+  def version(value: String): this.type                   = { this.version = value; this }
 }
 
-trait FieldIdentifierT extends AnyRef with ExpressionT with HasCanonicalNameT
+trait FieldIdentifierT    extends AnyRef with ExpressionT with HasCanonicalNameT
+trait FieldIdentifierBase extends AbstractNode with ExpressionBase with StaticType[FieldIdentifierT] {}
 class FieldIdentifier(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 13.toShort, seq_4762)
+    with FieldIdentifierBase
     with Expression
-    with StaticType[FieldIdentifierT] {
-//{propAccess}
-
+    with StaticType[FieldIdentifierT] {}
+object NewFieldIdentifier             { def apply(): NewFieldIdentifier = new NewFieldIdentifier }
+class NewFieldIdentifier extends NewNode(13.toShort) with FieldIdentifierBase {
+  type RelatedStored = FieldIdentifier
+  override def label: String                         = "FIELD_IDENTIFIER"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var canonicalName: String                          = "<empty>": String
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var lineNumber: Option[Int]                        = None
+  var order: Int                                     = -1: Int
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def canonicalName(value: String): this.type        = { this.canonicalName = value; this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
 }
 
-trait FileT                                       extends AnyRef with AstNodeT with HasHashT with HasNameT
-class File(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 14.toShort, seq_4762) with AstNode with StaticType[FileT] {
-//{propAccess}
-
+trait FileT    extends AnyRef with AstNodeT with HasHashT with HasNameT
+trait FileBase extends AbstractNode with AstNodeBase with StaticType[FileT] {}
+class File(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 14.toShort, seq_4762)
+    with FileBase
+    with AstNode
+    with StaticType[FileT] {}
+object NewFile             { def apply(): NewFile = new NewFile }
+class NewFile extends NewNode(14.toShort) with FileBase {
+  type RelatedStored = File
+  override def label: String                      = "FILE"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var hash: Option[String]                        = None
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def hash(value: Option[String]): this.type      = { this.hash = value; this }
+  def hash(value: String): this.type              = { this.hash = Option(value); this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait FindingT                                       extends AnyRef
-class Finding(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 15.toShort, seq_4762) with StaticType[FindingT] {
-//{propAccess}
+trait FindingT extends AnyRef
+trait FindingBase extends AbstractNode with StaticType[FindingT] {
+  def evidence: IndexedSeq[AbstractNode]
+  def keyValuePairs: IndexedSeq[KeyValuePairBase]
+}
+class Finding(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 15.toShort, seq_4762)
+    with FindingBase
+    with StaticType[FindingT] {
   def evidence: IndexedSeq[StoredNode]        = odb2.Accessors.getNodePropertyMulti[StoredNode](graph, nodeKind, 52, seq)
   def keyValuePairs: IndexedSeq[KeyValuePair] = odb2.Accessors.getNodePropertyMulti[KeyValuePair](graph, nodeKind, 53, seq)
 }
+object NewFinding { def apply(): NewFinding = new NewFinding }
+class NewFinding extends NewNode(15.toShort) with FindingBase {
+  type RelatedStored = Finding
+  override def label: String                                          = "FINDING"
+  var evidence: IndexedSeq[AbstractNode]                              = ArraySeq.empty
+  var keyValuePairs: IndexedSeq[KeyValuePairBase]                     = ArraySeq.empty
+  def evidence(value: IterableOnce[AbstractNode]): this.type          = { this.evidence = value.iterator.to(ArraySeq); this }
+  def keyValuePairs(value: IterableOnce[KeyValuePairBase]): this.type = { this.keyValuePairs = value.iterator.to(ArraySeq); this }
+}
 
-trait IdentifierT extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasNameT with HasTypeFullNameT
+trait IdentifierT    extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasNameT with HasTypeFullNameT
+trait IdentifierBase extends AbstractNode with ExpressionBase with StaticType[IdentifierT] {}
 class Identifier(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 16.toShort, seq_4762)
+    with IdentifierBase
     with Expression
-    with StaticType[IdentifierT] {
-//{propAccess}
-
+    with StaticType[IdentifierT] {}
+object NewIdentifier             { def apply(): NewIdentifier = new NewIdentifier }
+class NewIdentifier extends NewNode(16.toShort) with IdentifierBase {
+  type RelatedStored = Identifier
+  override def label: String                                          = "IDENTIFIER"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var lineNumber: Option[Int]                                         = None
+  var name: String                                                    = "<empty>": String
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def name(value: String): this.type                                  = { this.name = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
 trait ImportT
@@ -155,57 +470,178 @@ trait ImportT
     with HasImportedEntityT
     with HasIsExplicitT
     with HasIsWildcardT
+trait ImportBase extends AbstractNode with AstNodeBase with StaticType[ImportT] {}
 class Import(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 17.toShort, seq_4762)
+    with ImportBase
     with AstNode
-    with StaticType[ImportT] {
-//{propAccess}
-
+    with StaticType[ImportT] {}
+object NewImport             { def apply(): NewImport = new NewImport }
+class NewImport extends NewNode(17.toShort) with ImportBase {
+  type RelatedStored = Import
+  override def label: String                           = "IMPORT"
+  var code: String                                     = "<empty>": String
+  var columnNumber: Option[Int]                        = None
+  var explicitAs: Option[Boolean]                      = None
+  var importedAs: Option[String]                       = None
+  var importedEntity: Option[String]                   = None
+  var isExplicit: Option[Boolean]                      = None
+  var isWildcard: Option[Boolean]                      = None
+  var lineNumber: Option[Int]                          = None
+  var order: Int                                       = -1: Int
+  def code(value: String): this.type                   = { this.code = value; this }
+  def columnNumber(value: Int): this.type              = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type      = { this.columnNumber = value; this }
+  def explicitAs(value: Boolean): this.type            = { this.explicitAs = Option(value); this }
+  def explicitAs(value: Option[Boolean]): this.type    = { this.explicitAs = value; this }
+  def importedAs(value: Option[String]): this.type     = { this.importedAs = value; this }
+  def importedAs(value: String): this.type             = { this.importedAs = Option(value); this }
+  def importedEntity(value: Option[String]): this.type = { this.importedEntity = value; this }
+  def importedEntity(value: String): this.type         = { this.importedEntity = Option(value); this }
+  def isExplicit(value: Boolean): this.type            = { this.isExplicit = Option(value); this }
+  def isExplicit(value: Option[Boolean]): this.type    = { this.isExplicit = value; this }
+  def isWildcard(value: Boolean): this.type            = { this.isWildcard = Option(value); this }
+  def isWildcard(value: Option[Boolean]): this.type    = { this.isWildcard = value; this }
+  def lineNumber(value: Int): this.type                = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type        = { this.lineNumber = value; this }
+  def order(value: Int): this.type                     = { this.order = value; this }
 }
 
-trait JumpLabelT extends AnyRef with AstNodeT with HasNameT with HasParserTypeNameT
+trait JumpLabelT    extends AnyRef with AstNodeT with HasNameT with HasParserTypeNameT
+trait JumpLabelBase extends AbstractNode with AstNodeBase with StaticType[JumpLabelT] {}
 class JumpLabel(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 18.toShort, seq_4762)
+    with JumpLabelBase
     with AstNode
-    with StaticType[JumpLabelT] {
-//{propAccess}
-
+    with StaticType[JumpLabelT] {}
+object NewJumpLabel             { def apply(): NewJumpLabel = new NewJumpLabel }
+class NewJumpLabel extends NewNode(18.toShort) with JumpLabelBase {
+  type RelatedStored = JumpLabel
+  override def label: String                      = "JUMP_LABEL"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  var parserTypeName: String                      = "<empty>": String
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
+  def parserTypeName(value: String): this.type    = { this.parserTypeName = value; this }
 }
 
-trait JumpTargetT extends AnyRef with CfgNodeT with HasArgumentIndexT with HasNameT with HasParserTypeNameT
+trait JumpTargetT    extends AnyRef with CfgNodeT with HasArgumentIndexT with HasNameT with HasParserTypeNameT
+trait JumpTargetBase extends AbstractNode with CfgNodeBase with StaticType[JumpTargetT] {}
 class JumpTarget(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 19.toShort, seq_4762)
+    with JumpTargetBase
     with CfgNode
-    with StaticType[JumpTargetT] {
-//{propAccess}
-
+    with StaticType[JumpTargetT] {}
+object NewJumpTarget             { def apply(): NewJumpTarget = new NewJumpTarget }
+class NewJumpTarget extends NewNode(19.toShort) with JumpTargetBase {
+  type RelatedStored = JumpTarget
+  override def label: String                      = "JUMP_TARGET"
+  var argumentIndex: Int                          = -1: Int
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  var parserTypeName: String                      = "<empty>": String
+  def argumentIndex(value: Int): this.type        = { this.argumentIndex = value; this }
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
+  def parserTypeName(value: String): this.type    = { this.parserTypeName = value; this }
 }
 
-trait KeyValuePairT extends AnyRef with HasKeyT with HasValueT
+trait KeyValuePairT    extends AnyRef with HasKeyT with HasValueT
+trait KeyValuePairBase extends AbstractNode with StaticType[KeyValuePairT] {}
 class KeyValuePair(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 20.toShort, seq_4762)
-    with StaticType[KeyValuePairT] {
-//{propAccess}
-
+    with KeyValuePairBase
+    with StaticType[KeyValuePairT] {}
+object NewKeyValuePair             { def apply(): NewKeyValuePair = new NewKeyValuePair }
+class NewKeyValuePair extends NewNode(20.toShort) with KeyValuePairBase {
+  type RelatedStored = KeyValuePair
+  override def label: String          = "KEY_VALUE_PAIR"
+  var key: String                     = "<empty>": String
+  var value: String                   = "": String
+  def key(value: String): this.type   = { this.key = value; this }
+  def value(value: String): this.type = { this.value = value; this }
 }
 
-trait LiteralT extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait LiteralT    extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait LiteralBase extends AbstractNode with ExpressionBase with StaticType[LiteralT] {}
 class Literal(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 21.toShort, seq_4762)
+    with LiteralBase
     with Expression
-    with StaticType[LiteralT] {
-//{propAccess}
-
+    with StaticType[LiteralT] {}
+object NewLiteral             { def apply(): NewLiteral = new NewLiteral }
+class NewLiteral extends NewNode(21.toShort) with LiteralBase {
+  type RelatedStored = Literal
+  override def label: String                                          = "LITERAL"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var lineNumber: Option[Int]                                         = None
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
 trait LocalT extends AnyRef with AstNodeT with DeclarationT with HasClosureBindingIdT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait LocalBase extends AbstractNode with AstNodeBase with DeclarationBase with StaticType[LocalT] {}
 class Local(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 22.toShort, seq_4762)
+    with LocalBase
     with AstNode
     with Declaration
-    with StaticType[LocalT] {
-//{propAccess}
-
+    with StaticType[LocalT] {}
+object NewLocal             { def apply(): NewLocal = new NewLocal }
+class NewLocal extends NewNode(22.toShort) with LocalBase {
+  type RelatedStored = Local
+  override def label: String                                          = "LOCAL"
+  var closureBindingId: Option[String]                                = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var lineNumber: Option[Int]                                         = None
+  var name: String                                                    = "<empty>": String
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def closureBindingId(value: Option[String]): this.type              = { this.closureBindingId = value; this }
+  def closureBindingId(value: String): this.type                      = { this.closureBindingId = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def name(value: String): this.type                                  = { this.name = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
 trait LocationT
@@ -219,25 +655,94 @@ trait LocationT
     with HasNodeLabelT
     with HasPackageNameT
     with HasSymbolT
-class Location(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 23.toShort, seq_4762) with StaticType[LocationT] {
-//{propAccess}
+trait LocationBase extends AbstractNode with StaticType[LocationT] {
+  def node: Option[AbstractNode]
+}
+class Location(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 23.toShort, seq_4762)
+    with LocationBase
+    with StaticType[LocationT] {
   def node: Option[StoredNode] = odb2.Accessors.getNodePropertyOption[StoredNode](graph, nodeKind, 52, seq)
 }
-
-trait MemberT extends AnyRef with AstNodeT with DeclarationT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
-class Member(graph_4762: odb2.Graph, seq_4762: Int)
-    extends StoredNode(graph_4762, 24.toShort, seq_4762)
-    with AstNode
-    with Declaration
-    with StaticType[MemberT] {
-//{propAccess}
-
+object NewLocation { def apply(): NewLocation = new NewLocation }
+class NewLocation extends NewNode(23.toShort) with LocationBase {
+  type RelatedStored = Location
+  override def label: String                       = "LOCATION"
+  var className: String                            = "<empty>": String
+  var classShortName: String                       = "<empty>": String
+  var filename: String                             = "<empty>": String
+  var lineNumber: Option[Int]                      = None
+  var methodFullName: String                       = "<empty>": String
+  var methodShortName: String                      = "<empty>": String
+  var node: Option[AbstractNode]                   = None
+  var nodeLabel: String                            = "<empty>": String
+  var packageName: String                          = "<empty>": String
+  var symbol: String                               = "<empty>": String
+  def className(value: String): this.type          = { this.className = value; this }
+  def classShortName(value: String): this.type     = { this.classShortName = value; this }
+  def filename(value: String): this.type           = { this.filename = value; this }
+  def lineNumber(value: Int): this.type            = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type    = { this.lineNumber = value; this }
+  def methodFullName(value: String): this.type     = { this.methodFullName = value; this }
+  def methodShortName(value: String): this.type    = { this.methodShortName = value; this }
+  def node(value: AbstractNode): this.type         = { this.node = Option(value); this }
+  def node(value: Option[AbstractNode]): this.type = { this.node = value; this }
+  def nodeLabel(value: String): this.type          = { this.nodeLabel = value; this }
+  def packageName(value: String): this.type        = { this.packageName = value; this }
+  def symbol(value: String): this.type             = { this.symbol = value; this }
 }
 
-trait MetaDataT extends AnyRef with HasHashT with HasLanguageT with HasOverlaysT with HasRootT with HasVersionT
-class MetaData(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 25.toShort, seq_4762) with StaticType[MetaDataT] {
-//{propAccess}
+trait MemberT    extends AnyRef with AstNodeT with DeclarationT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait MemberBase extends AbstractNode with AstNodeBase with DeclarationBase with StaticType[MemberT] {}
+class Member(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 24.toShort, seq_4762)
+    with MemberBase
+    with AstNode
+    with Declaration
+    with StaticType[MemberT] {}
+object NewMember             { def apply(): NewMember = new NewMember }
+class NewMember extends NewNode(24.toShort) with MemberBase {
+  type RelatedStored = Member
+  override def label: String                                          = "MEMBER"
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var lineNumber: Option[Int]                                         = None
+  var name: String                                                    = "<empty>": String
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def name(value: String): this.type                                  = { this.name = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
+}
 
+trait MetaDataT    extends AnyRef with HasHashT with HasLanguageT with HasOverlaysT with HasRootT with HasVersionT
+trait MetaDataBase extends AbstractNode with StaticType[MetaDataT] {}
+class MetaData(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 25.toShort, seq_4762)
+    with MetaDataBase
+    with StaticType[MetaDataT] {}
+object NewMetaData             { def apply(): NewMetaData = new NewMetaData }
+class NewMetaData extends NewNode(25.toShort) with MetaDataBase {
+  type RelatedStored = MetaData
+  override def label: String                           = "META_DATA"
+  var hash: Option[String]                             = None
+  var language: String                                 = "<empty>": String
+  var overlays: IndexedSeq[String]                     = ArraySeq.empty
+  var root: String                                     = "<empty>": String
+  var version: String                                  = "<empty>": String
+  def hash(value: Option[String]): this.type           = { this.hash = value; this }
+  def hash(value: String): this.type                   = { this.hash = Option(value); this }
+  def language(value: String): this.type               = { this.language = value; this }
+  def overlays(value: IterableOnce[String]): this.type = { this.overlays = value.iterator.to(ArraySeq); this }
+  def root(value: String): this.type                   = { this.root = value; this }
+  def version(value: String): this.type                = { this.version = value; this }
 }
 
 trait MethodT
@@ -253,13 +758,50 @@ trait MethodT
     with HasIsExternalT
     with HasLineNumberEndT
     with HasSignatureT
+trait MethodBase extends AbstractNode with CfgNodeBase with DeclarationBase with StaticType[MethodT] {}
 class Method(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 26.toShort, seq_4762)
+    with MethodBase
     with CfgNode
     with Declaration
-    with StaticType[MethodT] {
-//{propAccess}
-
+    with StaticType[MethodT] {}
+object NewMethod             { def apply(): NewMethod = new NewMethod }
+class NewMethod extends NewNode(26.toShort) with MethodBase {
+  type RelatedStored = Method
+  override def label: String                         = "METHOD"
+  var astParentFullName: String                      = "<empty>": String
+  var astParentType: String                          = "<empty>": String
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var columnNumberEnd: Option[Int]                   = None
+  var filename: String                               = "<empty>": String
+  var fullName: String                               = "<empty>": String
+  var hash: Option[String]                           = None
+  var isExternal: Boolean                            = false: Boolean
+  var lineNumber: Option[Int]                        = None
+  var lineNumberEnd: Option[Int]                     = None
+  var name: String                                   = "<empty>": String
+  var order: Int                                     = -1: Int
+  var signature: String                              = "": String
+  def astParentFullName(value: String): this.type    = { this.astParentFullName = value; this }
+  def astParentType(value: String): this.type        = { this.astParentType = value; this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def columnNumberEnd(value: Int): this.type         = { this.columnNumberEnd = Option(value); this }
+  def columnNumberEnd(value: Option[Int]): this.type = { this.columnNumberEnd = value; this }
+  def filename(value: String): this.type             = { this.filename = value; this }
+  def fullName(value: String): this.type             = { this.fullName = value; this }
+  def hash(value: Option[String]): this.type         = { this.hash = value; this }
+  def hash(value: String): this.type                 = { this.hash = Option(value); this }
+  def isExternal(value: Boolean): this.type          = { this.isExternal = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def lineNumberEnd(value: Int): this.type           = { this.lineNumberEnd = Option(value); this }
+  def lineNumberEnd(value: Option[Int]): this.type   = { this.lineNumberEnd = value; this }
+  def name(value: String): this.type                 = { this.name = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
+  def signature(value: String): this.type            = { this.signature = value; this }
 }
 
 trait MethodParameterInT
@@ -271,13 +813,39 @@ trait MethodParameterInT
     with HasIndexT
     with HasIsVariadicT
     with HasTypeFullNameT
+trait MethodParameterInBase extends AbstractNode with CfgNodeBase with DeclarationBase with StaticType[MethodParameterInT] {}
 class MethodParameterIn(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 27.toShort, seq_4762)
+    with MethodParameterInBase
     with CfgNode
     with Declaration
-    with StaticType[MethodParameterInT] {
-//{propAccess}
-
+    with StaticType[MethodParameterInT] {}
+object NewMethodParameterIn             { def apply(): NewMethodParameterIn = new NewMethodParameterIn }
+class NewMethodParameterIn extends NewNode(27.toShort) with MethodParameterInBase {
+  type RelatedStored = MethodParameterIn
+  override def label: String                                          = "METHOD_PARAMETER_IN"
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var evaluationStrategy: String                                      = "<empty>": String
+  var index: Int                                                      = -1: Int
+  var isVariadic: Boolean                                             = false: Boolean
+  var lineNumber: Option[Int]                                         = None
+  var name: String                                                    = "<empty>": String
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def evaluationStrategy(value: String): this.type                    = { this.evaluationStrategy = value; this }
+  def index(value: Int): this.type                                    = { this.index = value; this }
+  def isVariadic(value: Boolean): this.type                           = { this.isVariadic = value; this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def name(value: String): this.type                                  = { this.name = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
 trait MethodParameterOutT
@@ -288,106 +856,313 @@ trait MethodParameterOutT
     with HasIndexT
     with HasIsVariadicT
     with HasTypeFullNameT
+trait MethodParameterOutBase extends AbstractNode with CfgNodeBase with DeclarationBase with StaticType[MethodParameterOutT] {}
 class MethodParameterOut(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 28.toShort, seq_4762)
+    with MethodParameterOutBase
     with CfgNode
     with Declaration
-    with StaticType[MethodParameterOutT] {
-//{propAccess}
-
+    with StaticType[MethodParameterOutT] {}
+object NewMethodParameterOut             { def apply(): NewMethodParameterOut = new NewMethodParameterOut }
+class NewMethodParameterOut extends NewNode(28.toShort) with MethodParameterOutBase {
+  type RelatedStored = MethodParameterOut
+  override def label: String                       = "METHOD_PARAMETER_OUT"
+  var code: String                                 = "<empty>": String
+  var columnNumber: Option[Int]                    = None
+  var evaluationStrategy: String                   = "<empty>": String
+  var index: Int                                   = -1: Int
+  var isVariadic: Boolean                          = false: Boolean
+  var lineNumber: Option[Int]                      = None
+  var name: String                                 = "<empty>": String
+  var order: Int                                   = -1: Int
+  var typeFullName: String                         = "<empty>": String
+  def code(value: String): this.type               = { this.code = value; this }
+  def columnNumber(value: Int): this.type          = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type  = { this.columnNumber = value; this }
+  def evaluationStrategy(value: String): this.type = { this.evaluationStrategy = value; this }
+  def index(value: Int): this.type                 = { this.index = value; this }
+  def isVariadic(value: Boolean): this.type        = { this.isVariadic = value; this }
+  def lineNumber(value: Int): this.type            = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type    = { this.lineNumber = value; this }
+  def name(value: String): this.type               = { this.name = value; this }
+  def order(value: Int): this.type                 = { this.order = value; this }
+  def typeFullName(value: String): this.type       = { this.typeFullName = value; this }
 }
 
-trait MethodRefT extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasMethodFullNameT with HasTypeFullNameT
+trait MethodRefT    extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasMethodFullNameT with HasTypeFullNameT
+trait MethodRefBase extends AbstractNode with ExpressionBase with StaticType[MethodRefT] {}
 class MethodRef(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 29.toShort, seq_4762)
+    with MethodRefBase
     with Expression
-    with StaticType[MethodRefT] {
-//{propAccess}
-
+    with StaticType[MethodRefT] {}
+object NewMethodRef             { def apply(): NewMethodRef = new NewMethodRef }
+class NewMethodRef extends NewNode(29.toShort) with MethodRefBase {
+  type RelatedStored = MethodRef
+  override def label: String                                          = "METHOD_REF"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var lineNumber: Option[Int]                                         = None
+  var methodFullName: String                                          = "<empty>": String
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def methodFullName(value: String): this.type                        = { this.methodFullName = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
-trait MethodReturnT extends AnyRef with CfgNodeT with HasDynamicTypeHintFullNameT with HasEvaluationStrategyT with HasTypeFullNameT
+trait MethodReturnT    extends AnyRef with CfgNodeT with HasDynamicTypeHintFullNameT with HasEvaluationStrategyT with HasTypeFullNameT
+trait MethodReturnBase extends AbstractNode with CfgNodeBase with StaticType[MethodReturnT] {}
 class MethodReturn(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 30.toShort, seq_4762)
+    with MethodReturnBase
     with CfgNode
-    with StaticType[MethodReturnT] {
-//{propAccess}
-
+    with StaticType[MethodReturnT] {}
+object NewMethodReturn             { def apply(): NewMethodReturn = new NewMethodReturn }
+class NewMethodReturn extends NewNode(30.toShort) with MethodReturnBase {
+  type RelatedStored = MethodReturn
+  override def label: String                                          = "METHOD_RETURN"
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var evaluationStrategy: String                                      = "<empty>": String
+  var lineNumber: Option[Int]                                         = None
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def evaluationStrategy(value: String): this.type                    = { this.evaluationStrategy = value; this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
-trait ModifierT extends AnyRef with AstNodeT with HasModifierTypeT
+trait ModifierT    extends AnyRef with AstNodeT with HasModifierTypeT
+trait ModifierBase extends AbstractNode with AstNodeBase with StaticType[ModifierT] {}
 class Modifier(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 31.toShort, seq_4762)
+    with ModifierBase
     with AstNode
-    with StaticType[ModifierT] {
-//{propAccess}
-
+    with StaticType[ModifierT] {}
+object NewModifier             { def apply(): NewModifier = new NewModifier }
+class NewModifier extends NewNode(31.toShort) with ModifierBase {
+  type RelatedStored = Modifier
+  override def label: String                      = "MODIFIER"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var modifierType: String                        = "<empty>": String
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def modifierType(value: String): this.type      = { this.modifierType = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait NamespaceT extends AnyRef with AstNodeT with HasNameT
+trait NamespaceT    extends AnyRef with AstNodeT with HasNameT
+trait NamespaceBase extends AbstractNode with AstNodeBase with StaticType[NamespaceT] {}
 class Namespace(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 32.toShort, seq_4762)
+    with NamespaceBase
     with AstNode
-    with StaticType[NamespaceT] {
-//{propAccess}
-
+    with StaticType[NamespaceT] {}
+object NewNamespace             { def apply(): NewNamespace = new NewNamespace }
+class NewNamespace extends NewNode(32.toShort) with NamespaceBase {
+  type RelatedStored = Namespace
+  override def label: String                      = "NAMESPACE"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait NamespaceBlockT extends AnyRef with AstNodeT with HasFilenameT with HasFullNameT with HasNameT
+trait NamespaceBlockT    extends AnyRef with AstNodeT with HasFilenameT with HasFullNameT with HasNameT
+trait NamespaceBlockBase extends AbstractNode with AstNodeBase with StaticType[NamespaceBlockT] {}
 class NamespaceBlock(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 33.toShort, seq_4762)
+    with NamespaceBlockBase
     with AstNode
-    with StaticType[NamespaceBlockT] {
-//{propAccess}
-
+    with StaticType[NamespaceBlockT] {}
+object NewNamespaceBlock             { def apply(): NewNamespaceBlock = new NewNamespaceBlock }
+class NewNamespaceBlock extends NewNode(33.toShort) with NamespaceBlockBase {
+  type RelatedStored = NamespaceBlock
+  override def label: String                      = "NAMESPACE_BLOCK"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var filename: String                            = "<empty>": String
+  var fullName: String                            = "<empty>": String
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def filename(value: String): this.type          = { this.filename = value; this }
+  def fullName(value: String): this.type          = { this.fullName = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait ReturnT extends AnyRef with ExpressionT
+trait ReturnT    extends AnyRef with ExpressionT
+trait ReturnBase extends AbstractNode with ExpressionBase with StaticType[ReturnT] {}
 class Return(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 34.toShort, seq_4762)
+    with ReturnBase
     with Expression
-    with StaticType[ReturnT] {
-//{propAccess}
-
+    with StaticType[ReturnT] {}
+object NewReturn             { def apply(): NewReturn = new NewReturn }
+class NewReturn extends NewNode(34.toShort) with ReturnBase {
+  type RelatedStored = Return
+  override def label: String                         = "RETURN"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var lineNumber: Option[Int]                        = None
+  var order: Int                                     = -1: Int
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
 }
 
 trait TagT                                       extends AnyRef with HasNameT with HasValueT
-class Tag(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 35.toShort, seq_4762) with StaticType[TagT] {
-//{propAccess}
-
+trait TagBase                                    extends AbstractNode with StaticType[TagT]                                              {}
+class Tag(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 35.toShort, seq_4762) with TagBase with StaticType[TagT] {}
+object NewTag { def apply(): NewTag = new NewTag }
+class NewTag extends NewNode(35.toShort) with TagBase {
+  type RelatedStored = Tag
+  override def label: String          = "TAG"
+  var name: String                    = "<empty>": String
+  var value: String                   = "": String
+  def name(value: String): this.type  = { this.name = value; this }
+  def value(value: String): this.type = { this.value = value; this }
 }
 
 trait TagNodePairT extends AnyRef
+trait TagNodePairBase extends AbstractNode with StaticType[TagNodePairT] {
+  def node: AbstractNode
+  def tag: TagBase
+}
 class TagNodePair(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 36.toShort, seq_4762)
+    with TagNodePairBase
     with StaticType[TagNodePairT] {
-//{propAccess}
   def node: StoredNode = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 52, seq, null: StoredNode)
   def tag: Tag         = odb2.Accessors.getNodePropertySingle(graph, nodeKind, 53, seq, null: Tag)
 }
+object NewTagNodePair { def apply(): NewTagNodePair = new NewTagNodePair }
+class NewTagNodePair extends NewNode(36.toShort) with TagNodePairBase {
+  type RelatedStored = TagNodePair
+  override def label: String               = "TAG_NODE_PAIR"
+  var node: AbstractNode                   = null
+  var tag: TagBase                         = null
+  def node(value: AbstractNode): this.type = { this.node = value; this }
+  def tag(value: TagBase): this.type       = { this.tag = value; this }
+}
 
-trait TemplateDomT extends AnyRef with ExpressionT with HasNameT
+trait TemplateDomT    extends AnyRef with ExpressionT with HasNameT
+trait TemplateDomBase extends AbstractNode with ExpressionBase with StaticType[TemplateDomT] {}
 class TemplateDom(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 37.toShort, seq_4762)
+    with TemplateDomBase
     with Expression
-    with StaticType[TemplateDomT] {
-//{propAccess}
-
+    with StaticType[TemplateDomT] {}
+object NewTemplateDom             { def apply(): NewTemplateDom = new NewTemplateDom }
+class NewTemplateDom extends NewNode(37.toShort) with TemplateDomBase {
+  type RelatedStored = TemplateDom
+  override def label: String                         = "TEMPLATE_DOM"
+  var argumentIndex: Int                             = -1: Int
+  var argumentName: Option[String]                   = None
+  var code: String                                   = "<empty>": String
+  var columnNumber: Option[Int]                      = None
+  var lineNumber: Option[Int]                        = None
+  var name: String                                   = "<empty>": String
+  var order: Int                                     = -1: Int
+  def argumentIndex(value: Int): this.type           = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type = { this.argumentName = value; this }
+  def argumentName(value: String): this.type         = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                 = { this.code = value; this }
+  def columnNumber(value: Int): this.type            = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type    = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type              = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type      = { this.lineNumber = value; this }
+  def name(value: String): this.type                 = { this.name = value; this }
+  def order(value: Int): this.type                   = { this.order = value; this }
 }
 
-trait TypeT                                       extends AnyRef with HasFullNameT with HasNameT with HasTypeDeclFullNameT
-class Type(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, 38.toShort, seq_4762) with StaticType[TypeT] {
-//{propAccess}
-
+trait TypeT    extends AnyRef with HasFullNameT with HasNameT with HasTypeDeclFullNameT
+trait TypeBase extends AbstractNode with StaticType[TypeT] {}
+class Type(graph_4762: odb2.Graph, seq_4762: Int)
+    extends StoredNode(graph_4762, 38.toShort, seq_4762)
+    with TypeBase
+    with StaticType[TypeT] {}
+object NewType             { def apply(): NewType = new NewType }
+class NewType extends NewNode(38.toShort) with TypeBase {
+  type RelatedStored = Type
+  override def label: String                     = "TYPE"
+  var fullName: String                           = "<empty>": String
+  var name: String                               = "<empty>": String
+  var typeDeclFullName: String                   = "<empty>": String
+  def fullName(value: String): this.type         = { this.fullName = value; this }
+  def name(value: String): this.type             = { this.name = value; this }
+  def typeDeclFullName(value: String): this.type = { this.typeDeclFullName = value; this }
 }
 
-trait TypeArgumentT extends AnyRef with AstNodeT
+trait TypeArgumentT    extends AnyRef with AstNodeT
+trait TypeArgumentBase extends AbstractNode with AstNodeBase with StaticType[TypeArgumentT] {}
 class TypeArgument(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 39.toShort, seq_4762)
+    with TypeArgumentBase
     with AstNode
-    with StaticType[TypeArgumentT] {
-//{propAccess}
-
+    with StaticType[TypeArgumentT] {}
+object NewTypeArgument             { def apply(): NewTypeArgument = new NewTypeArgument }
+class NewTypeArgument extends NewNode(39.toShort) with TypeArgumentBase {
+  type RelatedStored = TypeArgument
+  override def label: String                      = "TYPE_ARGUMENT"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
 trait TypeDeclT
@@ -401,30 +1176,102 @@ trait TypeDeclT
     with HasInheritsFromTypeFullNameT
     with HasIsExternalT
     with HasNameT
+trait TypeDeclBase extends AbstractNode with AstNodeBase with StaticType[TypeDeclT] {}
 class TypeDecl(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 40.toShort, seq_4762)
+    with TypeDeclBase
     with AstNode
-    with StaticType[TypeDeclT] {
-//{propAccess}
-
+    with StaticType[TypeDeclT] {}
+object NewTypeDecl             { def apply(): NewTypeDecl = new NewTypeDecl }
+class NewTypeDecl extends NewNode(40.toShort) with TypeDeclBase {
+  type RelatedStored = TypeDecl
+  override def label: String                              = "TYPE_DECL"
+  var aliasTypeFullName: Option[String]                   = None
+  var astParentFullName: String                           = "<empty>": String
+  var astParentType: String                               = "<empty>": String
+  var code: String                                        = "<empty>": String
+  var columnNumber: Option[Int]                           = None
+  var filename: String                                    = "<empty>": String
+  var fullName: String                                    = "<empty>": String
+  var inheritsFromTypeFullName: IndexedSeq[String]        = ArraySeq.empty
+  var isExternal: Boolean                                 = false: Boolean
+  var lineNumber: Option[Int]                             = None
+  var name: String                                        = "<empty>": String
+  var order: Int                                          = -1: Int
+  def aliasTypeFullName(value: Option[String]): this.type = { this.aliasTypeFullName = value; this }
+  def aliasTypeFullName(value: String): this.type         = { this.aliasTypeFullName = Option(value); this }
+  def astParentFullName(value: String): this.type         = { this.astParentFullName = value; this }
+  def astParentType(value: String): this.type             = { this.astParentType = value; this }
+  def code(value: String): this.type                      = { this.code = value; this }
+  def columnNumber(value: Int): this.type                 = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type         = { this.columnNumber = value; this }
+  def filename(value: String): this.type                  = { this.filename = value; this }
+  def fullName(value: String): this.type                  = { this.fullName = value; this }
+  def inheritsFromTypeFullName(value: IterableOnce[String]): this.type = {
+    this.inheritsFromTypeFullName = value.iterator.to(ArraySeq); this
+  }
+  def isExternal(value: Boolean): this.type     = { this.isExternal = value; this }
+  def lineNumber(value: Int): this.type         = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type = { this.lineNumber = value; this }
+  def name(value: String): this.type            = { this.name = value; this }
+  def order(value: Int): this.type              = { this.order = value; this }
 }
 
-trait TypeParameterT extends AnyRef with AstNodeT with HasNameT
+trait TypeParameterT    extends AnyRef with AstNodeT with HasNameT
+trait TypeParameterBase extends AbstractNode with AstNodeBase with StaticType[TypeParameterT] {}
 class TypeParameter(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 41.toShort, seq_4762)
+    with TypeParameterBase
     with AstNode
-    with StaticType[TypeParameterT] {
-//{propAccess}
-
+    with StaticType[TypeParameterT] {}
+object NewTypeParameter             { def apply(): NewTypeParameter = new NewTypeParameter }
+class NewTypeParameter extends NewNode(41.toShort) with TypeParameterBase {
+  type RelatedStored = TypeParameter
+  override def label: String                      = "TYPE_PARAMETER"
+  var code: String                                = "<empty>": String
+  var columnNumber: Option[Int]                   = None
+  var lineNumber: Option[Int]                     = None
+  var name: String                                = "<empty>": String
+  var order: Int                                  = -1: Int
+  def code(value: String): this.type              = { this.code = value; this }
+  def columnNumber(value: Int): this.type         = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type = { this.columnNumber = value; this }
+  def lineNumber(value: Int): this.type           = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type   = { this.lineNumber = value; this }
+  def name(value: String): this.type              = { this.name = value; this }
+  def order(value: Int): this.type                = { this.order = value; this }
 }
 
-trait TypeRefT extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait TypeRefT    extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT with HasTypeFullNameT
+trait TypeRefBase extends AbstractNode with ExpressionBase with StaticType[TypeRefT] {}
 class TypeRef(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 42.toShort, seq_4762)
+    with TypeRefBase
     with Expression
-    with StaticType[TypeRefT] {
-//{propAccess}
-
+    with StaticType[TypeRefT] {}
+object NewTypeRef             { def apply(): NewTypeRef = new NewTypeRef }
+class NewTypeRef extends NewNode(42.toShort) with TypeRefBase {
+  type RelatedStored = TypeRef
+  override def label: String                                          = "TYPE_REF"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var lineNumber: Option[Int]                                         = None
+  var order: Int                                                      = -1: Int
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }
 
 trait UnknownT
@@ -434,10 +1281,37 @@ trait UnknownT
     with HasDynamicTypeHintFullNameT
     with HasParserTypeNameT
     with HasTypeFullNameT
+trait UnknownBase extends AbstractNode with ExpressionBase with StaticType[UnknownT] {}
 class Unknown(graph_4762: odb2.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 43.toShort, seq_4762)
+    with UnknownBase
     with Expression
-    with StaticType[UnknownT] {
-//{propAccess}
-
+    with StaticType[UnknownT] {}
+object NewUnknown             { def apply(): NewUnknown = new NewUnknown }
+class NewUnknown extends NewNode(43.toShort) with UnknownBase {
+  type RelatedStored = Unknown
+  override def label: String                                          = "UNKNOWN"
+  var argumentIndex: Int                                              = -1: Int
+  var argumentName: Option[String]                                    = None
+  var code: String                                                    = "<empty>": String
+  var columnNumber: Option[Int]                                       = None
+  var containedRef: String                                            = "<empty>": String
+  var dynamicTypeHintFullName: IndexedSeq[String]                     = ArraySeq.empty
+  var lineNumber: Option[Int]                                         = None
+  var order: Int                                                      = -1: Int
+  var parserTypeName: String                                          = "<empty>": String
+  var typeFullName: String                                            = "<empty>": String
+  def argumentIndex(value: Int): this.type                            = { this.argumentIndex = value; this }
+  def argumentName(value: Option[String]): this.type                  = { this.argumentName = value; this }
+  def argumentName(value: String): this.type                          = { this.argumentName = Option(value); this }
+  def code(value: String): this.type                                  = { this.code = value; this }
+  def columnNumber(value: Int): this.type                             = { this.columnNumber = Option(value); this }
+  def columnNumber(value: Option[Int]): this.type                     = { this.columnNumber = value; this }
+  def containedRef(value: String): this.type                          = { this.containedRef = value; this }
+  def dynamicTypeHintFullName(value: IterableOnce[String]): this.type = { this.dynamicTypeHintFullName = value.iterator.to(ArraySeq); this }
+  def lineNumber(value: Int): this.type                               = { this.lineNumber = Option(value); this }
+  def lineNumber(value: Option[Int]): this.type                       = { this.lineNumber = value; this }
+  def order(value: Int): this.type                                    = { this.order = value; this }
+  def parserTypeName(value: String): this.type                        = { this.parserTypeName = value; this }
+  def typeFullName(value: String): this.type                          = { this.typeFullName = value; this }
 }

--- a/joernGenerated/src/main/scala/generated/RootTypes.scala
+++ b/joernGenerated/src/main/scala/generated/RootTypes.scala
@@ -3,7 +3,9 @@ import io.joern.odb2
 
 trait StaticType[+T]
 
-trait AbstractNode extends odb2.DNodeOrNode with StaticType[AnyRef]
+trait AbstractNode extends odb2.DNodeOrNode with StaticType[AnyRef] {
+  def label: String
+}
 
 abstract class StoredNode(graph_4762: odb2.Graph, kind_4762: Short, seq_4762: Int)
     extends odb2.GNode(graph_4762, kind_4762, seq_4762)
@@ -135,4 +137,10 @@ abstract class StoredNode(graph_4762: odb2.Graph, kind_4762: Short, seq_4762: In
 
 }
 
-abstract class NewNode extends AbstractNode with odb2.DNode
+abstract class NewNode(val nodeKind: Short) extends AbstractNode with odb2.DNode {
+  type RelatedStored <: StoredNode
+  private /* volatile? */ var _storedRef: RelatedStored               = null.asInstanceOf[RelatedStored]
+  override def storedRef: Option[RelatedStored]                       = Option(this._storedRef)
+  override def storedRef_=(stored: Option[odb2.GNode]): Unit          = this._storedRef = stored.orNull.asInstanceOf[RelatedStored]
+  def flattenProperties(interface: odb2.BatchedUpdateInterface): Unit = ???
+}

--- a/schemaGen/src/main/scala/io/joern/odb2/schemagen/schemagen.scala
+++ b/schemaGen/src/main/scala/io/joern/odb2/schemagen/schemagen.scala
@@ -81,6 +81,24 @@ object SchemaGen {
     val edgeTypes    = schema.edgeTypes.sortBy(_.name).toArray
     val edgeIdByType = edgeTypes.zipWithIndex.toMap
 
+    val newPropsAtNodeSet = (schema.nodeBaseTypes.iterator ++ schema.nodeTypes.iterator).map { n =>
+      n -> (n.properties.toSet &~ n.extendzRecursively.flatMap { _.properties }.toSet)
+    }.toMap
+    val newPropsAtNodeList = newPropsAtNodeSet.map { case (k -> v) => k -> v.toList.sortBy(_.name) }
+    val newExtendzMap = (schema.nodeBaseTypes.iterator ++ schema.nodeTypes.iterator).map { n =>
+      n -> (n.extendz.toSet &~ n.extendzRecursively.flatMap {
+        _.extendz
+      }.toSet).toList.sortBy(_.name)
+    }.toMap
+
+    val prioStages = mutable.ArrayBuffer[mutable.ArrayBuffer[overflowdb.schema.NodeBaseType]]()
+    for (baseType <- schema.nodeBaseTypes) {
+      val props = newPropsAtNodeSet(baseType)
+      val dst   = prioStages.find { stage => stage.forall(other => (newPropsAtNodeSet(other) & props).isEmpty) }
+      if (dst.isDefined) { dst.get.addOne(baseType) }
+      else prioStages.addOne(mutable.ArrayBuffer(baseType))
+    }
+
     // base file
     val edgeAccess = edgeTypes
       .map { et =>
@@ -112,33 +130,35 @@ object SchemaGen {
          |
          |trait StaticType[+T]
          |
-         |trait AbstractNode extends odb2.DNodeOrNode with StaticType[AnyRef]
+         |trait AbstractNode extends odb2.DNodeOrNode with StaticType[AnyRef] {
+         |  def label: String
+         |}
          |
          |abstract class StoredNode(graph_4762: odb2.Graph, kind_4762: Short, seq_4762: Int) extends odb2.GNode(graph_4762, kind_4762, seq_4762) with AbstractNode {
          |${edgeAccess}
          |}
          |
-         |abstract class NewNode extends AbstractNode with odb2.DNode
+         |abstract class NewNode(val nodeKind:Short) extends AbstractNode with odb2.DNode {
+         |type RelatedStored <: StoredNode
+         |private /* volatile? */ var _storedRef: RelatedStored = null.asInstanceOf[RelatedStored]
+         |override def storedRef:Option[RelatedStored] = Option(this._storedRef)
+         |override def storedRef_=(stored: Option[odb2.GNode]):Unit = this._storedRef = stored.orNull.asInstanceOf[RelatedStored]
+         |def flattenProperties(interface: odb2.BatchedUpdateInterface): Unit = ???
+         |}
          |""".stripMargin
     outputDir.createChild("RootTypes.scala").write(rootTypes)
 
     val propertyMarkers = actualProperties.map { p => s"trait Has${p.className}T" }.mkString("\n")
     val basetypefile = schema.nodeBaseTypes
       .map { baseType =>
-        val newExtendz = (baseType.extendz.toSet &~ baseType.extendz.flatMap { p => p.extendzRecursively }.toSet).toList.sortBy {
-          _.name
-        }
+        val newExtendz = newExtendzMap(baseType)
         val mixinsBase = List("AbstractNode") ++ newExtendz.map(_.className + "Base") ++ baseType.markerTraits.map(_.name)
 
         val mixinsStored =
           List("StoredNode", s"${baseType.className}Base") ++ newExtendz.map(_.className) ++ baseType.markerTraits.map(_.name)
         val mixinsNew =
           List("NewNode", s"${baseType.className}Base") ++ baseType.extendz.map(_.className + "New") ++ baseType.markerTraits.map(_.name)
-        val newProperties = (baseType.properties.toSet &~ baseType.extendzRecursively.flatMap {
-          _.properties
-        }.toSet).toList.sortBy {
-          _.name
-        }
+        val newProperties = newPropsAtNodeList(baseType)
         val mixinsT =
           (List("AnyRef") ++ newExtendz.map { _.className + "T" } ++ newProperties.map { p => s"Has${p.className}T" }).mkString(" with ")
         val oldProperties = (baseType.properties.toSet &~ newProperties.toSet).toList.sortBy {
@@ -147,21 +167,28 @@ object SchemaGen {
         val oldExtendz = (baseType.extendzRecursively.toSet &~ newExtendz.toSet).toList.sortBy {
           _.name
         }
-        val accessors = newProperties
-          .map { p =>
-            val pre = s"def ${Helpers.camelCase(p.name)}: ${typeForProperty(p)}"
-            /*
-            val access = p.cardinality match {
-              case Cardinality.ZeroOrOne =>
-                s" = odb2.Accessors.getNodePropertyOption[${unpackTypeUnboxed(p.valueType, true, false)}]((this: StoredNode).graph, (this: StoredNode).nodeKind, ${idByProperty(p)}, (this: StoredNode).seq)"
-              case Cardinality.List =>
-                s" = odb2.Accessors.getNodePropertyMulti[${unpackTypeUnboxed(p.valueType, true, false)}]((this: StoredNode).graph, (this: StoredNode).nodeKind, ${idByProperty(p)}, (this: StoredNode).seq)"
-              case _: Cardinality.One[_] =>
-                s" = odb2.Accessors.getNodePropertySingle[${unpackTypeUnboxed(p.valueType, true, false)}]((this: StoredNode).graph, (this: StoredNode).nodeKind, ${idByProperty(p)}, (this: StoredNode).seq)"
-            } */
-            pre // + access
+
+        val newNodeDefs = mutable.ArrayBuffer[String]()
+
+        for (p <- newProperties) {
+          val pname = Helpers.camelCase(p.name)
+          val ptyp  = unpackTypeUnboxed(p.valueType, false, false)
+          p.cardinality match {
+            case Cardinality.List =>
+              newNodeDefs.append(s"def ${pname}: IndexedSeq[${ptyp}]")
+              newNodeDefs.append(s"def ${pname}_=(value: IndexedSeq[${ptyp}]): Unit")
+              newNodeDefs.append(s"def ${pname}(value: IterableOnce[${ptyp}]): this.type")
+            case Cardinality.ZeroOrOne =>
+              newNodeDefs.append(s"def ${pname}: Option[${ptyp}]")
+              newNodeDefs.append(s"def ${pname}_=(value: Option[${ptyp}]): Unit")
+              newNodeDefs.append(s"def ${pname}(value: Option[${ptyp}]): this.type")
+              newNodeDefs.append(s"def ${pname}(value: ${ptyp}): this.type")
+            case one: Cardinality.One[_] =>
+              newNodeDefs.append(s"def ${pname}: ${ptyp}")
+              newNodeDefs.append(s"def ${pname}_=(value: ${ptyp}): Unit")
+              newNodeDefs.append(s"def ${pname}(value: ${ptyp}): this.type")
           }
-          .mkString("\n")
+        }
 
         s"""trait ${baseType.className}T extends ${mixinsT}
            |
@@ -180,11 +207,12 @@ object SchemaGen {
             }
             .mkString(", ")}
            |trait ${baseType.className} extends ${mixinsStored
-            .mkString(" with ")} with StaticType[${baseType.className}T] {
-            |//{accessors}
-            |}
+            .mkString(" with ")} with StaticType[${baseType.className}T]
            |
-           |trait ${baseType.className}New extends ${mixinsNew.mkString(" with ")} with StaticType[${baseType.className}T]
+           |trait ${baseType.className}New extends ${mixinsNew.mkString(" with ")} with StaticType[${baseType.className}T]{
+           |  type RelatedStored <:  ${baseType.className}
+           |  ${newNodeDefs.mkString("\n")}
+           |}
            |""".stripMargin
       }
       .mkString(
@@ -239,29 +267,24 @@ object SchemaGen {
 
     val concreteNodes = nodeTypes.iterator.zipWithIndex
       .map { case (nodeType, kind) =>
-        val newExtendz = (nodeType.extendz.toSet &~ nodeType.extendz.flatMap { p => p.extendzRecursively }.toSet).toList.sortBy {
-          _.name
-        }
-        val newProperties = (nodeType.properties.toSet &~ nodeType.extendzRecursively.flatMap {
-          _.properties
-        }.toSet).toList.sortBy {
-          _.name
-        }
+        val newExtendz    = newExtendzMap(nodeType)
+        val newProperties = newPropsAtNodeList(nodeType)
         val staticTyp =
           (s"""trait ${nodeType.className}T extends AnyRef""" +: newExtendz.map { b => s"${b.className}T" } ++: newProperties.map { p =>
             s"Has${p.className}T"
           }).mkString(" with ")
 
-        // fixme
         val base = (s"""trait ${nodeType.className}Base extends AbstractNode""" +: newExtendz
           .map { base => base.className + "Base" } ++: List(s"StaticType[${nodeType.className}T]")).mkString(" with ")
 
         val stored =
-          (s"""class ${nodeType.className}(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, ${kind}.toShort , seq_4762)""" +: newExtendz
+          (s"""class ${nodeType.className}(graph_4762: odb2.Graph, seq_4762: Int) extends StoredNode(graph_4762, ${kind}.toShort , seq_4762)""" :: s"${nodeType.className}Base" +: newExtendz
             .map { base => base.className } ++: List(s"StaticType[${nodeType.className}T]")).mkString(" with ")
         // val base = (s"""class ${nodeType.className}""")
-        val newNodeProps  = mutable.ArrayBuffer[String]()
-        val newNodeFluent = mutable.ArrayBuffer[String]()
+        val newNodeProps    = mutable.ArrayBuffer[String]()
+        val newNodeFluent   = mutable.ArrayBuffer[String]()
+        val storedNodeProps = mutable.ArrayBuffer[String]()
+        val baseNodeProps   = mutable.ArrayBuffer[String]()
 
         for (p <- nodeType.properties) {
           val pname = Helpers.camelCase(p.name)
@@ -285,48 +308,55 @@ object SchemaGen {
         }
         for (c <- nodeType.containedNodes) {
           val pname = c.localName
-          val ptyp  = c.nodeType.className + "Base"
+          val ptyp  = classNameToBase(c.nodeType.className)
+          val styp  = c.nodeType.className
+          val index = actualProperties.size + containedIndexByName(c.localName)
           c.cardinality match {
             case Cardinality.List =>
               newNodeProps.append(s"var ${pname}: IndexedSeq[${ptyp}] = ArraySeq.empty")
               newNodeFluent.append(
                 s"def ${pname}(value: IterableOnce[${ptyp}]): this.type = {this.${pname} = value.iterator.to(ArraySeq); this }"
               )
+              baseNodeProps.append(s"def ${pname}: IndexedSeq[${ptyp}]")
+              storedNodeProps.append(
+                s"def ${pname}: IndexedSeq[${styp}] = odb2.Accessors.getNodePropertyMulti[$styp](graph, nodeKind, $index, seq)"
+              )
+
             case Cardinality.ZeroOrOne =>
               newNodeProps.append(s"var ${pname}: Option[${ptyp}] = None")
               newNodeFluent.append(s"def ${pname}(value: Option[${ptyp}]): this.type = {this.${pname} = value; this }")
               newNodeFluent.append(s"def ${pname}(value: ${ptyp}): this.type = {this.${pname} = Option(value); this }")
+              baseNodeProps.append(s"def ${pname}: Option[${ptyp}]")
+              storedNodeProps.append(
+                s"def ${pname}: Option[${styp}] = odb2.Accessors.getNodePropertyOption[$styp](graph, nodeKind, $index, seq)"
+              )
+
             case one: Cardinality.One[_] =>
               newNodeProps.append(s"var ${pname}: ${ptyp} = null")
               newNodeFluent.append(s"def ${pname}(value: ${ptyp}): this.type = {this.${pname} = value; this }")
+              baseNodeProps.append(s"def ${pname}: ${ptyp}")
+              storedNodeProps.append(
+                s"def ${pname}: ${styp} = odb2.Accessors.getNodePropertySingle(graph, nodeKind, $index, seq, null: ${styp})"
+              )
+
           }
         }
 
         val newNode =
           s"""object New${nodeType.className}{def apply():  New${nodeType.className} = new  New${nodeType.className}}
-             |class New${nodeType.className}{
+             |class New${nodeType.className} extends NewNode(${kindByNode(nodeType)}.toShort) with ${nodeType.className}Base {
+             |type RelatedStored = ${nodeType.className}
+             |override def label: String = "${nodeType.name}"
              |${newNodeProps.sorted.mkString("\n")}
              |${newNodeFluent.sorted.mkString("\n")}
              |}""".stripMargin
 
-        val containedAccess = nodeType.containedNodes
-          .map { contained =>
-            s"""def ${contained.localName}: ${contained.cardinality match {
-                case Cardinality.ZeroOrOne =>
-                  s"Option[${contained.nodeType.className}] = odb2.Accessors.getNodePropertyOption[${contained.nodeType.className}](graph, nodeKind, ${actualProperties.size + containedIndexByName(contained.localName)}, seq)"
-                case _: Cardinality.One[_] =>
-                  s"${contained.nodeType.className} = odb2.Accessors.getNodePropertySingle(graph, nodeKind, ${actualProperties.size + containedIndexByName(
-                      contained.localName
-                    )}, seq, null: ${contained.nodeType.className})"
-                case Cardinality.List =>
-                  s"IndexedSeq[${contained.nodeType.className}] = odb2.Accessors.getNodePropertyMulti[${contained.nodeType.className}](graph, nodeKind, ${actualProperties.size + containedIndexByName(contained.localName)}, seq)"
-              }}""".stripMargin
-          }
-          .mkString("\n")
-
         s"""${staticTyp}
+           |${base}{
+           |${baseNodeProps.mkString("\n")}
+           |}
            |${stored} {
-           |${containedAccess}
+           |${storedNodeProps.mkString("\n")}
            |}
            |${newNode}
            |""".stripMargin
@@ -416,36 +446,68 @@ object SchemaGen {
          |}""".stripMargin
     outputDir.createChild("GraphSchema.scala").write(schemaFile)
 
-    /*
-    val containedAccessorClassesAndNode = mutable.ArrayBuffer[(String, String)]()
-    val containedAccessors = nodeTypes
-      .flatMap { nt =>
-        nt.containedNodes.map {
-          (nt, _)
-        }
-      }
-      .map { case (node, contained) =>
-        val cc = s"Access_contained_${contained.localName}_${node.name}"
-        containedAccessorClassesAndNode.append((cc, node.name))
-        s"""class ${cc}(val containingNode: nodes.StoredNode) extends AnyVal {
-           |  def ${contained.localName}: ${contained.cardinality match {
+    val concreteStoredAccess = mutable.ArrayBuffer[String]()
+    val concreteStoredConv   = mutable.ArrayBuffer[String]()
+    val baseAccess           = mutable.ArrayBuffer[String]()
+    val baseConvert          = Range(0, prioStages.length + 1).map { _ => mutable.ArrayBuffer.empty[String] }
+
+    for (p <- actualProperties) {
+      val funName = Helpers.camelCase(p.name)
+      concreteStoredAccess.addOne(
+        s"""final class Access_Property_${p.name}(val node: nodes.StoredNode) extends AnyVal {
+           |  def ${funName}: ${typeForProperty(p)}  = ${p.cardinality match {
             case Cardinality.ZeroOrOne =>
-              s"Option[nodes.${contained.nodeType.className}] = odb2.Accessors.getNodePropertyOption[nodes.${contained.nodeType.className}](containingNode.graph, containingNode.nodeKind, ${actualProperties.size + containedIndexByName(contained.localName)}, containingNode.seq)"
-            case _: Cardinality.One[_] =>
-              s"nodes.${contained.nodeType.className} = odb2.Accessors.getNodePropertySingle[nodes.${contained.nodeType.className}](containingNode.graph, containingNode.nodeKind, ${actualProperties.size + containedIndexByName(contained.localName)}, containingNode.seq)"
+              s"odb2.Accessors.getNodePropertyOption[${unpackTypeUnboxed(p.valueType, true, false)}](node.graph, node.nodeKind, ${idByProperty(p)}, node.seq)"
             case Cardinality.List =>
-              s"IndexedSeq[nodes.${contained.nodeType.className}] = odb2.Accessors.getNodePropertyMulti[nodes.${contained.nodeType.className}](containingNode.graph, containingNode.nodeKind, ${actualProperties.size + containedIndexByName(contained.localName)}, containingNode.seq)"
+              s"odb2.Accessors.getNodePropertyMulti[${unpackTypeUnboxed(p.valueType, true, false)}](node.graph, node.nodeKind, ${idByProperty(p)}, node.seq)"
+            case one: Cardinality.One[_] =>
+              s"odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, ${idByProperty(p)}, node.seq(), ${unpackDefault(p.valueType, one.default)})"
           }}
            |}""".stripMargin
-      }
-      .mkString("\n")
-     */
+      )
+      concreteStoredConv.addOne(
+        s"""implicit def accessProperty${p.className}(node: nodes.StoredNode with nodes.StaticType[nodes.Has${p.className}T]): Access_Property_${p.name} = new Access_Property_${p.name}(node)""".stripMargin
+      )
+    }
 
-    val propertyBaseConversions = actualProperties
-      .map { p =>
-        s"implicit def accessProperty${p.className}(node: nodes.StoredNode with nodes.StaticType[nodes.Has${p.className}T]): Access_property_${p.name} = new Access_property_${p.name}(node)"
+    for ((convertForStage, stage) <- baseConvert.iterator.zip(Iterator(nodeTypes.iterator) ++ prioStages.iterator)) {
+      for (baseType <- stage) {
+        val extensionClass = s"Access_${baseType.className}Base"
+        convertForStage.addOne(
+          s"implicit def access_${baseType.className}Base(node: nodes.${baseType.className}Base): $extensionClass = new $extensionClass(node)"
+        )
+        val newName = if (baseType.isInstanceOf[overflowdb.schema.NodeBaseType]) { baseType.className + "New" }
+        else { "New" + baseType.className }
+        val accessors = mutable.ArrayBuffer[String]()
+        for (p <- newPropsAtNodeList(baseType)) {
+          val funName = Helpers.camelCase(p.name)
+          accessors.addOne(s"""def ${funName}: ${typeForProperty(p)}  = node match {
+          | case stored: nodes.StoredNode => new Access_Property_${p.name}(stored).${funName}
+          | case newNode: nodes.${newName} => newNode.${funName}
+          |}""".stripMargin)
+        }
+        baseAccess.addOne(
+          accessors.mkString(s"final class ${extensionClass}(val node: nodes.${baseType.className}Base) extends AnyVal {\n", "\n", "\n}")
+        )
       }
-      .mkString("\n")
+    }
+    val convtraits = mutable.ArrayBuffer[String]()
+    for (idx <- Range(0, baseConvert.length + 1)) {
+      val (tname, tparent, conv) = idx match {
+        case 0 => ("ConcreteStoredConversions", Some("ConcreteBaseConversions"), concreteStoredConv.toBuffer)
+        case 1 => ("ConcreteBaseConversions", if (baseConvert.length > 1) Some("AbstractBaseConversions0") else None, baseConvert(0))
+        case _ =>
+          (
+            s"AbstractBaseConversions${idx - 2}",
+            if (idx < baseConvert.length) Some(s"AbstractBaseConversions${idx - 1}") else None,
+            baseConvert(idx - 1)
+          )
+      }
+      convtraits.addOne(s"""trait ${tname} ${tparent.map { p => s" extends ${p}" }.getOrElse("")} {
+           |import Accessors._
+           |${conv.mkString("\n")}
+           |}""".stripMargin)
+    }
 
     val accessors =
       s"""package ${basePackage}.accessors
@@ -454,52 +516,19 @@ object SchemaGen {
          |import scala.collection.immutable.IndexedSeq
          |
          |object Accessors {
-         |  ${actualProperties
-          .map { p =>
-            val pre =
-              s"class Access_property_${p.name}(val node: nodes.StoredNode) extends AnyVal {\n  def ${Helpers.camelCase(p.name)}: ${typeForProperty(p)}  ="
-            val access = p.cardinality match {
-              case Cardinality.ZeroOrOne =>
-                s"odb2.Accessors.getNodePropertyOption[${unpackTypeUnboxed(p.valueType, true, false)}](node.graph, node.nodeKind, ${idByProperty(p)}, node.seq)"
-              case Cardinality.List =>
-                s"odb2.Accessors.getNodePropertyMulti[${unpackTypeUnboxed(p.valueType, true, false)}](node.graph, node.nodeKind, ${idByProperty(p)}, node.seq)"
-              case one: Cardinality.One[_] =>
-                s"odb2.Accessors.getNodePropertySingle(node.graph, node.nodeKind, ${idByProperty(p)}, node.seq(), ${unpackDefault(p.valueType, one.default)})"
-            }
-            pre + "\n    " + access + "\n}"
-          }
-          .mkString("\n\n")}
+         |  ${concreteStoredAccess.mkString("\n")}
+         |  //
+         |  ${baseAccess.mkString("\n")}
          |}
          |
-         |object Lang extends ImplicitAccessors
-         |trait ImplicitAccessors{
-         |import Accessors._
-         |${propertyBaseConversions}
-         |}""".stripMargin
+         |object Lang extends ConcreteStoredConversions {}
+         |
+         |${convtraits.mkString("\n\n")}
+         |""".stripMargin
 
-    // for now, let's skip accessors.
     outputDir.createChild("Accessors.scala").write(accessors)
 
-    /*
-if (containedNodes.size != containedNodes.map { _.localName }.size) {
-  println(containedNodes.toList.sortBy {
-    _.localName
-  })
-  println(
-    containedNodes
-      .map {
-        _.localName
-      }
-      .toList
-      .sorted
-  )
-  throw new RuntimeException()
-}
-     */
-
-    // val properties = schema.properties.filter{schema.nodeTypes.exists{nt => nt.}}
-
-  }
+  } // end generate
 
   def typeForProperty(p: Property[_]): String = {
     val typ = unpackTypeUnboxed(p.valueType, true, false)
@@ -510,6 +539,12 @@ if (containedNodes.size != containedNodes.map { _.localName }.size) {
     }
   }
 
+  def classNameToBase(classname: String): String = {
+    classname match {
+      case "StoredNode" => "AbstractNode"
+      case other        => other + "Base"
+    }
+  }
   def unpackDefault(typ: ValueType[_], default: Default[_]): String = {
     import org.apache.commons.text.StringEscapeUtils.escapeJava
     typ match {


### PR DESCRIPTION
This adds generated code for NewNode classes and accessors for `AstBase` et al properties.

The generated code is incomplete: we need a little more interface work for batched updates, copy-methods, view as dictionary, etc.

I'd like to point out the very annoying construction with implicit priority ordering: That's what I wanted to avoid with the `HasNameT` traits. Unfortunately we need that to access `(node:AstBase).name` methods. 

As a recap: The problem is with ambiguous  implicits. We put implicits into priority stages, with the following rules:
1. If two implicits provide the same name, then they are in different stages.
2. If two implicits provide the same name, then the strictness of the implicit conversion signature is either incomparable or the more specific must be in a lower priority stage (in the current code we never do this).

I considered being more relaxed about (1): Say, e.g., that no node that extends both A and B exists. Then why do we care about ambiguity on `A with B`? We care about it because of otherwise inscrutable compile time errors. 