### PR TITLE
drop `.v2` from namespace of generated code

### DIFF
--- a/domain-classes-generator/src/main/scala/io/joern/odb2/schemagen/DomainClassesGenerator.scala
+++ b/domain-classes-generator/src/main/scala/io/joern/odb2/schemagen/DomainClassesGenerator.scala
@@ -33,7 +33,7 @@ class DomainClassesGenerator(schema: Schema) {
     os.remove.all(outputDir0)
     os.makeDir.all(outputDir0)
 
-    val basePackage = schema.basePackage + ".v2"
+    val basePackage = schema.basePackage
 
     val propertyContexts   = relevantPropertyContexts(schema)
     val relevantProperties = propertyContexts.properties
@@ -772,7 +772,7 @@ class DomainClassesGenerator(schema: Schema) {
       val file = outputDir / s"$className.java"
       os.write(
         file,
-        s"""package ${schema.basePackage}.v2;
+        s"""package ${schema.basePackage};
            |
            |import java.util.HashSet;
            |import java.util.Set;
@@ -846,7 +846,7 @@ class DomainClassesGenerator(schema: Schema) {
       .mkString("\n")
 
     s"""
-       |package ${schema.basePackage}.v2.nodes
+       |package ${schema.basePackage}.nodes
        |
        |extension (iterator: Iterator[StoredNode]) {
        |  $neighborSteps

--- a/joern-generated/src/main/scala/generated/Accessors.scala
+++ b/joern-generated/src/main/scala/generated/Accessors.scala
@@ -1,6 +1,6 @@
-package io.shiftleft.codepropertygraph.generated.v2.accessors
+package io.shiftleft.codepropertygraph.generated.accessors
 import io.joern.odb2
-import io.shiftleft.codepropertygraph.generated.v2.nodes
+import io.shiftleft.codepropertygraph.generated.nodes
 import scala.collection.immutable.IndexedSeq
 
 object Lang extends ConcreteStoredConversions

--- a/joern-generated/src/main/scala/generated/BaseTypes.scala
+++ b/joern-generated/src/main/scala/generated/BaseTypes.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2.nodes
+package io.shiftleft.codepropertygraph.generated.nodes
 import io.joern.odb2
 
 trait AstNodeT extends AnyRef with HasCodeT with HasColumnNumberT with HasLineNumberT with HasOrderT

--- a/joern-generated/src/main/scala/generated/ControlStructureTypes.java
+++ b/joern-generated/src/main/scala/generated/ControlStructureTypes.java
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2;
+package io.shiftleft.codepropertygraph.generated;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/joern-generated/src/main/scala/generated/Cpg.scala
+++ b/joern-generated/src/main/scala/generated/Cpg.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2
+package io.shiftleft.codepropertygraph.generated
 import io.joern.odb2
 
 object Cpg {

--- a/joern-generated/src/main/scala/generated/DispatchTypes.java
+++ b/joern-generated/src/main/scala/generated/DispatchTypes.java
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2;
+package io.shiftleft.codepropertygraph.generated;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/joern-generated/src/main/scala/generated/EdgeTypes.java
+++ b/joern-generated/src/main/scala/generated/EdgeTypes.java
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2;
+package io.shiftleft.codepropertygraph.generated;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/joern-generated/src/main/scala/generated/EdgeTypes.scala
+++ b/joern-generated/src/main/scala/generated/EdgeTypes.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2.edges
+package io.shiftleft.codepropertygraph.generated.edges
 import io.joern.odb2
 
 class AliasOf(src_4762: odb2.GNode, dst_4762: odb2.GNode, subSeq_4862: Int, property_4862: Any)

--- a/joern-generated/src/main/scala/generated/EvaluationStrategies.java
+++ b/joern-generated/src/main/scala/generated/EvaluationStrategies.java
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2;
+package io.shiftleft.codepropertygraph.generated;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/joern-generated/src/main/scala/generated/GraphSchema.scala
+++ b/joern-generated/src/main/scala/generated/GraphSchema.scala
@@ -1,7 +1,7 @@
-package io.shiftleft.codepropertygraph.generated.v2
+package io.shiftleft.codepropertygraph.generated
 import io.joern.odb2
-import io.shiftleft.codepropertygraph.generated.v2.nodes
-import io.shiftleft.codepropertygraph.generated.v2.edges
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.edges
 
 object GraphSchema extends odb2.Schema {
   val nodeLabels = Array(

--- a/joern-generated/src/main/scala/generated/Languages.java
+++ b/joern-generated/src/main/scala/generated/Languages.java
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2;
+package io.shiftleft.codepropertygraph.generated;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/joern-generated/src/main/scala/generated/ModifierTypes.java
+++ b/joern-generated/src/main/scala/generated/ModifierTypes.java
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2;
+package io.shiftleft.codepropertygraph.generated;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/joern-generated/src/main/scala/generated/NeighborAccessors.scala
+++ b/joern-generated/src/main/scala/generated/NeighborAccessors.scala
@@ -1,7 +1,7 @@
-package io.shiftleft.codepropertygraph.generated.v2.neighboraccessors
+package io.shiftleft.codepropertygraph.generated.neighboraccessors
 import io.joern.odb2
 import io.joern.odb2.Traversal.*
-import io.shiftleft.codepropertygraph.generated.v2.nodes
+import io.shiftleft.codepropertygraph.generated.nodes
 
 object Lang extends Conversions
 

--- a/joern-generated/src/main/scala/generated/NodeTypes.java
+++ b/joern-generated/src/main/scala/generated/NodeTypes.java
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2;
+package io.shiftleft.codepropertygraph.generated;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/joern-generated/src/main/scala/generated/NodeTypes.scala
+++ b/joern-generated/src/main/scala/generated/NodeTypes.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2.nodes
+package io.shiftleft.codepropertygraph.generated.nodes
 import io.joern.odb2
 import scala.collection.immutable.{IndexedSeq, ArraySeq}
 
@@ -6,7 +6,7 @@ trait AnnotationT extends AnyRef with ExpressionT with HasFullNameT with HasName
 trait AnnotationBase extends AbstractNode with ExpressionBase with StaticType[AnnotationT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }
@@ -63,7 +63,7 @@ trait AnnotationLiteralT extends AnyRef with ExpressionT with HasNameT
 trait AnnotationLiteralBase extends AbstractNode with ExpressionBase with StaticType[AnnotationLiteralT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }
@@ -116,7 +116,7 @@ trait AnnotationParameterT extends AnyRef with AstNodeT
 trait AnnotationParameterBase extends AbstractNode with AstNodeBase with StaticType[AnnotationParameterT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -156,7 +156,7 @@ trait AnnotationParameterAssignT extends AnyRef with AstNodeT
 trait AnnotationParameterAssignBase extends AbstractNode with AstNodeBase with StaticType[AnnotationParameterAssignT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -196,7 +196,7 @@ trait ArrayInitializerT extends AnyRef with ExpressionT
 trait ArrayInitializerBase extends AbstractNode with ExpressionBase with StaticType[ArrayInitializerT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }
@@ -245,7 +245,7 @@ trait BindingT extends AnyRef with HasMethodFullNameT with HasNameT with HasSign
 trait BindingBase extends AbstractNode with StaticType[BindingT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("METHOD_FULL_NAME", this.methodFullName)
     res.put("NAME", this.name)
@@ -278,7 +278,7 @@ trait BlockT extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT wi
 trait BlockBase extends AbstractNode with ExpressionBase with StaticType[BlockT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }
@@ -348,7 +348,7 @@ trait CallT
 trait CallBase extends AbstractNode with CallReprBase with ExpressionBase with StaticType[CallT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }
@@ -427,7 +427,7 @@ trait ClosureBindingT extends AnyRef with HasClosureBindingIdT with HasClosureOr
 trait ClosureBindingBase extends AbstractNode with StaticType[ClosureBindingT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     this.closureBindingId.foreach { p => res.put("CLOSURE_BINDING_ID", p) }
     this.closureOriginalName.foreach { p => res.put("CLOSURE_ORIGINAL_NAME", p) }
@@ -462,7 +462,7 @@ trait CommentT extends AnyRef with AstNodeT with HasFilenameT
 trait CommentBase extends AbstractNode with AstNodeBase with StaticType[CommentT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -506,7 +506,7 @@ trait ConfigFileT extends AnyRef with HasContentT with HasNameT
 trait ConfigFileBase extends AbstractNode with StaticType[ConfigFileT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CONTENT", this.content)
     res.put("NAME", this.name)
@@ -535,7 +535,7 @@ trait ControlStructureT extends AnyRef with ExpressionT with HasControlStructure
 trait ControlStructureBase extends AbstractNode with ExpressionBase with StaticType[ControlStructureT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }
@@ -592,7 +592,7 @@ trait DependencyT extends AnyRef with HasDependencyGroupIdT with HasNameT with H
 trait DependencyBase extends AbstractNode with StaticType[DependencyT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     this.dependencyGroupId.foreach { p => res.put("DEPENDENCY_GROUP_ID", p) }
     res.put("NAME", this.name)
@@ -626,7 +626,7 @@ trait FieldIdentifierT extends AnyRef with ExpressionT with HasCanonicalNameT
 trait FieldIdentifierBase extends AbstractNode with ExpressionBase with StaticType[FieldIdentifierT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }
@@ -679,7 +679,7 @@ trait FileT extends AnyRef with AstNodeT with HasHashT with HasNameT
 trait FileBase extends AbstractNode with AstNodeBase with StaticType[FileT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -729,7 +729,7 @@ trait FindingBase extends AbstractNode with StaticType[FindingT] {
   def evidence: IndexedSeq[AbstractNode]
   def keyValuePairs: IndexedSeq[KeyValuePairBase]
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res              = new java.util.HashMap[String, Any]()
     val tmpevidence      = this.evidence; if (tmpevidence.nonEmpty) res.put("evidence", tmpevidence)
     val tmpkeyValuePairs = this.keyValuePairs; if (tmpkeyValuePairs.nonEmpty) res.put("keyValuePairs", tmpkeyValuePairs)
@@ -767,7 +767,7 @@ trait IdentifierT
 trait IdentifierBase extends AbstractNode with ExpressionBase with StaticType[IdentifierT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }
@@ -840,7 +840,7 @@ trait ImportT
 trait ImportBase extends AbstractNode with AstNodeBase with StaticType[ImportT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -905,7 +905,7 @@ trait JumpLabelT extends AnyRef with AstNodeT with HasNameT with HasParserTypeNa
 trait JumpLabelBase extends AbstractNode with AstNodeBase with StaticType[JumpLabelT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -953,7 +953,7 @@ trait JumpTargetT extends AnyRef with CfgNodeT with HasArgumentIndexT with HasNa
 trait JumpTargetBase extends AbstractNode with CfgNodeBase with StaticType[JumpTargetT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     res.put("CODE", this.code)
@@ -1005,7 +1005,7 @@ trait KeyValuePairT extends AnyRef with HasKeyT with HasValueT
 trait KeyValuePairBase extends AbstractNode with StaticType[KeyValuePairT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("KEY", this.key)
     res.put("VALUE", this.value)
@@ -1034,7 +1034,7 @@ trait LiteralT extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT 
 trait LiteralBase extends AbstractNode with ExpressionBase with StaticType[LiteralT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }
@@ -1103,7 +1103,7 @@ trait LocalT
 trait LocalBase extends AbstractNode with AstNodeBase with DeclarationBase with StaticType[LocalT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     this.closureBindingId.foreach { p => res.put("CLOSURE_BINDING_ID", p) }
     res.put("CODE", this.code)
@@ -1176,7 +1176,7 @@ trait LocationT
 trait LocationBase extends AbstractNode with StaticType[LocationT] {
   def node: Option[AbstractNode]
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CLASS_NAME", this.className)
     res.put("CLASS_SHORT_NAME", this.classShortName)
@@ -1241,7 +1241,7 @@ trait MemberT extends AnyRef with AstNodeT with DeclarationT with HasDynamicType
 trait MemberBase extends AbstractNode with AstNodeBase with DeclarationBase with StaticType[MemberT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -1299,7 +1299,7 @@ trait MetaDataT extends AnyRef with HasHashT with HasLanguageT with HasOverlaysT
 trait MetaDataBase extends AbstractNode with StaticType[MetaDataT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     this.hash.foreach { p => res.put("HASH", p) }
     res.put("LANGUAGE", this.language)
@@ -1353,7 +1353,7 @@ trait MethodT
 trait MethodBase extends AbstractNode with CfgNodeBase with DeclarationBase with StaticType[MethodT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("AST_PARENT_FULL_NAME", this.astParentFullName)
     res.put("AST_PARENT_TYPE", this.astParentType)
@@ -1446,7 +1446,7 @@ trait MethodParameterInT
 trait MethodParameterInBase extends AbstractNode with CfgNodeBase with DeclarationBase with StaticType[MethodParameterInT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -1523,7 +1523,7 @@ trait MethodParameterOutT
 trait MethodParameterOutBase extends AbstractNode with CfgNodeBase with DeclarationBase with StaticType[MethodParameterOutT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -1590,7 +1590,7 @@ trait MethodRefT
 trait MethodRefBase extends AbstractNode with ExpressionBase with StaticType[MethodRefT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }
@@ -1662,7 +1662,7 @@ trait MethodReturnT
 trait MethodReturnBase extends AbstractNode with CfgNodeBase with StaticType[MethodReturnT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -1719,7 +1719,7 @@ trait ModifierT extends AnyRef with AstNodeT with HasModifierTypeT
 trait ModifierBase extends AbstractNode with AstNodeBase with StaticType[ModifierT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -1763,7 +1763,7 @@ trait NamespaceT extends AnyRef with AstNodeT with HasNameT
 trait NamespaceBase extends AbstractNode with AstNodeBase with StaticType[NamespaceT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -1807,7 +1807,7 @@ trait NamespaceBlockT extends AnyRef with AstNodeT with HasFilenameT with HasFul
 trait NamespaceBlockBase extends AbstractNode with AstNodeBase with StaticType[NamespaceBlockT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -1859,7 +1859,7 @@ trait ReturnT extends AnyRef with ExpressionT
 trait ReturnBase extends AbstractNode with ExpressionBase with StaticType[ReturnT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }
@@ -1908,7 +1908,7 @@ trait TagT extends AnyRef with HasNameT with HasValueT
 trait TagBase extends AbstractNode with StaticType[TagT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("NAME", this.name)
     res.put("VALUE", this.value)
@@ -1935,7 +1935,7 @@ trait TagNodePairBase extends AbstractNode with StaticType[TagNodePairT] {
   def node: AbstractNode
   def tag: TagBase
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("node", this.node)
     res.put("tag", this.tag)
@@ -1967,7 +1967,7 @@ trait TemplateDomT extends AnyRef with ExpressionT with HasNameT
 trait TemplateDomBase extends AbstractNode with ExpressionBase with StaticType[TemplateDomT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }
@@ -2020,7 +2020,7 @@ trait TypeT extends AnyRef with HasFullNameT with HasNameT with HasTypeDeclFullN
 trait TypeBase extends AbstractNode with StaticType[TypeT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("FULL_NAME", this.fullName)
     res.put("NAME", this.name)
@@ -2053,7 +2053,7 @@ trait TypeArgumentT extends AnyRef with AstNodeT
 trait TypeArgumentBase extends AbstractNode with AstNodeBase with StaticType[TypeArgumentT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -2103,7 +2103,7 @@ trait TypeDeclT
 trait TypeDeclBase extends AbstractNode with AstNodeBase with StaticType[TypeDeclT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     this.aliasTypeFullName.foreach { p => res.put("ALIAS_TYPE_FULL_NAME", p) }
     res.put("AST_PARENT_FULL_NAME", this.astParentFullName)
@@ -2179,7 +2179,7 @@ trait TypeParameterT extends AnyRef with AstNodeT with HasNameT
 trait TypeParameterBase extends AbstractNode with AstNodeBase with StaticType[TypeParameterT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("CODE", this.code)
     this.columnNumber.foreach { p => res.put("COLUMN_NUMBER", p) }
@@ -2223,7 +2223,7 @@ trait TypeRefT extends AnyRef with ExpressionT with HasDynamicTypeHintFullNameT 
 trait TypeRefBase extends AbstractNode with ExpressionBase with StaticType[TypeRefT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }
@@ -2292,7 +2292,7 @@ trait UnknownT
 trait UnknownBase extends AbstractNode with ExpressionBase with StaticType[UnknownT] {
 
   override def propertiesMap: java.util.Map[String, Any] = {
-    import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+    import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
     val res = new java.util.HashMap[String, Any]()
     res.put("ARGUMENT_INDEX", this.argumentIndex)
     this.argumentName.foreach { p => res.put("ARGUMENT_NAME", p) }

--- a/joern-generated/src/main/scala/generated/Operators.java
+++ b/joern-generated/src/main/scala/generated/Operators.java
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2;
+package io.shiftleft.codepropertygraph.generated;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/joern-generated/src/main/scala/generated/PropertyNames.java
+++ b/joern-generated/src/main/scala/generated/PropertyNames.java
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2;
+package io.shiftleft.codepropertygraph.generated;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/joern-generated/src/main/scala/generated/RootTypes.scala
+++ b/joern-generated/src/main/scala/generated/RootTypes.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2.nodes
+package io.shiftleft.codepropertygraph.generated.nodes
 import io.joern.odb2
 
 trait StaticType[+T]

--- a/joern-generated/src/main/scala/generated/RootTypesTraversals.scala
+++ b/joern-generated/src/main/scala/generated/RootTypesTraversals.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.codepropertygraph.generated.v2.nodes
+package io.shiftleft.codepropertygraph.generated.nodes
 
 extension (iterator: Iterator[StoredNode]) {
 

--- a/joern-generated/src/main/scala/generated/Traversals.scala
+++ b/joern-generated/src/main/scala/generated/Traversals.scala
@@ -1,11 +1,11 @@
-package io.shiftleft.codepropertygraph.generated.v2.traversals
+package io.shiftleft.codepropertygraph.generated.traversals
 import io.joern.odb2
-import io.shiftleft.codepropertygraph.generated.v2.nodes
+import io.shiftleft.codepropertygraph.generated.nodes
 
 object Lang extends ConcreteStoredConversions
 
 object Accessors {
-  import io.shiftleft.codepropertygraph.generated.v2.accessors.Lang.*
+  import io.shiftleft.codepropertygraph.generated.accessors.Lang.*
   import odb2.misc.Misc
 
   /* accessors for concrete stored nodes start */


### PR DESCRIPTION
no longer needed and simplifies conversion of joern