### PR TITLE
NodeTypeStarters: make extensible

### DIFF
--- a/domain-classes-generator/src/main/scala/io/joern/odb2/schemagen/DomainClassesGenerator.scala
+++ b/domain-classes-generator/src/main/scala/io/joern/odb2/schemagen/DomainClassesGenerator.scala
@@ -633,7 +633,7 @@ class DomainClassesGenerator(schema: Schema) {
          |assert(graph.schema == GraphSchema)
          |}
          |
-         |class ${domainShortName}NodeStarters(val wrappedCpg: $domainShortName) extends AnyVal {
+         |class ${domainShortName}NodeStarters(val wrappedCpg: $domainShortName) {
          |  def all: Iterator[nodes.StoredNode] = wrappedCpg.graph.allNodes.asInstanceOf[Iterator[nodes.StoredNode]]
          |
          |${concreteStarters.mkString("\n")}

--- a/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/v2/Cpg.scala
+++ b/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/v2/Cpg.scala
@@ -8,7 +8,7 @@ class Cpg(val graph: odb2.Graph) {
   assert(graph.schema == GraphSchema)
 }
 
-class CpgNodeStarters(val wrappedCpg: Cpg) extends AnyVal {
+class CpgNodeStarters(val wrappedCpg: Cpg) {
   def all: Iterator[nodes.StoredNode] = wrappedCpg.graph.allNodes.asInstanceOf[Iterator[nodes.StoredNode]]
 
   def annotation: Iterator[nodes.Annotation]                   = wrappedCpg.graph.nodes(0).asInstanceOf[Iterator[nodes.Annotation]]


### PR DESCRIPTION
we need to be able to extend NodeTypeStarters downstream because we want
to overload the generated methods (e.g. `method`) with argument-taking
ones with the same name (e.g. `method(name: String)`). This only works
with inheritance.