### PR TITLE
handle illegal storage file when trying to deserialise

### DIFF
--- a/core/src/main/scala/flatgraph/storage/package.scala
+++ b/core/src/main/scala/flatgraph/storage/package.scala
@@ -37,4 +37,5 @@ package object storage {
     val Header             = 0xdeadbeefdeadbeefL
   }
 
+  val HeaderSize = 16
 }


### PR DESCRIPTION
prior to this, we ran into an endless loop in `Deserialization.readManifest`