### PR TITLE
Schema.getNodePropertyDefault: also lookup in 'getPropertyOptionCompat'

### DIFF
--- a/core/src/main/scala/flatgraph/Accessors.scala
+++ b/core/src/main/scala/flatgraph/Accessors.scala
@@ -145,9 +145,9 @@ object Accessors {
     val seq      = node.seq()
     val nodeKind = node.nodeKind.toInt
     schema.getNodePropertyFormalQuantity(nodeKind, propertyKind) match {
-      case FormalQtyType.QtyNone => None
+      case FormalQtyType.QtyNone                          => None
       case FormalQtyType.QtyOne | FormalQtyType.QtyOption => getNodePropertyOption[Object](graph, nodeKind, propertyKind, seq)
-      case FormalQtyType.QtyMulti => Some(getNodePropertyMulti[Object](graph, nodeKind, propertyKind, seq))
+      case FormalQtyType.QtyMulti                         => Some(getNodePropertyMulti[Object](graph, nodeKind, propertyKind, seq))
     } match {
       case None =>
         val default = schema.getNodePropertyDefault(nodeKind = nodeKind, propertyKind = propertyKind)

--- a/core/src/main/scala/flatgraph/Accessors.scala
+++ b/core/src/main/scala/flatgraph/Accessors.scala
@@ -144,11 +144,15 @@ object Accessors {
     val schema   = graph.schema
     val seq      = node.seq()
     val nodeKind = node.nodeKind.toInt
-    val res      = getNodePropertyMulti[Object](graph, nodeKind, propertyKind, seq)
     schema.getNodePropertyFormalQuantity(nodeKind, propertyKind) match {
-      case FormalQtyType.QtyNone                          => None
+      case FormalQtyType.QtyNone => None
       case FormalQtyType.QtyOne | FormalQtyType.QtyOption => getNodePropertyOption[Object](graph, nodeKind, propertyKind, seq)
-      case FormalQtyType.QtyMulti                         => Some(getNodePropertyMulti[Object](graph, nodeKind, propertyKind, seq))
+      case FormalQtyType.QtyMulti => Some(getNodePropertyMulti[Object](graph, nodeKind, propertyKind, seq))
+    } match {
+      case None =>
+        val default = schema.getNodePropertyDefault(nodeKind = nodeKind, propertyKind = propertyKind)
+        Option(default).map(_.asInstanceOf[AnyRef])
+      case some => some
     }
   }
 

--- a/core/src/main/scala/flatgraph/Schema.scala
+++ b/core/src/main/scala/flatgraph/Schema.scala
@@ -128,6 +128,7 @@ abstract class Schema {
   def allocateEdgeProperty(nodeKind: Int, direction: Direction, edgeKind: Int, size: Int): Array[_]
   def getNodePropertyFormalType(nodeKind: Int, propertyKind: Int): FormalQtyType.FormalType
   def getNodePropertyFormalQuantity(nodeKind: Int, propertyKind: Int): FormalQtyType.FormalQuantity
+  def getNodePropertyDefault(nodeKind: Int, propertyKind: Int): Any
 }
 
 class FreeSchema(
@@ -181,5 +182,8 @@ class FreeSchema(
       case _                         => FormalQtyType.QtyMulti
     }
     else formalqtys(propertyOffsetArrayIndex(nodeKind, propertyKind))
+    
+  override def getNodePropertyDefault(nodeKind: Int, propertyKind: Int): Any =
+    null
 
 }

--- a/core/src/main/scala/flatgraph/Schema.scala
+++ b/core/src/main/scala/flatgraph/Schema.scala
@@ -182,7 +182,7 @@ class FreeSchema(
       case _                         => FormalQtyType.QtyMulti
     }
     else formalqtys(propertyOffsetArrayIndex(nodeKind, propertyKind))
-    
+
   override def getNodePropertyDefault(nodeKind: Int, propertyKind: Int): Any =
     null
 

--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
@@ -604,8 +604,8 @@ class DomainClassesGenerator(schema: Schema) {
       val nodePropertyDefaultsImpl = {
         val cases = for {
           (node, nodeKind) <- nodeTypes.zipWithIndex
-          property <- node.properties
-          default <- property.default
+          property         <- node.properties
+          default          <- property.default
           propertyKind = propertyKindByProperty(property)
         } yield s"if (nodeKind == $nodeKind && propertyKind == $propertyKind) { ${Helpers.defaultValueImpl(default)} }"
 
@@ -615,6 +615,7 @@ class DomainClassesGenerator(schema: Schema) {
            |}""".stripMargin
       }
 
+      // format: off
       s"""package $basePackage
          |import $basePackage.nodes
          |import $basePackage.edges
@@ -653,6 +654,7 @@ class DomainClassesGenerator(schema: Schema) {
          |  override def getNodePropertyFormalQuantity(nodeKind: Int, propertyKind: Int): FormalQtyType.FormalQuantity = nodePropertyDescriptors(1 + propertyOffsetArrayIndex(nodeKind, propertyKind)).asInstanceOf[FormalQtyType.FormalQuantity]
          |  $nodePropertyDefaultsImpl
          |}""".stripMargin
+      // format: on
     }
     os.write(outputDir0 / "GraphSchema.scala", schemaFile)
 


### PR DESCRIPTION
Domain classes: currently generating as a list of if/else statements - given that it's two parameters the jvm will probably not compile it into a tableswitch. What do you think,
should we rather change it into a Map or a 2d array instead?

getPropertyOptionCompat needs to take the default value into account, so that the behaviour matches overflowdb. 