### PR TITLE
generate traversal filter steps for 'property does not equal'

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,6 +100,21 @@ lazy val odbConvert = project
     )
   )
 
+/** temporarily we still want to keep the generated files for the cpg domain in here,
+  * in order to be able to quickly see the differences in the generated files if we
+  * change the codegen
+  * n.b. relies on a manually published version of cpg-schema from https://github.com/ShiftLeftSecurity/codepropertygraph/tree/michael/flatgraph
+  */
+lazy val domainClassesGeneratorJoern = project
+  .in(file("domain-classes-generator-joern"))
+  .dependsOn(domainClassesGenerator_3)
+  .settings(
+    name := "domain-classes-generator-joern",
+    scalaVersion := scala3,
+    publish / skip := true,
+    libraryDependencies += "io.shiftleft" %% "codepropertygraph-schema" % "1.6.6+21-c6774ab5"
+  )
+
 lazy val joernGenerated = project
   .in(file("joern-generated"))
   .dependsOn(core)

--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/CodeSnippets.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/CodeSnippets.scala
@@ -269,9 +269,22 @@ object CodeSnippets {
          |  * */
          |def $nameCamelCase(values: $baseType*): Iterator[NodeType] = {
          |  val vset = values.toSet
-         |  traversal.filter{node => !vset.contains(node.$nameCamelCase)}
+         |  traversal.filter{node => vset.contains(node.$nameCamelCase)}
          |}
          |
+         |/**
+         |  * Traverse to nodes where the $nameCamelCase does not equal the given `value`
+         |  * */
+         |def ${nameCamelCase}Not(value: $baseType): Iterator[NodeType] =
+         |  traversal.filter{_.$nameCamelCase != value}
+         |
+         |/**
+         |  * Traverse to nodes where the $nameCamelCase does not equal any one of the given `values`
+         |  * */
+         |def ${nameCamelCase}Not(values: $baseType*): Iterator[NodeType] = {
+         |  val vset = values.toSet
+         |  traversal.filter{node => !vset.contains(node.$nameCamelCase)}
+         |}
          |""".stripMargin
     }
 
@@ -287,7 +300,21 @@ object CodeSnippets {
          |  * */
          |def $nameCamelCase(values: $baseType*): Iterator[NodeType] = {
          |  val vset = values.toSet
-         |  traversal.filter{node => node.$nameCamelCase.isDefined && !vset.contains(node.$nameCamelCase.get)}
+         |  traversal.filter{node => node.$nameCamelCase.isDefined && vset.contains(node.$nameCamelCase.get)}
+         |}
+         |
+         |/**
+         |  * Traverse to nodes where the $nameCamelCase does not equal the given `value`
+         |  * */
+         |def ${nameCamelCase}Not(value: $baseType): Iterator[NodeType] =
+         |  traversal.filter{node => node.$nameCamelCase.empty || node.$nameCamelCase.get != value}
+         |
+         |/**
+         |  * Traverse to nodes where the $nameCamelCase does not equal any one of the given `values`
+         |  * */
+         |def ${nameCamelCase}Not(values: $baseType*): Iterator[NodeType] = {
+         |  val vset = values.toSet
+         |  traversal.filter{node => node.$nameCamelCase.empty || !vset.contains(node.$nameCamelCase.get)}
          |}
          |""".stripMargin
     }

--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/CodeSnippets.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/CodeSnippets.scala
@@ -161,6 +161,20 @@ object CodeSnippets {
          |}
          |
          |/**
+         |  * Traverse to nodes where the $nameCamelCase is not equal to the given `value`
+         |  * */
+         |def ${nameCamelCase}Not(value: $baseType): Iterator[NodeType] =
+         |  traversal.filter{_.$nameCamelCase != value}
+         |
+         |/**
+         |  * Traverse to nodes where the $nameCamelCase is not equal to any of the given `values`
+         |  * */
+         |def ${nameCamelCase}Not(values: $baseType*): Iterator[NodeType] = {
+         |  val vset = values.toSet
+         |  traversal.filter{node => !vset.contains(node.$nameCamelCase)}
+         |}
+         |
+         |/**
          |  * Traverse to nodes where the $nameCamelCase is greater than the given `value`
          |  * */
          |def ${nameCamelCase}Gt(value: $baseType): Iterator[NodeType] =
@@ -200,6 +214,20 @@ object CodeSnippets {
          |def $nameCamelCase(values: $baseType*): Iterator[NodeType] = {
          |  val vset = values.toSet
          |  traversal.filter{node => val tmp = node.$nameCamelCase; tmp.isDefined && vset.contains(tmp.get)}
+         |}
+         |
+         |/**
+         |  * Traverse to nodes where the $nameCamelCase is not equal to the given `value`
+         |  * */
+         |def ${nameCamelCase}Not(value: $baseType): Iterator[NodeType] =
+         |  traversal.filter{node => val tmp = node.$nameCamelCase; tmp.isEmtpy || tmp.get != value}
+         |
+         |/**
+         |  * Traverse to nodes where the $nameCamelCase does not equal any one of the given `values`
+         |  * */
+         |def ${nameCamelCase}Not(values: $baseType*): Iterator[NodeType] = {
+         |  val vset = values.toSet
+         |  traversal.filter{node => val tmp = node.$nameCamelCase; tmp.isEmpty || !vset.contains(tmp.get)}
          |}
          |
          |/**

--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/CodeSnippets.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/CodeSnippets.scala
@@ -220,7 +220,7 @@ object CodeSnippets {
          |  * Traverse to nodes where the $nameCamelCase is not equal to the given `value`
          |  * */
          |def ${nameCamelCase}Not(value: $baseType): Iterator[NodeType] =
-         |  traversal.filter{node => val tmp = node.$nameCamelCase; tmp.isEmtpy || tmp.get != value}
+         |  traversal.filter{node => val tmp = node.$nameCamelCase; tmp.isEmpty || tmp.get != value}
          |
          |/**
          |  * Traverse to nodes where the $nameCamelCase does not equal any one of the given `values`

--- a/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/Accessors.scala
+++ b/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/Accessors.scala
@@ -778,6 +778,14 @@ object Accessors {
       case stored: nodes.StoredNode   => new Access_Property_NAME(stored).name
       case newNode: nodes.NewTypeDecl => newNode.name
     }
+    def offset: Option[Int] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_OFFSET(stored).offset
+      case newNode: nodes.NewTypeDecl => newNode.offset
+    }
+    def offsetEnd: Option[Int] = node match {
+      case stored: nodes.StoredNode   => new Access_Property_OFFSET_END(stored).offsetEnd
+      case newNode: nodes.NewTypeDecl => newNode.offsetEnd
+    }
   }
   final class Access_TypeParameterBase(val node: nodes.TypeParameterBase) extends AnyVal {
     def name: String = node match {

--- a/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/Cpg.scala
+++ b/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/Cpg.scala
@@ -136,6 +136,9 @@ which contains the method's (short-) name and `SIGNATURE`, which contains
 any information we may have about the types of arguments and return value.""")
   def call: Iterator[nodes.Call] = wrappedCpg.graph._nodes(7).asInstanceOf[Iterator[nodes.Call]]
 
+  /** Shorthand for call.name */
+  def call(name: String): Iterator[nodes.Call] = call.name(name)
+
   /** Represents the binding of a LOCAL or METHOD_PARAMETER_IN into the closure of a method */
   @flatgraph.help.Doc(info =
     """Represents the binding of a LOCAL or METHOD_PARAMETER_IN into the closure of a method"""
@@ -146,6 +149,9 @@ any information we may have about the types of arguments and return value.""")
   /** A source code comment */
   @flatgraph.help.Doc(info = """A source code comment""")
   def comment: Iterator[nodes.Comment] = wrappedCpg.graph._nodes(9).asInstanceOf[Iterator[nodes.Comment]]
+
+  /** Shorthand for comment.code */
+  def comment(code: String): Iterator[nodes.Comment] = comment.code(code)
 
   /** This node type represent a configuration file, where `NAME` is the name of the file and `content` is its content.
     * The exact representation of the name is left undefined and can be chosen as required by consumers of the
@@ -183,6 +189,9 @@ for construction of the control flow layer.""")
   @flatgraph.help.Doc(info = """This node represents a dependency""")
   def dependency: Iterator[nodes.Dependency] = wrappedCpg.graph._nodes(12).asInstanceOf[Iterator[nodes.Dependency]]
 
+  /** Shorthand for dependency.name */
+  def dependency(name: String): Iterator[nodes.Dependency] = dependency.name(name)
+
   /** This node represents the field accessed in a field access, e.g., in `a.b`, it represents `b`. The field name as it
     * occurs in the code is stored in the `CODE` field. This may mean that the `CODE` field holds an expression. The
     * `CANONICAL_NAME` field MAY contain the same value is the `CODE` field but SHOULD contain the normalized name that
@@ -206,35 +215,24 @@ it.""")
   /** File nodes represent source files or a shared objects from which the CPG was generated. File nodes serve as
     * indices, that is, they allow looking up all elements of the code by file.
     *
-    * For each file, the graph MUST contain exactly one File node. As file nodes are root nodes of abstract syntax
-    * tress, they are AstNodes and their order field is set to 0. This is because they have no sibling nodes, not
-    * because they are the first node of the AST.
-    *
-    * Each CPG MUST contain a special file node with name set to `<unknown>`. This node is a placeholder used in cases
-    * where a file cannot be determined at compile time. As an example, consider external library functions. As their
-    * code is not available on CPG construction, the file name is unknown.
-    *
-    * File nodes MUST NOT be created by the language frontend. Instead, the language frontend is assumed to fill out the
-    * `FILENAME` field wherever possible, allowing File nodes to be created automatically upon first loading the CPG.
+    * For each file, the graph CAN contain exactly one File node, if not File nodes are created as indicated by
+    * `FILENAME` property of other nodes. As file nodes are root nodes of abstract syntax tress, they are AstNodes and
+    * their order field is set to 0. This is because they have no sibling nodes, not because they are the first node of
+    * the AST.
     */
   @flatgraph.help.Doc(info = """File nodes represent source files or a shared objects from which the CPG
 was generated. File nodes serve as indices, that is, they allow looking up all
 elements of the code by file.
 
-For each file, the graph MUST contain exactly one File node.
+For each file, the graph CAN contain exactly one File node, if not File nodes
+are created as indicated by `FILENAME` property of other nodes.
 As file nodes are root nodes of abstract syntax tress, they are AstNodes and
 their order field is set to 0. This is because they have no sibling nodes,
-not because they are the first node of the AST.
-
-Each CPG MUST contain a special file node with name set to
-`<unknown>`. This node is a placeholder used in cases where a file cannot be
-determined at compile time. As an example, consider external library functions.
-As their code is not available on CPG construction, the file name is unknown.
-
-File nodes MUST NOT be created by the language frontend. Instead, the language
-frontend is assumed to fill out the `FILENAME` field wherever possible,
-allowing File nodes to be created automatically upon first loading the CPG.""")
+not because they are the first node of the AST.""")
   def file: Iterator[nodes.File] = wrappedCpg.graph._nodes(14).asInstanceOf[Iterator[nodes.File]]
+
+  /** Shorthand for file.name */
+  def file(name: String): Iterator[nodes.File] = file.name(name)
 
   /** Finding nodes may be used to store analysis results in the graph that are to be exposed to an end-user, e.g.,
     * information about potential vulnerabilities or dangerous programming practices. A Finding node may contain an
@@ -256,6 +254,9 @@ serve as evidence for the finding.""")
 It holds the identifier's name in the `NAME` field and its fully-qualified type
 name in `TYPE_FULL_NAME`.""")
   def identifier: Iterator[nodes.Identifier] = wrappedCpg.graph._nodes(16).asInstanceOf[Iterator[nodes.Identifier]]
+
+  /** Shorthand for identifier.name */
+  def identifier(name: String): Iterator[nodes.Identifier] = identifier.name(name)
 
   /** Declarative import as it is found in statically typed languages like Java. This kind of node is not supposed to be
     * used for imports in dynamically typed languages like Javascript.
@@ -300,6 +301,9 @@ The `TYPE_FULL_NAME` field stores the literal's fully-qualified type name,
 e.g., `java.lang.Integer`.""")
   def literal: Iterator[nodes.Literal] = wrappedCpg.graph._nodes(21).asInstanceOf[Iterator[nodes.Literal]]
 
+  /** Shorthand for literal.code */
+  def literal(code: String): Iterator[nodes.Literal] = literal.code(code)
+
   /** This node represents a local variable. Its fully qualified type name is stored in the `TYPE_FULL_NAME` field and
     * its name in the `NAME` field. The `CODE` field contains the entire local variable declaration without
     * initialization, e.g., for `int x = 10;`, it contains `int x`.
@@ -309,6 +313,9 @@ in the `TYPE_FULL_NAME` field and its name in the `NAME` field. The `CODE` field
 contains the entire local variable declaration without initialization, e.g., for
 `int x = 10;`, it contains `int x`.""")
   def local: Iterator[nodes.Local] = wrappedCpg.graph._nodes(22).asInstanceOf[Iterator[nodes.Local]]
+
+  /** Shorthand for local.name */
+  def local(name: String): Iterator[nodes.Local] = local.name(name)
 
   /** A location node summarizes a source code location. */
   @flatgraph.help.Doc(info = """A location node summarizes a source code location.""")
@@ -321,6 +328,9 @@ contains the entire local variable declaration without initialization, e.g., for
  type declaration `class Foo{ int i ; }`, it represents the declaration of the
  variable `i`.""")
   def member: Iterator[nodes.Member] = wrappedCpg.graph._nodes(24).asInstanceOf[Iterator[nodes.Member]]
+
+  /** Shorthand for member.name */
+  def member(name: String): Iterator[nodes.Member] = member.name(name)
 
   /** This node contains the CPG meta data. Exactly one node of this type MUST exist per CPG. The `HASH` property MAY
     * contain a hash value calculated over the source files this CPG was generated from. The `VERSION` MUST be set to
@@ -348,9 +358,10 @@ which language frontend was used to generate the CPG and the list property
     *
     * Line and column number information is specified in the optional fields `LINE_NUMBER`, `COLUMN_NUMBER`,
     * `LINE_NUMBER_END`, and `COLUMN_NUMBER_END` and the name of the source file is specified in `FILENAME`. An optional
-    * hash value MAY be calculated over the function contents and included in the `HASH` field. The optional `OFFSET`
-    * and `OFFSET_END` specify the start and exclusive end position of the code belonging to a method within the
-    * corresponding `FILE` nodes `CONTENT` property.
+    * hash value MAY be calculated over the function contents and included in the `HASH` field.
+    *
+    * The optional `OFFSET` and `OFFSET_END` specify the start and exclusive end position of the code belonging to a
+    * method within the corresponding `FILE` nodes `CONTENT` property.
     *
     * Finally, the fully qualified name of the program constructs that the method is immediately contained in is stored
     * in the `AST_PARENT_FULL_NAME` field and its type is indicated in the `AST_PARENT_TYPE` field to be one of
@@ -373,6 +384,7 @@ Line and column number information is specified in the optional fields
 `LINE_NUMBER`, `COLUMN_NUMBER`, `LINE_NUMBER_END`, and `COLUMN_NUMBER_END` and
 the name of the source file is specified in `FILENAME`. An optional hash value
 MAY be calculated over the function contents and included in the `HASH` field.
+
 The optional `OFFSET` and `OFFSET_END` specify the start
 and exclusive end position of the code belonging to a method within the corresponding
 `FILE` nodes `CONTENT` property.
@@ -383,6 +395,9 @@ and its type is indicated in the `AST_PARENT_TYPE` field to be one of
 `METHOD`, `TYPE_DECL` or `NAMESPACE_BLOCK`.""")
   def method: Iterator[nodes.Method] = wrappedCpg.graph._nodes(26).asInstanceOf[Iterator[nodes.Method]]
 
+  /** Shorthand for method.name */
+  def method(name: String): Iterator[nodes.Method] = method.name(name)
+
   /** This node represents a formal input parameter. The field `NAME` contains its name, while the field
     * `TYPE_FULL_NAME` contains the fully qualified type name.
     */
@@ -390,6 +405,9 @@ and its type is indicated in the `AST_PARENT_TYPE` field to be one of
 name, while the field `TYPE_FULL_NAME` contains the fully qualified type name.""")
   def methodParameterIn: Iterator[nodes.MethodParameterIn] =
     wrappedCpg.graph._nodes(27).asInstanceOf[Iterator[nodes.MethodParameterIn]]
+
+  /** Shorthand for methodParameterIn.name */
+  def methodParameterIn(name: String): Iterator[nodes.MethodParameterIn] = methodParameterIn.name(name)
 
   /** This node represents a formal output parameter. Corresponding output parameters for input parameters MUST NOT be
     * created by the frontend as they are automatically created upon first loading the CPG.
@@ -445,6 +463,9 @@ they are generated from NAMESPACE_BLOCK nodes automatically upon
 first loading of the CPG.""")
   def namespace: Iterator[nodes.Namespace] = wrappedCpg.graph._nodes(32).asInstanceOf[Iterator[nodes.Namespace]]
 
+  /** Shorthand for namespace.name */
+  def namespace(name: String): Iterator[nodes.Namespace] = namespace.name(name)
+
   /** A reference to a namespace. We borrow the concept of a "namespace block" from C++, that is, a namespace block is a
     * block of code that has been placed in the same namespace by a programmer. This block may be introduced via a
     * `package` statement in Java or a `namespace{ }` statement in C++.
@@ -474,6 +495,9 @@ that the right hand side is a sub namespace of the left hand side, e.g.,
   def namespaceBlock: Iterator[nodes.NamespaceBlock] =
     wrappedCpg.graph._nodes(33).asInstanceOf[Iterator[nodes.NamespaceBlock]]
 
+  /** Shorthand for namespaceBlock.name */
+  def namespaceBlock(name: String): Iterator[nodes.NamespaceBlock] = namespaceBlock.name(name)
+
   /** This node represents a return instruction, e.g., `return x`. Note that it does NOT represent a formal return
     * parameter as formal return parameters are represented via `METHOD_RETURN` nodes.
     */
@@ -482,9 +506,15 @@ NOT represent a formal return parameter as formal return parameters are
 represented via `METHOD_RETURN` nodes.""")
   def ret: Iterator[nodes.Return] = wrappedCpg.graph._nodes(34).asInstanceOf[Iterator[nodes.Return]]
 
+  /** Shorthand for ret.code */
+  def ret(code: String): Iterator[nodes.Return] = ret.code(code)
+
   /** This node represents a tag. */
   @flatgraph.help.Doc(info = """This node represents a tag.""")
   def tag: Iterator[nodes.Tag] = wrappedCpg.graph._nodes(35).asInstanceOf[Iterator[nodes.Tag]]
+
+  /** Shorthand for tag.name */
+  def tag(name: String): Iterator[nodes.Tag] = tag.name(name)
 
   /** This node contains an arbitrary node and an associated tag node. */
   @flatgraph.help.Doc(info = """This node contains an arbitrary node and an associated tag node.""")
@@ -499,6 +529,9 @@ represented via `METHOD_RETURN` nodes.""")
   @flatgraph.help.Doc(info = """This node represents a type instance, that is, a concrete instantiation
 of a type declaration.""")
   def typ: Iterator[nodes.Type] = wrappedCpg.graph._nodes(38).asInstanceOf[Iterator[nodes.Type]]
+
+  /** Shorthand for typ.name */
+  def typ(name: String): Iterator[nodes.Type] = typ.name(name)
 
   /** An (actual) type argument as used to instantiate a parametrized type, in the same way an (actual) arguments
     * provides concrete values for a parameter at method call sites. As it true for arguments, the method is not
@@ -529,6 +562,9 @@ to  interpret the type argument. It MUST however store its code in the
     * fully-qualified name of a base type. If the type is known to be an alias of another type (as for example
     * introduced via the C `typedef` statement), the name of the alias is stored in `ALIAS_TYPE_FULL_NAME`.
     *
+    * The optional `OFFSET` and `OFFSET_END` specify the start and exclusive end position of the code belonging to a
+    * `TYPE_DECL` within the corresponding `FILE` nodes `CONTENT` property.
+    *
     * Finally, the fully qualified name of the program constructs that the type declaration is immediately contained in
     * is stored in the `AST_PARENT_FULL_NAME` field and its type is indicated in the `AST_PARENT_TYPE` field to be one
     * of `METHOD`, `TYPE_DECL` or `NAMESPACE_BLOCK`.
@@ -554,11 +590,18 @@ each entry contains the fully-qualified name of a base type. If the type is
 known to be an alias of another type (as for example introduced via the C
 `typedef` statement), the name of the alias is stored in `ALIAS_TYPE_FULL_NAME`.
 
+The optional `OFFSET` and `OFFSET_END` specify the start
+and exclusive end position of the code belonging to a `TYPE_DECL` within the corresponding
+`FILE` nodes `CONTENT` property.
+
 Finally, the fully qualified name of the program constructs that the type declaration
 is immediately contained in is stored in the `AST_PARENT_FULL_NAME` field
 and its type is indicated in the `AST_PARENT_TYPE` field to be one of
 `METHOD`, `TYPE_DECL` or `NAMESPACE_BLOCK`.""")
   def typeDecl: Iterator[nodes.TypeDecl] = wrappedCpg.graph._nodes(40).asInstanceOf[Iterator[nodes.TypeDecl]]
+
+  /** Shorthand for typeDecl.name */
+  def typeDecl(name: String): Iterator[nodes.TypeDecl] = typeDecl.name(name)
 
   /** This node represents a formal type parameter, that is, the type parameter as given in a type-parametrized method
     * or type declaration. Examples for languages that support type parameters are Java (via Generics) and C++ (via

--- a/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/GraphSchema.scala
+++ b/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/GraphSchema.scala
@@ -857,6 +857,10 @@ object GraphSchema extends flatgraph.Schema {
     nodePropertyDescriptors(3073) = FormalQtyType.QtyOption
     nodePropertyDescriptors(3512) = FormalQtyType.StringType // TYPE_DECL.NAME
     nodePropertyDescriptors(3513) = FormalQtyType.QtyOne
+    nodePropertyDescriptors(3688) = FormalQtyType.IntType // TYPE_DECL.OFFSET
+    nodePropertyDescriptors(3689) = FormalQtyType.QtyOption
+    nodePropertyDescriptors(3776) = FormalQtyType.IntType // TYPE_DECL.OFFSET_END
+    nodePropertyDescriptors(3777) = FormalQtyType.QtyOption
     nodePropertyDescriptors(3864) = FormalQtyType.IntType // TYPE_DECL.ORDER
     nodePropertyDescriptors(3865) = FormalQtyType.QtyOne
     nodePropertyDescriptors(962) = FormalQtyType.StringType // TYPE_PARAMETER.CODE

--- a/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/Languages.java
+++ b/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/Languages.java
@@ -59,6 +59,9 @@ public static final String RUBYSRC = "RUBYSRC";
 /** Source-based frontend for Swift */
 public static final String SWIFTSRC = "SWIFTSRC";
 
+/** Source-based frontend for C# and .NET */
+public static final String CSHARPSRC = "CSHARPSRC";
+
 public static Set<String> ALL = new HashSet<String>() {{
 add(JAVA);
 add(JAVASCRIPT);
@@ -78,6 +81,7 @@ add(JSSRC);
 add(SOLIDITY);
 add(RUBYSRC);
 add(SWIFTSRC);
+add(CSHARPSRC);
 }};
 
 }

--- a/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/NodeTypes.java
+++ b/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/NodeTypes.java
@@ -95,19 +95,11 @@ public static final String FIELD_IDENTIFIER = "FIELD_IDENTIFIER";
 was generated. File nodes serve as indices, that is, they allow looking up all
 elements of the code by file.
 
-For each file, the graph MUST contain exactly one File node.
+For each file, the graph CAN contain exactly one File node, if not File nodes
+are created as indicated by `FILENAME` property of other nodes.
 As file nodes are root nodes of abstract syntax tress, they are AstNodes and
 their order field is set to 0. This is because they have no sibling nodes,
-not because they are the first node of the AST.
-
-Each CPG MUST contain a special file node with name set to
-`<unknown>`. This node is a placeholder used in cases where a file cannot be
-determined at compile time. As an example, consider external library functions.
-As their code is not available on CPG construction, the file name is unknown.
-
-File nodes MUST NOT be created by the language frontend. Instead, the language
-frontend is assumed to fill out the `FILENAME` field wherever possible,
-allowing File nodes to be created automatically upon first loading the CPG. */
+not because they are the first node of the AST. */
 public static final String FILE = "FILE";
 
 /** Finding nodes may be used to store analysis results in the graph
@@ -188,6 +180,7 @@ Line and column number information is specified in the optional fields
 `LINE_NUMBER`, `COLUMN_NUMBER`, `LINE_NUMBER_END`, and `COLUMN_NUMBER_END` and
 the name of the source file is specified in `FILENAME`. An optional hash value
 MAY be calculated over the function contents and included in the `HASH` field.
+
 The optional `OFFSET` and `OFFSET_END` specify the start
 and exclusive end position of the code belonging to a method within the corresponding
 `FILE` nodes `CONTENT` property.
@@ -294,6 +287,10 @@ Base types can be specified via the `INHERITS_FROM_TYPE_FULL_NAME` list, where
 each entry contains the fully-qualified name of a base type. If the type is
 known to be an alias of another type (as for example introduced via the C
 `typedef` statement), the name of the alias is stored in `ALIAS_TYPE_FULL_NAME`.
+
+The optional `OFFSET` and `OFFSET_END` specify the start
+and exclusive end position of the code belonging to a `TYPE_DECL` within the corresponding
+`FILE` nodes `CONTENT` property.
 
 Finally, the fully qualified name of the program constructs that the type declaration
 is immediately contained in is stored in the `AST_PARENT_FULL_NAME` field

--- a/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/PropertyNames.java
+++ b/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/PropertyNames.java
@@ -236,6 +236,10 @@ public static final String POSSIBLE_TYPES = "POSSIBLE_TYPES";
 /** The path to the root directory of the source/binary this CPG is generated from. */
 public static final String ROOT = "ROOT";
 
+/** ID from a different context, e.g. if the graph was imported from a different format,
+we can use this to preserve the link to the original */
+public static final String SECONDARY_ID = "SECONDARY_ID";
+
 /** The method signature encodes the types of parameters in a string.
 The string SHOULD be human readable and suitable for differentiating methods
 with different parameter types sufficiently to allow for resolving of
@@ -318,6 +322,7 @@ add(PACKAGE_NAME);
 add(PARSER_TYPE_NAME);
 add(POSSIBLE_TYPES);
 add(ROOT);
+add(SECONDARY_ID);
 add(SIGNATURE);
 add(SYMBOL);
 add(TYPE_DECL_FULL_NAME);

--- a/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/Traversals.scala
+++ b/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/Traversals.scala
@@ -107,6 +107,18 @@ object Accessors {
       traversal.filter { node => vset.contains(node.argumentIndex) }
     }
 
+    /** Traverse to nodes where the argumentIndex is not equal to the given `value`
+      */
+    def argumentIndexNot(value: Int): Iterator[NodeType] =
+      traversal.filter { _.argumentIndex != value }
+
+    /** Traverse to nodes where the argumentIndex is not equal to any of the given `values`
+      */
+    def argumentIndexNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node => !vset.contains(node.argumentIndex) }
+    }
+
     /** Traverse to nodes where the argumentIndex is greater than the given `value`
       */
     def argumentIndexGt(value: Int): Iterator[NodeType] =
@@ -778,6 +790,22 @@ object Accessors {
       }
     }
 
+    /** Traverse to nodes where the columnNumber is not equal to the given `value`
+      */
+    def columnNumberNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.columnNumber; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the columnNumber does not equal any one of the given `values`
+      */
+    def columnNumberNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.columnNumber; tmp.isEmpty || !vset.contains(tmp.get)
+      }
+    }
+
     /** Traverse to nodes where the columnNumber is greater than the given `value`
       */
     def columnNumberGt(value: Int): Iterator[NodeType] =
@@ -829,6 +857,22 @@ object Accessors {
       val vset = values.toSet
       traversal.filter { node =>
         val tmp = node.columnNumberEnd; tmp.isDefined && vset.contains(tmp.get)
+      }
+    }
+
+    /** Traverse to nodes where the columnNumberEnd is not equal to the given `value`
+      */
+    def columnNumberEndNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.columnNumberEnd; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the columnNumberEnd does not equal any one of the given `values`
+      */
+    def columnNumberEndNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.columnNumberEnd; tmp.isEmpty || !vset.contains(tmp.get)
       }
     }
 
@@ -1673,6 +1717,18 @@ object Accessors {
       traversal.filter { node => vset.contains(node.index) }
     }
 
+    /** Traverse to nodes where the index is not equal to the given `value`
+      */
+    def indexNot(value: Int): Iterator[NodeType] =
+      traversal.filter { _.index != value }
+
+    /** Traverse to nodes where the index is not equal to any of the given `values`
+      */
+    def indexNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node => !vset.contains(node.index) }
+    }
+
     /** Traverse to nodes where the index is greater than the given `value`
       */
     def indexGt(value: Int): Iterator[NodeType] =
@@ -1917,6 +1973,22 @@ object Accessors {
       }
     }
 
+    /** Traverse to nodes where the lineNumber is not equal to the given `value`
+      */
+    def lineNumberNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.lineNumber; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the lineNumber does not equal any one of the given `values`
+      */
+    def lineNumberNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.lineNumber; tmp.isEmpty || !vset.contains(tmp.get)
+      }
+    }
+
     /** Traverse to nodes where the lineNumber is greater than the given `value`
       */
     def lineNumberGt(value: Int): Iterator[NodeType] =
@@ -1968,6 +2040,22 @@ object Accessors {
       val vset = values.toSet
       traversal.filter { node =>
         val tmp = node.lineNumberEnd; tmp.isDefined && vset.contains(tmp.get)
+      }
+    }
+
+    /** Traverse to nodes where the lineNumberEnd is not equal to the given `value`
+      */
+    def lineNumberEndNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.lineNumberEnd; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the lineNumberEnd does not equal any one of the given `values`
+      */
+    def lineNumberEndNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.lineNumberEnd; tmp.isEmpty || !vset.contains(tmp.get)
       }
     }
 
@@ -2347,6 +2435,22 @@ object Accessors {
       }
     }
 
+    /** Traverse to nodes where the offset is not equal to the given `value`
+      */
+    def offsetNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offset; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the offset does not equal any one of the given `values`
+      */
+    def offsetNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.offset; tmp.isEmpty || !vset.contains(tmp.get)
+      }
+    }
+
     /** Traverse to nodes where the offset is greater than the given `value`
       */
     def offsetGt(value: Int): Iterator[NodeType] =
@@ -2400,6 +2504,22 @@ object Accessors {
       }
     }
 
+    /** Traverse to nodes where the offsetEnd is not equal to the given `value`
+      */
+    def offsetEndNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offsetEnd; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the offsetEnd does not equal any one of the given `values`
+      */
+    def offsetEndNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.offsetEnd; tmp.isEmpty || !vset.contains(tmp.get)
+      }
+    }
+
     /** Traverse to nodes where the offsetEnd is greater than the given `value`
       */
     def offsetEndGt(value: Int): Iterator[NodeType] =
@@ -2447,6 +2567,18 @@ object Accessors {
     def order(values: Int*): Iterator[NodeType] = {
       val vset = values.toSet
       traversal.filter { node => vset.contains(node.order) }
+    }
+
+    /** Traverse to nodes where the order is not equal to the given `value`
+      */
+    def orderNot(value: Int): Iterator[NodeType] =
+      traversal.filter { _.order != value }
+
+    /** Traverse to nodes where the order is not equal to any of the given `values`
+      */
+    def orderNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node => !vset.contains(node.order) }
     }
 
     /** Traverse to nodes where the order is greater than the given `value`
@@ -5119,6 +5251,18 @@ object Accessors {
       traversal.filter { node => vset.contains(node.argumentIndex) }
     }
 
+    /** Traverse to nodes where the argumentIndex is not equal to the given `value`
+      */
+    def argumentIndexNot(value: Int): Iterator[NodeType] =
+      traversal.filter { _.argumentIndex != value }
+
+    /** Traverse to nodes where the argumentIndex is not equal to any of the given `values`
+      */
+    def argumentIndexNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node => !vset.contains(node.argumentIndex) }
+    }
+
     /** Traverse to nodes where the argumentIndex is greater than the given `value`
       */
     def argumentIndexGt(value: Int): Iterator[NodeType] =
@@ -5789,6 +5933,22 @@ object Accessors {
       val vset = values.toSet
       traversal.filter { node =>
         val tmp = node.lineNumber; tmp.isDefined && vset.contains(tmp.get)
+      }
+    }
+
+    /** Traverse to nodes where the lineNumber is not equal to the given `value`
+      */
+    def lineNumberNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.lineNumber; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the lineNumber does not equal any one of the given `values`
+      */
+    def lineNumberNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.lineNumber; tmp.isEmpty || !vset.contains(tmp.get)
       }
     }
 
@@ -6701,6 +6861,22 @@ object Accessors {
       }
     }
 
+    /** Traverse to nodes where the columnNumberEnd is not equal to the given `value`
+      */
+    def columnNumberEndNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.columnNumberEnd; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the columnNumberEnd does not equal any one of the given `values`
+      */
+    def columnNumberEndNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.columnNumberEnd; tmp.isEmpty || !vset.contains(tmp.get)
+      }
+    }
+
     /** Traverse to nodes where the columnNumberEnd is greater than the given `value`
       */
     def columnNumberEndGt(value: Int): Iterator[NodeType] =
@@ -6949,6 +7125,22 @@ object Accessors {
       }
     }
 
+    /** Traverse to nodes where the lineNumberEnd is not equal to the given `value`
+      */
+    def lineNumberEndNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.lineNumberEnd; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the lineNumberEnd does not equal any one of the given `values`
+      */
+    def lineNumberEndNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.lineNumberEnd; tmp.isEmpty || !vset.contains(tmp.get)
+      }
+    }
+
     /** Traverse to nodes where the lineNumberEnd is greater than the given `value`
       */
     def lineNumberEndGt(value: Int): Iterator[NodeType] =
@@ -6997,6 +7189,22 @@ object Accessors {
       }
     }
 
+    /** Traverse to nodes where the offset is not equal to the given `value`
+      */
+    def offsetNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offset; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the offset does not equal any one of the given `values`
+      */
+    def offsetNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.offset; tmp.isEmpty || !vset.contains(tmp.get)
+      }
+    }
+
     /** Traverse to nodes where the offset is greater than the given `value`
       */
     def offsetGt(value: Int): Iterator[NodeType] =
@@ -7042,6 +7250,22 @@ object Accessors {
       val vset = values.toSet
       traversal.filter { node =>
         val tmp = node.offsetEnd; tmp.isDefined && vset.contains(tmp.get)
+      }
+    }
+
+    /** Traverse to nodes where the offsetEnd is not equal to the given `value`
+      */
+    def offsetEndNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offsetEnd; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the offsetEnd does not equal any one of the given `values`
+      */
+    def offsetEndNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.offsetEnd; tmp.isEmpty || !vset.contains(tmp.get)
       }
     }
 
@@ -7289,6 +7513,18 @@ object Accessors {
       traversal.filter { node => vset.contains(node.index) }
     }
 
+    /** Traverse to nodes where the index is not equal to the given `value`
+      */
+    def indexNot(value: Int): Iterator[NodeType] =
+      traversal.filter { _.index != value }
+
+    /** Traverse to nodes where the index is not equal to any of the given `values`
+      */
+    def indexNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node => !vset.contains(node.index) }
+    }
+
     /** Traverse to nodes where the index is greater than the given `value`
       */
     def indexGt(value: Int): Iterator[NodeType] =
@@ -7459,6 +7695,18 @@ object Accessors {
     def index(values: Int*): Iterator[NodeType] = {
       val vset = values.toSet
       traversal.filter { node => vset.contains(node.index) }
+    }
+
+    /** Traverse to nodes where the index is not equal to the given `value`
+      */
+    def indexNot(value: Int): Iterator[NodeType] =
+      traversal.filter { _.index != value }
+
+    /** Traverse to nodes where the index is not equal to any of the given `values`
+      */
+    def indexNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node => !vset.contains(node.index) }
     }
 
     /** Traverse to nodes where the index is greater than the given `value`
@@ -8868,6 +9116,134 @@ object Accessors {
       traversal.filter { item => matchers.find { _.reset(item.name).matches }.isEmpty }
     }
 
+    /** Traverse to offset property */
+    def offset: Iterator[Int] =
+      traversal.flatMap(_.offset)
+
+    /** Traverse to nodes where the offset equals the given `value`
+      */
+    def offset(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offset; tmp.isDefined && tmp.get == value
+      }
+
+    /** Traverse to nodes where the offset equals at least one of the given `values`
+      */
+    def offset(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.offset; tmp.isDefined && vset.contains(tmp.get)
+      }
+    }
+
+    /** Traverse to nodes where the offset is not equal to the given `value`
+      */
+    def offsetNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offset; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the offset does not equal any one of the given `values`
+      */
+    def offsetNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.offset; tmp.isEmpty || !vset.contains(tmp.get)
+      }
+    }
+
+    /** Traverse to nodes where the offset is greater than the given `value`
+      */
+    def offsetGt(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offset; tmp.isDefined && tmp.get > value
+      }
+
+    /** Traverse to nodes where the offset is greater than or equal the given `value`
+      */
+    def offsetGte(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offset; tmp.isDefined && tmp.get >= value
+      }
+
+    /** Traverse to nodes where the offset is less than the given `value`
+      */
+    def offsetLt(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offset; tmp.isDefined && tmp.get < value
+      }
+
+    /** Traverse to nodes where the offset is less than or equal the given `value`
+      */
+    def offsetLte(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offset; tmp.isDefined && tmp.get <= value
+      }
+
+    /** Traverse to offsetEnd property */
+    def offsetEnd: Iterator[Int] =
+      traversal.flatMap(_.offsetEnd)
+
+    /** Traverse to nodes where the offsetEnd equals the given `value`
+      */
+    def offsetEnd(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offsetEnd; tmp.isDefined && tmp.get == value
+      }
+
+    /** Traverse to nodes where the offsetEnd equals at least one of the given `values`
+      */
+    def offsetEnd(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.offsetEnd; tmp.isDefined && vset.contains(tmp.get)
+      }
+    }
+
+    /** Traverse to nodes where the offsetEnd is not equal to the given `value`
+      */
+    def offsetEndNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offsetEnd; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the offsetEnd does not equal any one of the given `values`
+      */
+    def offsetEndNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.offsetEnd; tmp.isEmpty || !vset.contains(tmp.get)
+      }
+    }
+
+    /** Traverse to nodes where the offsetEnd is greater than the given `value`
+      */
+    def offsetEndGt(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offsetEnd; tmp.isDefined && tmp.get > value
+      }
+
+    /** Traverse to nodes where the offsetEnd is greater than or equal the given `value`
+      */
+    def offsetEndGte(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offsetEnd; tmp.isDefined && tmp.get >= value
+      }
+
+    /** Traverse to nodes where the offsetEnd is less than the given `value`
+      */
+    def offsetEndLt(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offsetEnd; tmp.isDefined && tmp.get < value
+      }
+
+    /** Traverse to nodes where the offsetEnd is less than or equal the given `value`
+      */
+    def offsetEndLte(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.offsetEnd; tmp.isDefined && tmp.get <= value
+      }
+
   }
   final class Traversal_TypeParameterBase[NodeType <: nodes.TypeParameterBase](val traversal: Iterator[NodeType])
       extends AnyVal {
@@ -9271,6 +9647,22 @@ object Accessors {
       }
     }
 
+    /** Traverse to nodes where the columnNumber is not equal to the given `value`
+      */
+    def columnNumberNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.columnNumber; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the columnNumber does not equal any one of the given `values`
+      */
+    def columnNumberNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.columnNumber; tmp.isEmpty || !vset.contains(tmp.get)
+      }
+    }
+
     /** Traverse to nodes where the columnNumber is greater than the given `value`
       */
     def columnNumberGt(value: Int): Iterator[NodeType] =
@@ -9319,6 +9711,22 @@ object Accessors {
       }
     }
 
+    /** Traverse to nodes where the lineNumber is not equal to the given `value`
+      */
+    def lineNumberNot(value: Int): Iterator[NodeType] =
+      traversal.filter { node =>
+        val tmp = node.lineNumber; tmp.isEmpty || tmp.get != value
+      }
+
+    /** Traverse to nodes where the lineNumber does not equal any one of the given `values`
+      */
+    def lineNumberNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node =>
+        val tmp = node.lineNumber; tmp.isEmpty || !vset.contains(tmp.get)
+      }
+    }
+
     /** Traverse to nodes where the lineNumber is greater than the given `value`
       */
     def lineNumberGt(value: Int): Iterator[NodeType] =
@@ -9361,6 +9769,18 @@ object Accessors {
     def order(values: Int*): Iterator[NodeType] = {
       val vset = values.toSet
       traversal.filter { node => vset.contains(node.order) }
+    }
+
+    /** Traverse to nodes where the order is not equal to the given `value`
+      */
+    def orderNot(value: Int): Iterator[NodeType] =
+      traversal.filter { _.order != value }
+
+    /** Traverse to nodes where the order is not equal to any of the given `values`
+      */
+    def orderNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node => !vset.contains(node.order) }
     }
 
     /** Traverse to nodes where the order is greater than the given `value`
@@ -9523,6 +9943,18 @@ object Accessors {
     def argumentIndex(values: Int*): Iterator[NodeType] = {
       val vset = values.toSet
       traversal.filter { node => vset.contains(node.argumentIndex) }
+    }
+
+    /** Traverse to nodes where the argumentIndex is not equal to the given `value`
+      */
+    def argumentIndexNot(value: Int): Iterator[NodeType] =
+      traversal.filter { _.argumentIndex != value }
+
+    /** Traverse to nodes where the argumentIndex is not equal to any of the given `values`
+      */
+    def argumentIndexNot(values: Int*): Iterator[NodeType] = {
+      val vset = values.toSet
+      traversal.filter { node => !vset.contains(node.argumentIndex) }
     }
 
     /** Traverse to nodes where the argumentIndex is greater than the given `value`

--- a/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/nodes/TypeDecl.scala
+++ b/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/nodes/TypeDecl.scala
@@ -14,6 +14,8 @@ trait TypeDeclEMT
     with HasInheritsFromTypeFullNameEMT
     with HasIsExternalEMT
     with HasNameEMT
+    with HasOffsetEMT
+    with HasOffsetEndEMT
 
 trait TypeDeclBase extends AbstractNode with AstNodeBase with StaticType[TypeDeclEMT] {
 
@@ -32,6 +34,8 @@ trait TypeDeclBase extends AbstractNode with AstNodeBase with StaticType[TypeDec
     res.put("IS_EXTERNAL", this.isExternal)
     this.lineNumber.foreach { p => res.put("LINE_NUMBER", p) }
     res.put("NAME", this.name)
+    this.offset.foreach { p => res.put("OFFSET", p) }
+    this.offsetEnd.foreach { p => res.put("OFFSET_END", p) }
     res.put("ORDER", this.order)
     res
   }
@@ -51,6 +55,8 @@ object TypeDecl {
     val IsExternal = io.shiftleft.codepropertygraph.generated.PropertyNames.IS_EXTERNAL
     val LineNumber = io.shiftleft.codepropertygraph.generated.PropertyNames.LINE_NUMBER
     val Name = io.shiftleft.codepropertygraph.generated.PropertyNames.NAME
+    val Offset = io.shiftleft.codepropertygraph.generated.PropertyNames.OFFSET
+    val OffsetEnd = io.shiftleft.codepropertygraph.generated.PropertyNames.OFFSET_END
     val Order = io.shiftleft.codepropertygraph.generated.PropertyNames.ORDER
   }
   object PropertyDefaults {
@@ -84,7 +90,9 @@ class TypeDecl(graph_4762: flatgraph.Graph, seq_4762: Int)
       case 8  => "isExternal"
       case 9  => "lineNumber"
       case 10 => "name"
-      case 11 => "order"
+      case 11 => "offset"
+      case 12 => "offsetEnd"
+      case 13 => "order"
       case _  => ""
     }
 
@@ -101,12 +109,14 @@ class TypeDecl(graph_4762: flatgraph.Graph, seq_4762: Int)
       case 8  => this.isExternal
       case 9  => this.lineNumber
       case 10 => this.name
-      case 11 => this.order
+      case 11 => this.offset
+      case 12 => this.offsetEnd
+      case 13 => this.order
       case _  => null
     }
 
   override def productPrefix = "TypeDecl"
-  override def productArity = 12
+  override def productArity = 14
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[TypeDecl]
 }
@@ -1369,6 +1379,8 @@ class NewTypeDecl extends NewNode(40.toShort) with TypeDeclBase with AstNodeNew 
   var isExternal: Boolean = false: Boolean
   var lineNumber: Option[Int] = None
   var name: String = "<empty>": String
+  var offset: Option[Int] = None
+  var offsetEnd: Option[Int] = None
   var order: Int = -1: Int
   def aliasTypeFullName(value: Option[String]): this.type = { this.aliasTypeFullName = value; this }
   def aliasTypeFullName(value: String): this.type = { this.aliasTypeFullName = Option(value); this }
@@ -1386,6 +1398,10 @@ class NewTypeDecl extends NewNode(40.toShort) with TypeDeclBase with AstNodeNew 
   def lineNumber(value: Int): this.type = { this.lineNumber = Option(value); this }
   def lineNumber(value: Option[Int]): this.type = { this.lineNumber = value; this }
   def name(value: String): this.type = { this.name = value; this }
+  def offset(value: Int): this.type = { this.offset = Option(value); this }
+  def offset(value: Option[Int]): this.type = { this.offset = value; this }
+  def offsetEnd(value: Int): this.type = { this.offsetEnd = Option(value); this }
+  def offsetEnd(value: Option[Int]): this.type = { this.offsetEnd = value; this }
   def order(value: Int): this.type = { this.order = value; this }
   override def flattenProperties(interface: flatgraph.BatchedUpdateInterface): Unit = {
     if (aliasTypeFullName.nonEmpty) interface.insertProperty(this, 0, this.aliasTypeFullName)
@@ -1399,6 +1415,8 @@ class NewTypeDecl extends NewNode(40.toShort) with TypeDeclBase with AstNodeNew 
     interface.insertProperty(this, 29, Iterator(this.isExternal))
     if (lineNumber.nonEmpty) interface.insertProperty(this, 34, this.lineNumber)
     interface.insertProperty(this, 39, Iterator(this.name))
+    if (offset.nonEmpty) interface.insertProperty(this, 41, this.offset)
+    if (offsetEnd.nonEmpty) interface.insertProperty(this, 42, this.offsetEnd)
     interface.insertProperty(this, 43, Iterator(this.order))
   }
 
@@ -1415,6 +1433,8 @@ class NewTypeDecl extends NewNode(40.toShort) with TypeDeclBase with AstNodeNew 
     newInstance.isExternal = this.isExternal
     newInstance.lineNumber = this.lineNumber
     newInstance.name = this.name
+    newInstance.offset = this.offset
+    newInstance.offsetEnd = this.offsetEnd
     newInstance.order = this.order
     newInstance.asInstanceOf[this.type]
   }
@@ -1432,7 +1452,9 @@ class NewTypeDecl extends NewNode(40.toShort) with TypeDeclBase with AstNodeNew 
       case 8  => "isExternal"
       case 9  => "lineNumber"
       case 10 => "name"
-      case 11 => "order"
+      case 11 => "offset"
+      case 12 => "offsetEnd"
+      case 13 => "order"
       case _  => ""
     }
 
@@ -1449,11 +1471,13 @@ class NewTypeDecl extends NewNode(40.toShort) with TypeDeclBase with AstNodeNew 
       case 8  => this.isExternal
       case 9  => this.lineNumber
       case 10 => this.name
-      case 11 => this.order
+      case 11 => this.offset
+      case 12 => this.offsetEnd
+      case 13 => this.order
       case _  => null
     }
 
   override def productPrefix = "NewTypeDecl"
-  override def productArity = 12
+  override def productArity = 14
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[NewTypeDecl]
 }


### PR DESCRIPTION
* e.g. Expression.orderNot - to match what overflowdb generated
* also note that I reversed (fixed) the logic for two of the 'equals' cases