### PR TITLE
add functionality to clone graphs (important for unit test performance)

### DIFF
--- a/core/src/main/scala/flatgraph/DiffGraphApplier.scala
+++ b/core/src/main/scala/flatgraph/DiffGraphApplier.scala
@@ -407,8 +407,12 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder) 
     val size   = graph.neighbors(pos + 1).asInstanceOf[Array[GNode]].size
     val oldQty = graph.neighbors(pos).asInstanceOf[Array[Int]]
     val edgeProp = graph.neighbors(pos + 2) match {
-      case _: DefaultValue => graph.schema.allocateEdgeProperty(nodeKind, direction, edgeKind, size)
-      case other: Array[_] => other.clone() // this is not strictly necessary, but everything else is copy-on-write
+      case _: DefaultValue =>
+        graph.schema.allocateEdgeProperty(nodeKind, direction, edgeKind, size)
+      case other =>
+        other
+        // ^ change this once we switch away from full copy-on-write, see e.g.
+        // https://github.com/joernio/flatgraph/pull/163#discussion_r1537246314
     }
     val propview = mutable.ArraySeq.make(edgeProp.asInstanceOf[Array[_]]).asInstanceOf[mutable.ArraySeq[Any]]
     // this will fail if the edge doesn't support properties. todo: better error message

--- a/core/src/main/scala/flatgraph/DiffGraphApplier.scala
+++ b/core/src/main/scala/flatgraph/DiffGraphApplier.scala
@@ -411,8 +411,8 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder) 
         graph.schema.allocateEdgeProperty(nodeKind, direction, edgeKind, size)
       case other =>
         other
-        // ^ change this once we switch away from full copy-on-write, see e.g.
-        // https://github.com/joernio/flatgraph/pull/163#discussion_r1537246314
+      // ^ change this once we switch away from full copy-on-write, see e.g.
+      // https://github.com/joernio/flatgraph/pull/163#discussion_r1537246314
     }
     val propview = mutable.ArraySeq.make(edgeProp.asInstanceOf[Array[_]]).asInstanceOf[mutable.ArraySeq[Any]]
     // this will fail if the edge doesn't support properties. todo: better error message

--- a/core/src/main/scala/flatgraph/DiffGraphApplier.scala
+++ b/core/src/main/scala/flatgraph/DiffGraphApplier.scala
@@ -408,7 +408,7 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder) 
     val oldQty = graph.neighbors(pos).asInstanceOf[Array[Int]]
     val edgeProp = graph.neighbors(pos + 2) match {
       case _: DefaultValue => graph.schema.allocateEdgeProperty(nodeKind, direction, edgeKind, size)
-      case other           => other
+      case other: Array[_] => other.clone() // this is not strictly necessary, but everything else is copy-on-write
     }
     val propview = mutable.ArraySeq.make(edgeProp.asInstanceOf[Array[_]]).asInstanceOf[mutable.ArraySeq[Any]]
     // this will fail if the edge doesn't support properties. todo: better error message

--- a/core/src/main/scala/flatgraph/Graph.scala
+++ b/core/src/main/scala/flatgraph/Graph.scala
@@ -35,10 +35,9 @@ object Graph {
       Graph(schema, storagePathMaybe)
     }
   }
-
 }
 
-class Graph(val schema: Schema, var storagePathMaybe: Option[Path] = None) extends AutoCloseable {
+class Graph(val schema: Schema, val storagePathMaybe: Option[Path] = None) extends AutoCloseable {
   private val nodeKindCount   = schema.getNumberOfNodeKinds
   private val edgeKindCount   = schema.getNumberOfEdgeKinds
   private val propertiesCount = schema.getNumberOfProperties
@@ -146,13 +145,6 @@ class Graph(val schema: Schema, var storagePathMaybe: Option[Path] = None) exten
   }
 
   def cloneDataFrom(other: Graph): this.type = {
-    // we might want to implement cloning from different schemas in the future.
-    if (!this.schema.equals(other.schema)) throw new RuntimeException("Can currently clone only from graph with same schema")
-    if (this.nodesArray.exists(_.length > 0)) throw new RuntimeException("Can currently only clone into empty graphs")
-
-    // we also might want to implement cloning from different Graph subclasses in the future. These should do their thing and
-    // then call super.cloneDataFrom.
-
     for (kind <- Range(0, schema.getNumberOfNodeKinds)) {
       val arr = other.nodesArray(kind).clone()
       this.nodesArray(kind) = arr

--- a/core/src/main/scala/flatgraph/Graph.scala
+++ b/core/src/main/scala/flatgraph/Graph.scala
@@ -144,33 +144,4 @@ class Graph(val schema: Schema, val storagePathMaybe: Option[Path] = None) exten
     }
   }
 
-  def cloneDataFrom(other: Graph): this.type = {
-    for (kind <- Range(0, schema.getNumberOfNodeKinds)) {
-      val arr = other.nodesArray(kind).clone()
-      this.nodesArray(kind) = arr
-      arr.mapInPlace { old =>
-        val n = schema.makeNode(this, old.nodeKind, old.seq())
-        if (AccessHelpers.isDeleted(old)) AccessHelpers.markDeleted(n)
-        n
-      }
-    }
-
-    def cloneThing(item: AnyRef): AnyRef = item match {
-      case null => null
-      case a: Array[GNode] =>
-        a.clone().mapInPlace { oldNode =>
-          if (oldNode == null) null else this.nodesArray(oldNode.nodeKind)(oldNode.seq())
-        }
-      case other => other
-    }
-    // adjust that once we do diffgraph applications in-place
-    for (idx <- Range(0, this.properties.length))
-      this.properties(idx) = cloneThing(other.properties(idx))
-    for (idx <- Range(0, this.neighbors.length))
-      this.neighbors(idx) = cloneThing(other.neighbors(idx))
-    java.lang.System.arraycopy(other.livingNodeCountByKind, 0, this.livingNodeCountByKind, 0, this.livingNodeCountByKind.length)
-
-    this
-  }
-
 }

--- a/core/src/main/scala/flatgraph/misc/TestUtils.scala
+++ b/core/src/main/scala/flatgraph/misc/TestUtils.scala
@@ -2,6 +2,8 @@ package flatgraph.misc
 
 import flatgraph.*
 
+import java.nio.file.Path
+
 /** Convenience functions for common use test use-cases. Context: applying a Diff */
 object TestUtils {
 
@@ -23,6 +25,39 @@ object TestUtils {
       applyDiff(_.addNode(node))
       node.storedRef.get
     }
+
+    def copy(storagePathMaybe: Option[Path] = None): Graph = {
+      val schema = graph.schema
+      val newGraph = new Graph(schema, storagePathMaybe)
+      
+      for (kind <- Range(0, schema.getNumberOfNodeKinds)) {
+        newGraph.nodesArray(kind) = graph.nodesArray(kind).clone()
+        newGraph.nodesArray(kind).mapInPlace { oldNode =>
+          val newNode = schema.makeNode(newGraph, oldNode.nodeKind, oldNode.seq())
+          if (AccessHelpers.isDeleted(oldNode)) AccessHelpers.markDeleted(newNode)
+          newNode
+        }
+      }
+
+      def cloneThing(item: AnyRef): AnyRef = item match {
+        case null => null
+        case a: Array[GNode] =>
+          a.clone().mapInPlace { oldNode =>
+            if (oldNode == null) null 
+            else graph.nodesArray(oldNode.nodeKind)(oldNode.seq())
+          }
+        case other => other
+      }
+      // adjust that once we do diffgraph applications in-place
+      for (idx <- Range(0, graph.properties.length))
+        graph.properties(idx) = cloneThing(newGraph.properties(idx))
+      for (idx <- Range(0, graph.neighbors.length))
+        graph.neighbors(idx) = cloneThing(newGraph.neighbors(idx))
+      java.lang.System.arraycopy(newGraph.livingNodeCountByKind, 0, graph.livingNodeCountByKind, 0, graph.livingNodeCountByKind.length)
+
+      newGraph
+    }
+
   }
 
 }

--- a/core/src/main/scala/flatgraph/misc/TestUtils.scala
+++ b/core/src/main/scala/flatgraph/misc/TestUtils.scala
@@ -29,7 +29,7 @@ object TestUtils {
     def copy(storagePathMaybe: Option[Path] = None): Graph = {
       val schema = graph.schema
       val newGraph = new Graph(schema, storagePathMaybe)
-      
+
       for (kind <- Range(0, schema.getNumberOfNodeKinds)) {
         newGraph.nodesArray(kind) = graph.nodesArray(kind).clone()
         newGraph.nodesArray(kind).mapInPlace { oldNode =>
@@ -43,17 +43,20 @@ object TestUtils {
         case null => null
         case a: Array[GNode] =>
           a.clone().mapInPlace { oldNode =>
-            if (oldNode == null) null 
-            else graph.nodesArray(oldNode.nodeKind)(oldNode.seq())
+            if (oldNode == null) null
+            else newGraph.nodesArray(oldNode.nodeKind)(oldNode.seq())
           }
-        case other => other
+        case a: Array[_] =>
+          a.clone()
+        case other =>
+          other
       }
       // adjust that once we do diffgraph applications in-place
       for (idx <- Range(0, graph.properties.length))
-        graph.properties(idx) = cloneThing(newGraph.properties(idx))
+        newGraph.properties(idx) = cloneThing(graph.properties(idx))
       for (idx <- Range(0, graph.neighbors.length))
-        graph.neighbors(idx) = cloneThing(newGraph.neighbors(idx))
-      java.lang.System.arraycopy(newGraph.livingNodeCountByKind, 0, graph.livingNodeCountByKind, 0, graph.livingNodeCountByKind.length)
+        newGraph.neighbors(idx) = cloneThing(graph.neighbors(idx))
+      System.arraycopy(graph.livingNodeCountByKind, 0, newGraph.livingNodeCountByKind, 0, graph.livingNodeCountByKind.length)
 
       newGraph
     }

--- a/core/src/main/scala/flatgraph/misc/TestUtils.scala
+++ b/core/src/main/scala/flatgraph/misc/TestUtils.scala
@@ -27,7 +27,7 @@ object TestUtils {
     }
 
     def copy(storagePathMaybe: Option[Path] = None): Graph = {
-      val schema = graph.schema
+      val schema   = graph.schema
       val newGraph = new Graph(schema, storagePathMaybe)
 
       for (kind <- Range(0, schema.getNumberOfNodeKinds)) {

--- a/core/src/test/scala/flatgraph/GraphTests.scala
+++ b/core/src/test/scala/flatgraph/GraphTests.scala
@@ -6,6 +6,7 @@ import flatgraph.misc.DebugDump.debugDump
 import flatgraph.storage.Deserialization
 import flatgraph.storage.Deserialization.DeserializationException
 import flatgraph.traversal.Language.*
+import flatgraph.util.DiffToolTests
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.should.Matchers.shouldBe
 import org.scalatest.wordspec.AnyWordSpec
@@ -999,5 +1000,42 @@ class GraphTests extends AnyWordSpec with Matchers {
         assertThrows[DeserializationException](Deserialization.readGraph(storagePath, None))
       }
     }
+  }
+
+  "copying a graph" in {
+    import flatgraph.misc.TestUtils.copy
+
+    val graph = DiffToolTests.makeSampleGraph()
+    val debugDumpOriginalGraph = debugDump(graph)
+    debugDumpOriginalGraph shouldBe
+      """#Node numbers (kindId, nnodes) (0: 2), total 2
+        |Node kind 0. (eid, nEdgesOut, nEdgesIn): (0, 1 [dense], 1 [dense]),
+        |   V0_0       : 0: [A], 1: [40]
+        |   V0_0   [0] -> (edgePropertyValue) V0_1
+        |   V0_1       : 0: [X, Y], 1: [50, 51]
+        |   V0_1   [0] <- (edgePropertyValue) V0_0
+        |""".stripMargin
+
+    val graphCopy = graph.copy()
+    debugDump(graph) shouldBe debugDump(graphCopy)
+
+    // make some changes only to the graph copy
+    val v0 = graphCopy.node(kind = 0, seq = 0)
+    val edge = Accessors.getEdgesOut(v0).head
+    DiffGraphApplier.applyDiff(graphCopy, new DiffGraphBuilder(DiffToolTests.sampleSchema)
+      .setNodeProperty(v0, "0", "updatedNodeProperty")
+      .setEdgeProperty(edge, "updatedEdgeProperty")
+    )
+    debugDump(graphCopy) shouldBe
+      """#Node numbers (kindId, nnodes) (0: 2), total 2
+        |Node kind 0. (eid, nEdgesOut, nEdgesIn): (0, 1 [dense], 1 [dense]),
+        |   V0_0       : 0: [updatedNodeProperty], 1: [40]
+        |   V0_0   [0] -> (updatedEdgeProperty) V0_1
+        |   V0_1       : 0: [X, Y], 1: [50, 51]
+        |   V0_1   [0] <- (updatedEdgeProperty) V0_0
+        |""".stripMargin
+
+    // original graph should be untouched
+    debugDump(graph) shouldBe debugDumpOriginalGraph
   }
 }

--- a/core/src/test/scala/flatgraph/GraphTests.scala
+++ b/core/src/test/scala/flatgraph/GraphTests.scala
@@ -1005,7 +1005,7 @@ class GraphTests extends AnyWordSpec with Matchers {
   "copying a graph" in {
     import flatgraph.misc.TestUtils.copy
 
-    val graph = DiffToolTests.makeSampleGraph()
+    val graph                  = DiffToolTests.makeSampleGraph()
     val debugDumpOriginalGraph = debugDump(graph)
     debugDumpOriginalGraph shouldBe
       """#Node numbers (kindId, nnodes) (0: 2), total 2
@@ -1020,11 +1020,13 @@ class GraphTests extends AnyWordSpec with Matchers {
     debugDump(graph) shouldBe debugDump(graphCopy)
 
     // make some changes only to the graph copy
-    val v0 = graphCopy.node(kind = 0, seq = 0)
+    val v0   = graphCopy.node(kind = 0, seq = 0)
     val edge = Accessors.getEdgesOut(v0).head
-    DiffGraphApplier.applyDiff(graphCopy, new DiffGraphBuilder(DiffToolTests.sampleSchema)
-      .setNodeProperty(v0, "0", "updatedNodeProperty")
-      .setEdgeProperty(edge, "updatedEdgeProperty")
+    DiffGraphApplier.applyDiff(
+      graphCopy,
+      new DiffGraphBuilder(DiffToolTests.sampleSchema)
+        .setNodeProperty(v0, "0", "updatedNodeProperty")
+        .setEdgeProperty(edge, "updatedEdgeProperty")
     )
     debugDump(graphCopy) shouldBe
       """#Node numbers (kindId, nnodes) (0: 2), total 2

--- a/core/src/test/scala/flatgraph/TestHelpers.scala
+++ b/core/src/test/scala/flatgraph/TestHelpers.scala
@@ -3,6 +3,7 @@ package flatgraph
 import flatgraph.TestHelpers.withTemporaryFile
 import flatgraph.misc.DebugDump.debugDump
 import flatgraph.misc.Conversions.toShortSafely
+import flatgraph.misc.TestUtils.copy
 import flatgraph.storage.{Deserialization, Serialization}
 import org.scalatest.matchers.should.Matchers.shouldBe
 
@@ -49,8 +50,8 @@ object TestSchema {
       val deserialized = Deserialization.readGraph(storagePath, Option(graph.schema))
       val newDump      = debugDump(deserialized)
       originalDump shouldBe newDump
-      // we also test cloning.
-      val cloned    = new Graph(graph.schema).cloneDataFrom(graph)
+
+      val cloned    = graph.copy()
       val cloneDump = debugDump(cloned)
       originalDump shouldBe cloneDump
     }

--- a/core/src/test/scala/flatgraph/TestHelpers.scala
+++ b/core/src/test/scala/flatgraph/TestHelpers.scala
@@ -49,6 +49,10 @@ object TestSchema {
       val deserialized = Deserialization.readGraph(storagePath, Option(graph.schema))
       val newDump      = debugDump(deserialized)
       originalDump shouldBe newDump
+      // we also test cloning.
+      val cloned    = new Graph(graph.schema).cloneDataFrom(graph)
+      val cloneDump = debugDump(cloned)
+      originalDump shouldBe cloneDump
     }
   }
 

--- a/core/src/test/scala/flatgraph/util/DiffToolTests.scala
+++ b/core/src/test/scala/flatgraph/util/DiffToolTests.scala
@@ -9,6 +9,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import scala.jdk.CollectionConverters.*
 
 class DiffToolTests extends AnyWordSpec {
+  import DiffToolTests.makeSampleGraph
 
   "detects zero changes for the same (identity) graph" in {
     val graph = makeSampleGraph()
@@ -88,29 +89,33 @@ class DiffToolTests extends AnyWordSpec {
     diff should contain("node flatgraph.GNode[label=V0; id=0] only exists in graph1")
   }
 
-  private def makeSampleGraph(): Graph = {
-    val schema = TestSchema.make(
-      nodeKinds = 1,
-      edgeKinds = 1,
-      properties = 2,
-      nodePropertyPrototypes = Array(Array.empty[String], Array.emptyShortArray),
-      edgePropertyPrototypes = Array(Array.empty[String])
-    )
-    val graph = new Graph(schema)
+}
+
+object DiffToolTests {
+  val sampleSchema = TestSchema.make(
+    nodeKinds = 1,
+    edgeKinds = 1,
+    properties = 2,
+    nodePropertyPrototypes = Array(Array.empty[String], Array.emptyShortArray),
+    edgePropertyPrototypes = Array(Array.empty[String])
+  )
+
+  def makeSampleGraph(): Graph = {
+    val graph = new Graph(sampleSchema)
 
     val v0 = new GenericDNode(0)
     val v1 = new GenericDNode(0)
 
-    DiffGraphApplier.applyDiff(graph, new DiffGraphBuilder(schema)._addEdge(v0, v1, 0, "edgePropertyValue"))
+    DiffGraphApplier.applyDiff(graph, new DiffGraphBuilder(sampleSchema)._addEdge(v0, v1, 0, "edgePropertyValue"))
     DiffGraphApplier.applyDiff(
       graph,
-      new DiffGraphBuilder(schema)
+      new DiffGraphBuilder(sampleSchema)
         ._setNodeProperty(v0.storedRef.get, 0, "A")
         ._setNodeProperty(v1.storedRef.get, 0, Seq("X", "Y"))
         ._setNodeProperty(v0.storedRef.get, 1, 40.toShort)
         ._setNodeProperty(v1.storedRef.get, 1, Seq(50.toShort, 51.toShort))
     )
-//    println(debugDump(graph))
+    //    println(debugDump(graph))
     debugDump(graph) shouldBe
       """#Node numbers (kindId, nnodes) (0: 2), total 2
         |Node kind 0. (eid, nEdgesOut, nEdgesIn): (0, 1 [dense], 1 [dense]),
@@ -122,5 +127,4 @@ class DiffToolTests extends AnyWordSpec {
     testSerialization(graph)
     graph
   }
-
 }


### PR DESCRIPTION
Alternative proposal to https://github.com/joernio/flatgraph/pull/162
I moved a few things around and refactored for readability. Main difference in API is that rather than
`graph.copyDataFrom(other: Graph)` 
this does
`graph.copy(): Graph`