### PR TITLE
fixup: on last PR i forgot to update the codegen

### DIFF
--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
@@ -632,7 +632,7 @@ class DomainClassesGenerator(schema: Schema) {
          |  }
          |
          |  override def getPropertyKindByName(label: String): Int = nodePropertyByLabel.getOrElse(label, flatgraph.Schema.UndefinedKind)
-         |  override def getNumberOfProperties: Int = ${relevantProperties.size + containedNames.size}
+         |  override def getNumberOfPropertyKinds: Int = ${relevantProperties.size + containedNames.size}
          |  override def makeNode(graph: flatgraph.Graph, nodeKind: Short, seq: Int): nodes.StoredNode = nodeFactories(nodeKind)(graph, seq)
          |  override def makeEdge(src: flatgraph.GNode, dst: flatgraph.GNode, edgeKind: Short, subSeq: Int, property: Any): flatgraph.Edge = edgeFactories(edgeKind)(src, dst, subSeq, property)
          |  override def allocateEdgeProperty(nodeKind: Int, direction: flatgraph.Edge.Direction, edgeKind: Int, size: Int): Array[?] = edgePropertyAllocators(edgeKind)(size)


### PR DESCRIPTION
n.b. regenerating the domain classes with this has a dependency
resolution issue, it picks the old codegen. Not sure why, but since we
don't really need the full cpg domain classes committed here I'll take
that as a trigger to setup a simplified sample schema here which is
independent of cpg...