### PR TITLE
neighbor types: take inherited neighbors into account

### DIFF
--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
@@ -1053,16 +1053,8 @@ class DomainClassesGenerator(schema: Schema) {
 
       val neighborContextsByEdge: Seq[NeighborContextsByEdge] =
         Direction.all.flatMap { direction =>
-          // to ensure we generate each `neighborViaEdgeDirection` step only once for each node type hierarchy tree, only generate it for the highest-up node type
-          // this is to avoid any 'presumably' duplicate steps, which would cause to unambiguous implicits
-          val inheritedNeighbors = nodeType.extendzRecursively
-            .flatMap(_.edges(direction))
-            .map(adjacentNode => (adjacentNode.viaEdge, adjacentNode.neighbor))
-            .toSet
-
           nodeType
             .edges(direction)
-            .filterNot(adjacentNode => inheritedNeighbors.contains((adjacentNode.viaEdge, adjacentNode.neighbor)))
             .groupBy(_.viaEdge)
             .map { case (edge, adjacentNodes) =>
               val neighborContexts = adjacentNodes.map { adjacentNode =>

--- a/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/GraphSchema.scala
+++ b/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/GraphSchema.scala
@@ -933,7 +933,7 @@ object GraphSchema extends flatgraph.Schema {
 
   override def getPropertyKindByName(label: String): Int =
     nodePropertyByLabel.getOrElse(label, flatgraph.Schema.UndefinedKind)
-  override def getNumberOfProperties: Int = 59
+  override def getNumberOfPropertyKinds: Int = 59
   override def makeNode(graph: flatgraph.Graph, nodeKind: Short, seq: Int): nodes.StoredNode =
     nodeFactories(nodeKind)(graph, seq)
   override def makeEdge(

--- a/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/neighboraccessors/Call.scala
+++ b/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/neighboraccessors/Call.scala
@@ -185,6 +185,10 @@ final class AccessNeighborsForCall(val node: nodes.Call) extends AnyVal {
     */
   def fieldIdentifierViaCdgOut: Iterator[nodes.FieldIdentifier] = cdgOut.collectAll[nodes.FieldIdentifier]
 
+  /** Traverse to FIELD_IDENTIFIER via CFG IN edge.
+    */
+  def fieldIdentifierViaCfgIn: Option[nodes.FieldIdentifier] = cfgIn.collectAll[nodes.FieldIdentifier].nextOption()
+
   /** Traverse to FIELD_IDENTIFIER via DOMINATE IN edge.
     */
   def fieldIdentifierViaDominateIn: Iterator[nodes.FieldIdentifier] = dominateIn.collectAll[nodes.FieldIdentifier]
@@ -565,6 +569,8 @@ final class AccessNeighborsForCall(val node: nodes.Call) extends AnyVal {
 
   def cdgOut: Iterator[nodes.CfgNode] = node._cdgOut.cast[nodes.CfgNode]
 
+  def cfgIn: Iterator[nodes.FieldIdentifier] = node._cfgIn.cast[nodes.FieldIdentifier]
+
   def cfgOut: Iterator[nodes.CfgNode] = node._cfgOut.cast[nodes.CfgNode]
 
   def conditionIn: Iterator[nodes.ControlStructure] = node._conditionIn.cast[nodes.ControlStructure]
@@ -774,6 +780,10 @@ final class AccessNeighborsForCallTraversal(val traversal: Iterator[nodes.Call])
   /** Traverse to FIELD_IDENTIFIER via CDG OUT edge.
     */
   def fieldIdentifierViaCdgOut: Iterator[nodes.FieldIdentifier] = traversal.flatMap(_.fieldIdentifierViaCdgOut)
+
+  /** Traverse to FIELD_IDENTIFIER via CFG IN edge.
+    */
+  def fieldIdentifierViaCfgIn: Iterator[nodes.FieldIdentifier] = traversal.flatMap(_.fieldIdentifierViaCfgIn)
 
   /** Traverse to FIELD_IDENTIFIER via DOMINATE IN edge.
     */
@@ -1155,6 +1165,8 @@ final class AccessNeighborsForCallTraversal(val traversal: Iterator[nodes.Call])
   def cdgIn: Iterator[nodes.CfgNode] = traversal.flatMap(_.cdgIn)
 
   def cdgOut: Iterator[nodes.CfgNode] = traversal.flatMap(_.cdgOut)
+
+  def cfgIn: Iterator[nodes.FieldIdentifier] = traversal.flatMap(_.cfgIn)
 
   def cfgOut: Iterator[nodes.CfgNode] = traversal.flatMap(_.cfgOut)
 

--- a/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/neighboraccessors/MethodReturn.scala
+++ b/joern-generated/src/main/scala/io/shiftleft/codepropertygraph/generated/neighboraccessors/MethodReturn.scala
@@ -100,6 +100,10 @@ final class AccessNeighborsForMethodReturn(val node: nodes.MethodReturn) extends
     }
   }
 
+  /** Traverse to METHOD via CFG IN edge.
+    */
+  def methodViaCfgIn: Option[nodes.Method] = cfgIn.collectAll[nodes.Method].nextOption()
+
   /** Traverse to METHOD via DOMINATE IN edge.
     */
   def methodViaDominateIn: Iterator[nodes.Method] = dominateIn.collectAll[nodes.Method]
@@ -111,6 +115,10 @@ final class AccessNeighborsForMethodReturn(val node: nodes.MethodReturn) extends
   /** Traverse to METHOD_REF via CDG IN edge.
     */
   def methodRefViaCdgIn: Iterator[nodes.MethodRef] = cdgIn.collectAll[nodes.MethodRef]
+
+  /** Traverse to METHOD_REF via CFG IN edge.
+    */
+  def methodRefViaCfgIn: Iterator[nodes.MethodRef] = cfgIn.collectAll[nodes.MethodRef]
 
   /** Traverse to METHOD_REF via DOMINATE IN edge.
     */
@@ -153,6 +161,10 @@ final class AccessNeighborsForMethodReturn(val node: nodes.MethodReturn) extends
     */
   def typeRefViaCdgIn: Iterator[nodes.TypeRef] = cdgIn.collectAll[nodes.TypeRef]
 
+  /** Traverse to TYPE_REF via CFG IN edge.
+    */
+  def typeRefViaCfgIn: Iterator[nodes.TypeRef] = cfgIn.collectAll[nodes.TypeRef]
+
   /** Traverse to TYPE_REF via DOMINATE IN edge.
     */
   def typeRefViaDominateIn: Iterator[nodes.TypeRef] = dominateIn.collectAll[nodes.TypeRef]
@@ -177,7 +189,7 @@ final class AccessNeighborsForMethodReturn(val node: nodes.MethodReturn) extends
 
   def cdgIn: Iterator[nodes.CfgNode] = node._cdgIn.cast[nodes.CfgNode]
 
-  def cfgIn: Iterator[nodes.Return] = node._cfgIn.cast[nodes.Return]
+  def cfgIn: Iterator[nodes.CfgNode] = node._cfgIn.cast[nodes.CfgNode]
 
   def dominateIn: Iterator[nodes.CfgNode] = node._dominateIn.cast[nodes.CfgNode]
 
@@ -279,6 +291,10 @@ final class AccessNeighborsForMethodReturnTraversal(val traversal: Iterator[node
     */
   def methodViaAstIn: Iterator[nodes.Method] = traversal.map(_.methodViaAstIn)
 
+  /** Traverse to METHOD via CFG IN edge.
+    */
+  def methodViaCfgIn: Iterator[nodes.Method] = traversal.flatMap(_.methodViaCfgIn)
+
   /** Traverse to METHOD via DOMINATE IN edge.
     */
   def methodViaDominateIn: Iterator[nodes.Method] = traversal.flatMap(_.methodViaDominateIn)
@@ -290,6 +306,10 @@ final class AccessNeighborsForMethodReturnTraversal(val traversal: Iterator[node
   /** Traverse to METHOD_REF via CDG IN edge.
     */
   def methodRefViaCdgIn: Iterator[nodes.MethodRef] = traversal.flatMap(_.methodRefViaCdgIn)
+
+  /** Traverse to METHOD_REF via CFG IN edge.
+    */
+  def methodRefViaCfgIn: Iterator[nodes.MethodRef] = traversal.flatMap(_.methodRefViaCfgIn)
 
   /** Traverse to METHOD_REF via DOMINATE IN edge.
     */
@@ -332,6 +352,10 @@ final class AccessNeighborsForMethodReturnTraversal(val traversal: Iterator[node
     */
   def typeRefViaCdgIn: Iterator[nodes.TypeRef] = traversal.flatMap(_.typeRefViaCdgIn)
 
+  /** Traverse to TYPE_REF via CFG IN edge.
+    */
+  def typeRefViaCfgIn: Iterator[nodes.TypeRef] = traversal.flatMap(_.typeRefViaCfgIn)
+
   /** Traverse to TYPE_REF via DOMINATE IN edge.
     */
   def typeRefViaDominateIn: Iterator[nodes.TypeRef] = traversal.flatMap(_.typeRefViaDominateIn)
@@ -356,7 +380,7 @@ final class AccessNeighborsForMethodReturnTraversal(val traversal: Iterator[node
 
   def cdgIn: Iterator[nodes.CfgNode] = traversal.flatMap(_.cdgIn)
 
-  def cfgIn: Iterator[nodes.Return] = traversal.flatMap(_.cfgIn)
+  def cfgIn: Iterator[nodes.CfgNode] = traversal.flatMap(_.cfgIn)
 
   def dominateIn: Iterator[nodes.CfgNode] = traversal.flatMap(_.dominateIn)
 


### PR DESCRIPTION
This part of the codegen was different to overflowdb up until now, and
unfortunately problems only became evident when porting codescience.
Specifically: `MethodReturn.cfgIn` must return an `Iterator[CfgNode]`, rather
than an `Iterator[Return]` as it was before this PR.