### PR TITLE
schema-conflicting node properties: only warn, don't error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,10 @@ lazy val tests = project
   .settings(
     name := "flatgraph-tests",
     publish / skip := true,
-    libraryDependencies += "com.github.pathikrit" %% "better-files" % "3.9.2" % Test,
+    libraryDependencies ++= Seq(
+      "com.github.pathikrit" %% "better-files" % "3.9.2" % Test,
+      "org.scalamock" %% "scalamock" % "6.0.0" % Test
+    ),
     Test/compile := (Test/compile).dependsOn(testSchemas/generateDomainClassesForTestSchemas).value,
   )
 

--- a/core/src/main/scala/flatgraph/DiffGraphApplier.scala
+++ b/core/src/main/scala/flatgraph/DiffGraphApplier.scala
@@ -8,7 +8,11 @@ import flatgraph.misc.SchemaViolationReporter
 import scala.collection.{Iterator, mutable}
 
 object DiffGraphApplier {
-  def applyDiff(graph: Graph, diff: DiffGraphBuilder, schemaViolationReporter: SchemaViolationReporter = new SchemaViolationReporter): Unit = {
+  def applyDiff(
+    graph: Graph,
+    diff: DiffGraphBuilder,
+    schemaViolationReporter: SchemaViolationReporter = new SchemaViolationReporter
+  ): Unit = {
     if (graph.isClosed) throw new GraphClosedException(s"graph cannot be modified any longer since it's closed")
     new DiffGraphApplier(graph, diff, schemaViolationReporter).applyUpdate()
     diff.buffer = null

--- a/core/src/main/scala/flatgraph/DiffGraphApplier.scala
+++ b/core/src/main/scala/flatgraph/DiffGraphApplier.scala
@@ -3,20 +3,21 @@ package flatgraph
 import DiffGraphBuilder.*
 import flatgraph.Edge.Direction
 import flatgraph.Edge.Direction.{Incoming, Outgoing}
+import flatgraph.misc.SchemaViolationReporter
 
 import scala.collection.{Iterator, mutable}
 
 object DiffGraphApplier {
-  def applyDiff(graph: Graph, diff: DiffGraphBuilder): Unit = {
+  def applyDiff(graph: Graph, diff: DiffGraphBuilder, schemaViolationReporter: SchemaViolationReporter = new SchemaViolationReporter): Unit = {
     if (graph.isClosed) throw new GraphClosedException(s"graph cannot be modified any longer since it's closed")
-    new DiffGraphApplier(graph, diff).applyUpdate()
+    new DiffGraphApplier(graph, diff, schemaViolationReporter).applyUpdate()
     diff.buffer = null
   }
 }
 
 /** The class that is responsible for applying diffgraphs. This is not supposed to be public API, users should stick to applyDiff
   */
-private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder) {
+private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder, schemaViolationReporter: SchemaViolationReporter) {
   val newNodes = new Array[mutable.ArrayBuffer[DNode]](graph.schema.getNumberOfNodeKinds)
   // newEdges and delEdges are oversized, in order to permit usage of the same indexing function
   val newEdges          = new Array[mutable.ArrayBuffer[AddEdgeProcessed]](graph.neighbors.size)
@@ -37,16 +38,20 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder) 
 
   private def insertProperty0(node: GNode, propertyKind: Int, propertyValues: Iterator[Any]): Unit = {
     val pos = graph.schema.propertyOffsetArrayIndex(node.nodeKind, propertyKind)
-    if (setNodeProperties(pos) == null)
-      setNodeProperties(pos) = mutable.ArrayBuffer.empty
-    val buf   = setNodeProperties(pos)
-    val start = buf.size
-    propertyValues.iterator.foreach {
-      case dnode: DNode => buf.addOne(getGNode(dnode))
-      case other        => buf.addOne(other)
+    if (0 > pos || pos >= setNodeProperties.length) {
+      schemaViolationReporter.illegalNodeProperty(node.nodeKind, propertyKind, graph.schema)
+    } else {
+      if (setNodeProperties(pos) == null)
+        setNodeProperties(pos) = mutable.ArrayBuffer.empty
+      val buf   = setNodeProperties(pos)
+      val start = buf.size
+      propertyValues.iterator.foreach {
+        case dnode: DNode => buf.addOne(getGNode(dnode))
+        case other        => buf.addOne(other)
+      }
+      val bound = new SetPropertyDesc(node, start, buf.size)
+      insert(setNodeProperties, bound, pos + 1)
     }
-    val bound = new SetPropertyDesc(node, start, buf.size)
-    insert(setNodeProperties, bound, pos + 1)
   }
 
   private def insert[T](a: Array[mutable.ArrayBuffer[T]], item: T, pos: Int): Unit = {
@@ -176,7 +181,7 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder) 
     drainDeferred()
   }
 
-  private def applyUpdate(): Unit = {
+  private[flatgraph] def applyUpdate(): Unit = {
     splitUpdate()
 
     // set edge properties
@@ -581,64 +586,52 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder) 
       dedupBy(setPropertyPositions, (setProp: SetPropertyDesc) => setProp.node.seq())
       val nodeCount = graph.nodesArray(nodeKind).length
 
-      def throwSchemaViolationException() = {
-        val contextBuilder = Seq.newBuilder[String]
-        contextBuilder += s"nodeKind=$nodeKind,propertyKind=$propertyKind"
-        schema.getNodeLabelMaybe(nodeKind).foreach { nodeLabel =>
-          contextBuilder += s"nodeLabel=$nodeLabel"
-          val allowedPropertyNames = schema.getNodePropertyNames(nodeLabel).toSeq.sorted.mkString(",")
-          contextBuilder += s"allowedPropertyNames=[$allowedPropertyNames]"
-        }
-        schema.getPropertyLabelMaybe(nodeKind, propertyKind).foreach { propertyLabel =>
-          contextBuilder += s"propertyLabel=$propertyLabel"
-        }
-        val context = contextBuilder.result().mkString(",")
-        throw new SchemaViolationException(s"""Unsupported property on node. Context: $context""")
-      }
-
       val setPropertyValues = schema.getNodePropertyFormalType(nodeKind, propertyKind).allocate(propertyBuf.size)
-      if (setPropertyValues == null) throwSchemaViolationException()
-      copyToArray(propertyBuf, setPropertyValues)
+      if (setPropertyValues == null) {
+        schemaViolationReporter.illegalNodeProperty(nodeKind, propertyKind, schema)
+      } else {
+        copyToArray(propertyBuf, setPropertyValues)
 
-      val oldQty = Option(graph.properties(pos).asInstanceOf[Array[Int]]).getOrElse(new Array[Int](1))
-      val oldProperty = Option(graph.properties(pos + 1))
-        .getOrElse(schema.getNodePropertyFormalType(nodeKind, propertyKind).allocate(0))
-        .asInstanceOf[Array[?]]
-      if (oldProperty == null) throwSchemaViolationException()
+        val oldQty = Option(graph.properties(pos).asInstanceOf[Array[Int]]).getOrElse(new Array[Int](1))
+        val oldProperty = Option(graph.properties(pos + 1))
+          .getOrElse(schema.getNodePropertyFormalType(nodeKind, propertyKind).allocate(0))
+          .asInstanceOf[Array[?]]
+        if (oldProperty == null) schemaViolationReporter.illegalNodeProperty(nodeKind, propertyKind, schema)
 
-      val newQty      = new Array[Int](nodeCount + 1)
-      val newProperty = schema.getNodePropertyFormalType(nodeKind, propertyKind).allocate(get(oldQty, nodeCount) + propertyBuf.size)
+        val newQty      = new Array[Int](nodeCount + 1)
+        val newProperty = schema.getNodePropertyFormalType(nodeKind, propertyKind).allocate(get(oldQty, nodeCount) + propertyBuf.size)
 
-      val insertionIter = setPropertyPositions.iterator
-      var copyStartSeq  = 0
-      var outIndex      = 0
-      while (copyStartSeq < nodeCount) {
-        val insertion      = insertionIter.nextOption()
-        val insertionSeq   = insertion.map(_.node.seq()).getOrElse(nodeCount)
-        val copyStartIndex = get(oldQty, copyStartSeq)
-        val copyEndIndex   = get(oldQty, insertionSeq)
-        val offset         = outIndex - copyStartIndex
-        System.arraycopy(oldProperty, copyStartIndex, newProperty, outIndex, copyEndIndex - copyStartIndex)
-        outIndex += copyEndIndex - copyStartIndex
-        assert(
-          newQty(copyStartSeq) == get(oldQty, copyStartSeq) + offset,
-          s"something went wrong while copying properties: newQty(copyStartSeq) was supposed to be ${get(oldQty, copyStartSeq) + offset} but instead was ${newQty(copyStartSeq)}"
-        )
-        for (idx <- Range(copyStartSeq + 1, insertionSeq + 1))
-          newQty(idx) = get(oldQty, idx) + offset
+        val insertionIter = setPropertyPositions.iterator
+        var copyStartSeq  = 0
+        var outIndex      = 0
+        while (copyStartSeq < nodeCount) {
+          val insertion      = insertionIter.nextOption()
+          val insertionSeq   = insertion.map(_.node.seq()).getOrElse(nodeCount)
+          val copyStartIndex = get(oldQty, copyStartSeq)
+          val copyEndIndex   = get(oldQty, insertionSeq)
+          val offset         = outIndex - copyStartIndex
+          System.arraycopy(oldProperty, copyStartIndex, newProperty, outIndex, copyEndIndex - copyStartIndex)
+          outIndex += copyEndIndex - copyStartIndex
+          assert(
+            newQty(copyStartSeq) == get(oldQty, copyStartSeq) + offset,
+            s"something went wrong while copying properties: newQty(copyStartSeq) was supposed to be ${get(oldQty, copyStartSeq) + offset} but instead was ${newQty(copyStartSeq)}"
+          )
+          for (idx <- Range(copyStartSeq + 1, insertionSeq + 1))
+            newQty(idx) = get(oldQty, idx) + offset
 
-        insertion.foreach { insertion =>
-          System.arraycopy(setPropertyValues, insertion.start, newProperty, outIndex, insertion.length)
-          outIndex += insertion.length
-          newQty(insertionSeq + 1) = outIndex
+          insertion.foreach { insertion =>
+            System.arraycopy(setPropertyValues, insertion.start, newProperty, outIndex, insertion.length)
+            outIndex += insertion.length
+            newQty(insertionSeq + 1) = outIndex
+          }
+          copyStartSeq = insertionSeq + 1
         }
-        copyStartSeq = insertionSeq + 1
-      }
-      newQty(nodeCount) = outIndex
+        newQty(nodeCount) = outIndex
 
-      graph.properties(pos) = newQty
-      // fixme: need to support graphs with unknown schema. Then we need to homogenize the array here.
-      graph.properties(pos + 1) = newProperty
+        graph.properties(pos) = newQty
+        // fixme: need to support graphs with unknown schema. Then we need to homogenize the array here.
+        graph.properties(pos + 1) = newProperty
+      }
     }
   }
 

--- a/core/src/main/scala/flatgraph/misc/SchemaViolationReporter.scala
+++ b/core/src/main/scala/flatgraph/misc/SchemaViolationReporter.scala
@@ -5,23 +5,23 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
 
-/** Illegal usage of node properties often roots in deserialising an old storage format, so we 
- *  don't want to error out but rather log a warning, and only do so once for each node/property combination. 
- */
+/** Illegal usage of node properties often roots in deserialising an old storage format, so we don't want to error out but rather log a
+  * warning, and only do so once for each node/property combination.
+  */
 class SchemaViolationReporter {
-  private val logger = LoggerFactory.getLogger(getClass)
-  private val loggedSchemaViolations = mutable.Set.empty[(Int, String|Int)] // (NodeKind, PropertyLabel|PropertyKind)
+  private val logger                 = LoggerFactory.getLogger(getClass)
+  private val loggedSchemaViolations = mutable.Set.empty[(Int, String | Int)] // (NodeKind, PropertyLabel|PropertyKind)
 
-  def illegalNodeProperty(nodeKind: Int, propertyIdentifier: String|Int, schema: Schema): Unit = {
+  def illegalNodeProperty(nodeKind: Int, propertyIdentifier: String | Int, schema: Schema): Unit = {
     if (loggedSchemaViolations.contains((nodeKind, propertyIdentifier))) {
       val contextBuilder = Seq.newBuilder[String]
-      
+
       contextBuilder += s"nodeKind=$nodeKind"
       schema.getNodeLabelMaybe(nodeKind).foreach { nodeLabel =>
         contextBuilder += s",nodeLabel=$nodeLabel"
       }
       propertyIdentifier match {
-        case name: String => 
+        case name: String =>
           contextBuilder += s",propertyName=$name"
         case kind: Int =>
           contextBuilder += s",propertyKind=$kind"

--- a/core/src/main/scala/flatgraph/misc/SchemaViolationReporter.scala
+++ b/core/src/main/scala/flatgraph/misc/SchemaViolationReporter.scala
@@ -1,0 +1,38 @@
+package flatgraph.misc
+
+import flatgraph.Schema
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
+
+/** Illegal usage of node properties often roots in deserialising an old storage format, so we 
+ *  don't want to error out but rather log a warning, and only do so once for each node/property combination. 
+ */
+class SchemaViolationReporter {
+  private val logger = LoggerFactory.getLogger(getClass)
+  private val loggedSchemaViolations = mutable.Set.empty[(Int, String|Int)] // (NodeKind, PropertyLabel|PropertyKind)
+
+  def illegalNodeProperty(nodeKind: Int, propertyIdentifier: String|Int, schema: Schema): Unit = {
+    if (loggedSchemaViolations.contains((nodeKind, propertyIdentifier))) {
+      val contextBuilder = Seq.newBuilder[String]
+      
+      contextBuilder += s"nodeKind=$nodeKind"
+      schema.getNodeLabelMaybe(nodeKind).foreach { nodeLabel =>
+        contextBuilder += s",nodeLabel=$nodeLabel"
+      }
+      propertyIdentifier match {
+        case name: String => 
+          contextBuilder += s",propertyName=$name"
+        case kind: Int =>
+          contextBuilder += s",propertyKind=$kind"
+          schema.getPropertyLabelMaybe(nodeKind, kind).foreach { name =>
+            contextBuilder += s",propertyName=$name"
+          }
+      }
+      val context = contextBuilder.result().mkString(",")
+      logger.warn(s"""Unsupported (deprecated?) property on node: $context""")
+      loggedSchemaViolations.addOne((nodeKind, propertyIdentifier))
+    }
+  }
+
+}

--- a/core/src/main/scala/flatgraph/traversal/Language.scala
+++ b/core/src/main/scala/flatgraph/traversal/Language.scala
@@ -600,4 +600,7 @@ class NodeSteps[A <: GNode](traversal: Iterator[A]) extends AnyVal {
 
   def property[@specialized ValueType](propertyKey: MultiPropertyKey[ValueType]): Iterator[ValueType] =
     traversal.flatMap(_.property(propertyKey))
+    
+  def propertiesMap: Iterator[java.util.Map[String, AnyRef]] =
+    traversal.map(_.propertiesMap)
 }

--- a/core/src/main/scala/flatgraph/traversal/Language.scala
+++ b/core/src/main/scala/flatgraph/traversal/Language.scala
@@ -600,7 +600,7 @@ class NodeSteps[A <: GNode](traversal: Iterator[A]) extends AnyVal {
 
   def property[@specialized ValueType](propertyKey: MultiPropertyKey[ValueType]): Iterator[ValueType] =
     traversal.flatMap(_.property(propertyKey))
-    
+
   def propertiesMap: Iterator[java.util.Map[String, AnyRef]] =
     traversal.map(_.propertiesMap)
 }

--- a/core/src/test/scala/flatgraph/DiffGraphTests.scala
+++ b/core/src/test/scala/flatgraph/DiffGraphTests.scala
@@ -1,6 +1,5 @@
-package flatgraph.misc
+package flatgraph
 
-import flatgraph.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
@@ -485,53 +485,53 @@ class DomainClassesGenerator(schema: Schema) {
       )
       val nodeSource = {
         s"""package $basePackage.nodes
-             |
-             |import $basePackage.Language.*
-             |import scala.collection.immutable.{IndexedSeq, ArraySeq}
-             |
-             |$erasedMarkerType
-             |
-             |$baseTrait {
-             |  ${baseNodeProps.mkString("\n")}
-             |  $propDictItemsSource
-             |}
-             |
-             |object ${nodeType.className} {
-             |  val Label = "${nodeType.name}"
-             |  object PropertyNames {
-             |    $propertyNames
-             |  }
-             |  object PropertyKeys {
-             |    $propertyKeys
-             |  }
-             |  object PropertyDefaults {
-             |    $propertyDefaults
-             |  }
-             |}
-             |
-             |$storedNode {
-             |  ${storedNodeProps.mkString("\n")}
-             |
-             |  override def productElementName(n: Int): String =
-             |    n match {
-             |      $productElementNames
-             |      case _ => ""
-             |    }
-             |
-             |  override def productElement(n: Int): Any =
-             |    n match {
-             |      $productElementAccessors
-             |      case _ => null
-             |    }
-             |
-             |  override def productPrefix = "${nodeType.className}"
-             |  override def productArity = ${productElements.size}
-             |
-             |  override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[${nodeType.className}]
-             |}
-             |
-             |$newNode
-             |""".stripMargin
+           |
+           |import $basePackage.Language.*
+           |import scala.collection.immutable.{IndexedSeq, ArraySeq}
+           |
+           |$erasedMarkerType
+           |
+           |$baseTrait {
+           |  ${baseNodeProps.mkString("\n")}
+           |  $propDictItemsSource
+           |}
+           |
+           |object ${nodeType.className} {
+           |  val Label = "${nodeType.name}"
+           |  object PropertyNames {
+           |    $propertyNames
+           |  }
+           |  object PropertyKeys {
+           |    $propertyKeys
+           |  }
+           |  object PropertyDefaults {
+           |    $propertyDefaults
+           |  }
+           |}
+           |
+           |$storedNode {
+           |  ${storedNodeProps.mkString("\n")}
+           |
+           |  override def productElementName(n: Int): String =
+           |    n match {
+           |      $productElementNames
+           |      case _ => ""
+           |    }
+           |
+           |  override def productElement(n: Int): Any =
+           |    n match {
+           |      $productElementAccessors
+           |      case _ => null
+           |    }
+           |
+           |  override def productPrefix = "${nodeType.className}"
+           |  override def productArity = ${productElements.size}
+           |
+           |  override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[${nodeType.className}]
+           |}
+           |
+           |$newNode
+           |""".stripMargin
       }
       os.write(nodesRootDir / s"${nodeType.className}.scala", nodeSource)
     }
@@ -690,6 +690,23 @@ class DomainClassesGenerator(schema: Schema) {
       // format: on
     }
     os.write(outputDir0 / "GraphSchema.scala", schemaFile)
+
+    os.write(outputDir0 / "PropertyErrorRegister.scala",
+      s"""package $basePackage
+         |
+         |object PropertyErrorRegister {
+         |  private var errorMap = Set.empty[(Class[?], String)]
+         |  private val logger = org.slf4j.LoggerFactory.getLogger(getClass)
+         |
+         |  def logPropertyErrorIfFirst(clazz: Class[?], propertyName: String): Unit = {
+         |    if (!errorMap.contains((clazz, propertyName))) {
+         |      logger.warn("Property " + propertyName + " is deprecated for " + clazz.getName + ".")
+         |      errorMap += ((clazz, propertyName))
+         |    }
+         |  }
+         |}
+         |""".stripMargin
+    )
 
     // Accessors and traversals: start
     // TODO extract into separate method

--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
@@ -691,7 +691,8 @@ class DomainClassesGenerator(schema: Schema) {
     }
     os.write(outputDir0 / "GraphSchema.scala", schemaFile)
 
-    os.write(outputDir0 / "PropertyErrorRegister.scala",
+    os.write(
+      outputDir0 / "PropertyErrorRegister.scala",
       s"""package $basePackage
          |
          |object PropertyErrorRegister {

--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/Helpers.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/Helpers.scala
@@ -164,20 +164,6 @@ object Helpers {
       .mkString(lineSeparator)
   }
 
-  val propertyErrorRegisterImpl =
-    s"""object PropertyErrorRegister {
-       |  private var errorMap = Set[(Class[_], String)]()
-       |  private val logger = org.slf4j.LoggerFactory.getLogger(getClass)
-       |
-       |  def logPropertyErrorIfFirst(clazz: Class[_], propertyName: String): Unit = {
-       |    if (!errorMap.contains((clazz, propertyName))) {
-       |      logger.warn("Property " + propertyName + " is deprecated for " + clazz.getName + ".")
-       |      errorMap += ((clazz, propertyName))
-       |    }
-       |  }
-       |}
-       |""".stripMargin
-
   /** obtained from repl via
     * {{{
     * :power

--- a/test-schemas-domain-classes/src/main/scala/flatgraph/testdomains/generic/PropertyErrorRegister.scala
+++ b/test-schemas-domain-classes/src/main/scala/flatgraph/testdomains/generic/PropertyErrorRegister.scala
@@ -1,0 +1,13 @@
+package flatgraph.testdomains.generic
+
+object PropertyErrorRegister {
+  private var errorMap = Set.empty[(Class[?], String)]
+  private val logger   = org.slf4j.LoggerFactory.getLogger(getClass)
+
+  def logPropertyErrorIfFirst(clazz: Class[?], propertyName: String): Unit = {
+    if (!errorMap.contains((clazz, propertyName))) {
+      logger.warn("Property " + propertyName + " is deprecated for " + clazz.getName + ".")
+      errorMap += ((clazz, propertyName))
+    }
+  }
+}

--- a/test-schemas-domain-classes/src/main/scala/flatgraph/testdomains/gratefuldead/PropertyErrorRegister.scala
+++ b/test-schemas-domain-classes/src/main/scala/flatgraph/testdomains/gratefuldead/PropertyErrorRegister.scala
@@ -1,0 +1,13 @@
+package flatgraph.testdomains.gratefuldead
+
+object PropertyErrorRegister {
+  private var errorMap = Set.empty[(Class[?], String)]
+  private val logger   = org.slf4j.LoggerFactory.getLogger(getClass)
+
+  def logPropertyErrorIfFirst(clazz: Class[?], propertyName: String): Unit = {
+    if (!errorMap.contains((clazz, propertyName))) {
+      logger.warn("Property " + propertyName + " is deprecated for " + clazz.getName + ".")
+      errorMap += ((clazz, propertyName))
+    }
+  }
+}

--- a/tests/src/test/scala/flatgraph/GraphTests.scala
+++ b/tests/src/test/scala/flatgraph/GraphTests.scala
@@ -14,15 +14,14 @@ import org.scalatest.wordspec.AnyWordSpec
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.MapHasAsScala
 
-
 class GraphTests extends AnyWordSpec with MockFactory {
 
   "node property: log warning for schema-unconform property usage" in {
     // unknown node properties often root in deserialising an old storage format,
     // so we don't want to error out but rather log a warning
-    val genericDomain = GenericDomain.empty
-    val graph = genericDomain.graph
-    val schema = graph.schema
+    val genericDomain     = GenericDomain.empty
+    val graph             = genericDomain.graph
+    val schema            = graph.schema
     val Seq(nodeA, nodeB) = TestHelpers.addNodes(graph, Seq(NewNodeA(), NewNodeB()))
 
     val mockSchemaViolationReporter = mock[SchemaViolationReporter]
@@ -42,7 +41,6 @@ class GraphTests extends AnyWordSpec with MockFactory {
     genericDomain.nodeA.head.propertiesMap.asScala shouldBe Map("int_optional" -> 100)
     genericDomain.nodeB.head.propertiesMap.asScala shouldBe Map()
   }
-
 
   /* sample graph:
    * L3 <- L2 <- L1 <- Center -> R1 -> R2 -> R3 -> R4 -> R5

--- a/tests/src/test/scala/flatgraph/GraphTests.scala
+++ b/tests/src/test/scala/flatgraph/GraphTests.scala
@@ -28,6 +28,7 @@ class GraphTests extends AnyWordSpec with MockFactory {
     mockSchemaViolationReporter.illegalNodeProperty.expects(nodeA.nodeKind: Int, "UNKNOWN", schema)
     mockSchemaViolationReporter.illegalNodeProperty.expects(nodeA.nodeKind: Int, 999, schema)
     mockSchemaViolationReporter.illegalNodeProperty.expects(nodeB.nodeKind: Int, NodeA.PropertyKeys.IntOptional.kind, schema)
+    mockSchemaViolationReporter.illegalNodeProperty.expects(nodeB.nodeKind: Int, 998, schema)
 
     val setProperties = new DiffGraphBuilder(schema, mockSchemaViolationReporter)
       // this is fine
@@ -36,6 +37,7 @@ class GraphTests extends AnyWordSpec with MockFactory {
       .setNodeProperty(nodeA, "UNKNOWN", "value1")
       ._setNodeProperty(nodeA, 999, "value2")
       .setNodeProperty(nodeB, NodeA.PropertyNames.IntOptional, 101)
+      ._setNodeProperty(nodeB, 998, 102)
     new DiffGraphApplier(graph, setProperties, mockSchemaViolationReporter).applyUpdate()
 
     genericDomain.nodeA.head.propertiesMap.asScala shouldBe Map("int_optional" -> 100)

--- a/tests/src/test/scala/flatgraph/GraphTests.scala
+++ b/tests/src/test/scala/flatgraph/GraphTests.scala
@@ -1,0 +1,195 @@
+package flatgraph
+
+import flatgraph.help.Table.AvailableWidthProvider
+import flatgraph.help.{DocSearchPackages, Table}
+import flatgraph.misc.SchemaViolationReporter
+import flatgraph.testdomains.generic.GenericDomain
+import flatgraph.testdomains.generic.Language.*
+import flatgraph.testdomains.generic.edges.ConnectedTo
+import flatgraph.testdomains.generic.nodes.{NewNodeA, NewNodeB, NodeA}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should.Matchers.*
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.MapHasAsScala
+
+
+class GraphTests extends AnyWordSpec with MockFactory {
+
+  "node property: log warning for schema-unconform property usage" in {
+    // unknown node properties often root in deserialising an old storage format,
+    // so we don't want to error out but rather log a warning
+    val genericDomain = GenericDomain.empty
+    val graph = genericDomain.graph
+    val schema = graph.schema
+    val Seq(nodeA, nodeB) = TestHelpers.addNodes(graph, Seq(NewNodeA(), NewNodeB()))
+
+    val mockSchemaViolationReporter = mock[SchemaViolationReporter]
+    mockSchemaViolationReporter.illegalNodeProperty.expects(nodeA.nodeKind: Int, "UNKNOWN", schema)
+    mockSchemaViolationReporter.illegalNodeProperty.expects(nodeA.nodeKind: Int, 999, schema)
+    mockSchemaViolationReporter.illegalNodeProperty.expects(nodeB.nodeKind: Int, NodeA.PropertyKeys.IntOptional.kind, schema)
+
+    val setProperties = new DiffGraphBuilder(schema, mockSchemaViolationReporter)
+      // this is fine
+      .setNodeProperty(nodeA, NodeA.PropertyNames.IntOptional, 100)
+      // these are not schema conform...
+      .setNodeProperty(nodeA, "UNKNOWN", "value1")
+      ._setNodeProperty(nodeA, 999, "value2")
+      .setNodeProperty(nodeB, NodeA.PropertyNames.IntOptional, 101)
+    new DiffGraphApplier(graph, setProperties, mockSchemaViolationReporter).applyUpdate()
+
+    genericDomain.nodeA.head.propertiesMap.asScala shouldBe Map("int_optional" -> 100)
+    genericDomain.nodeB.head.propertiesMap.asScala shouldBe Map()
+  }
+
+
+  /* sample graph:
+   * L3 <- L2 <- L1 <- Center -> R1 -> R2 -> R3 -> R4 -> R5
+   */
+  val flatlineGraph = TestGraphs.createFlatlineGraph()
+  def centerTrav    = flatlineGraph.nodeA.stringMandatory("Center")
+
+  "domain specific traversals" in {
+    centerTrav.connectedTo.size shouldBe 2
+    centerTrav.connectedToIn.size shouldBe 0
+  }
+
+  "generic GNode traversals" in {
+    centerTrav.label.l shouldBe Seq(NodeA.Label)
+    centerTrav.outE.size shouldBe 2
+    centerTrav.inE.size shouldBe 0
+    centerTrav.outE(ConnectedTo.Label).size shouldBe 2
+    centerTrav.inE(ConnectedTo.Label).size shouldBe 0
+  }
+
+  "can only be iterated once" in {
+    val one = Iterator.single("one")
+    one.size shouldBe 1
+    one.size shouldBe 0
+
+    val empty = Iterator.empty[String]
+    empty.size shouldBe 0
+    empty.size shouldBe 0
+  }
+
+  ".sideEffect step should apply provided function and do nothing else" in {
+    val sack = mutable.ListBuffer.empty[NodeA]
+    centerTrav.connectedTo.sideEffect(sack.addOne).connectedTo.stringMandatory.toSetMutable shouldBe Set("L2", "R2")
+    sack.map(_.stringMandatory).toSet shouldBe Set("L1", "R1")
+  }
+
+  ".dedup step" should {
+    "remove duplicates" in {
+      Iterator(1, 2, 1, 3).dedup.l shouldBe List(1, 2, 3)
+      Iterator(1, 2, 1, 3).dedupBy(_.hashCode).l shouldBe List(1, 2, 3)
+    }
+
+    "allow method only based on hashCode - to ensure the traversal doesn't hold onto elements after they've been consumed" in {
+      // when run with -Xmx128m we can hold ~7 of these at a time
+      def infiniteTraversalWithLargeElements = new Iterator[Any] {
+        var i       = 0
+        def hasNext = true
+        def next(): Any = {
+          val arr = Array.ofDim[Long](2048, 1024)
+          // assign unique value to make the arrays unique
+          arr(i)(i) = i
+          i += 1
+          arr
+        }
+      }
+
+      /** using dedup by hash comparison, we can traverse over these elements - already consumed elements are garbage collected
+        */
+      val traversal = infiniteTraversalWithLargeElements.dedupBy(_.hashCode)
+      0.to(128).foreach { i =>
+        traversal.next()
+      }
+    }
+  }
+
+  ".sort steps should order" in {
+    Iterator(1, 3, 2).sorted shouldBe Seq(1, 2, 3)
+    Iterator("aa", "aaa", "a").sortBy(_.length) shouldBe Seq("a", "aa", "aaa")
+  }
+
+  "`is` filter step" in {
+    def oneToFour = Iterator(1, 2, 3, 4)
+    oneToFour.is(2).l shouldBe Seq(2)
+  }
+
+  "within/without filter steps" in {
+    def oneToFour = Iterator(1, 2, 3, 4)
+    oneToFour.within(Set(2, 4)).l shouldBe Seq(2, 4)
+    oneToFour.without(Set(2, 4)).l shouldBe Seq(1, 3)
+  }
+
+  ".help step" should {
+    // a specific domain would provide it's own DocSearchPackage implementation, to specify where we're supposed to scan for @Doc annotations
+    given DocSearchPackages      = DocSearchPackages.default
+    given AvailableWidthProvider = new Table.ConstantWidth(120)
+
+    "generic help for `int`" in {
+      val helpText = Iterator(1, 2, 3, 4).help
+      helpText should include(".cast")
+      helpText should include("casts all elements to given type")
+      helpText should include(".whereNot")
+      helpText should include("only preserves elements if the provided traversal does")
+
+      val helpTextVerbose = Iterator(1, 2, 3, 4).helpVerbose
+      helpTextVerbose should include(".cast")
+      helpTextVerbose should include(".whereNot")
+      helpTextVerbose should include("""flatgraph.traversal.GenericSt""") // should contain the location of the step definition...
+    }
+
+    "help for nodes" in {
+      val helpText = Iterator.empty[GNode].help
+      helpText should include(".label")
+      helpText should include(".property")
+      helpText should include(".out")
+      helpText should include(".in")
+      helpText should include(".cast")
+
+      val helpTextVerbose = Iterator.empty[GNode].helpVerbose
+      helpTextVerbose should include(".label")
+      helpTextVerbose should include(".property")
+      helpTextVerbose should include(".cast")
+      helpTextVerbose should include("""flatgraph.traversal.GenericSt""") // should contain the location of the step definition...
+      helpTextVerbose should include("""flatgraph.traversal.NodeSteps""") // should contain the location of the step definition...
+    }
+
+    "give a domain overview" in {
+      given DocSearchPackages = GenericDomain.defaultDocSearchPackage
+      val helpText            = GenericDomain.help
+      // should list starter steps etc.
+      helpText should include(".nodeA")
+      helpText should include(".nodeB")
+      helpText should include("all nodes")
+    }
+
+    "provide node-specific overview" in {
+      val nodeATraversal     = flatlineGraph.nodeA
+      val nodeATraversalHelp = nodeATraversal.help
+
+      // TODO bring these back, by generating the @Doc annotations
+//      nodeATraversalHelp should include(".connectedTo") // step from `flatgraph.traversal.testdomains.simple.SimpleDomainTraversal`
+      nodeATraversalHelp should include(".sideEffect") // step from Traversal
+      nodeATraversalHelp should include(".label")      // step from ElementTraversal
+      nodeATraversalHelp should include(".out")        // step from NodeTraversal
+
+      // scala generates additional `fooBar$extension` methods, but those don't matter in the context of .help/@Doc
+      nodeATraversalHelp shouldNot include("$extension")
+
+      val thingTraversalHelpVerbose = nodeATraversal.helpVerbose
+      // TODO bring these back, by generating the @Doc annotations
+//      thingTraversalHelpVerbose should include("name of the Thing")
+//      thingTraversalHelpVerbose should include("simple.SimpleDomainTravers")
+      thingTraversalHelpVerbose should include("node label")
+      thingTraversalHelpVerbose should include("flatgraph.traversal.NodeSteps")
+      thingTraversalHelpVerbose should include("result to a list")
+      thingTraversalHelpVerbose should include("flatgraph.traversal.GenericSt")
+    }
+
+  }
+
+}

--- a/tests/src/test/scala/flatgraph/GraphTests.scala
+++ b/tests/src/test/scala/flatgraph/GraphTests.scala
@@ -1,17 +1,15 @@
 package flatgraph
 
-import flatgraph.help.Table.AvailableWidthProvider
-import flatgraph.help.{DocSearchPackages, Table}
+import flatgraph.help.Table
 import flatgraph.misc.SchemaViolationReporter
+import flatgraph.testutils.TestHelpers
 import flatgraph.testdomains.generic.GenericDomain
 import flatgraph.testdomains.generic.Language.*
-import flatgraph.testdomains.generic.edges.ConnectedTo
 import flatgraph.testdomains.generic.nodes.{NewNodeA, NewNodeB, NodeA}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers.*
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.collection.mutable
 import scala.jdk.CollectionConverters.MapHasAsScala
 
 class GraphTests extends AnyWordSpec with MockFactory {
@@ -42,154 +40,6 @@ class GraphTests extends AnyWordSpec with MockFactory {
 
     genericDomain.nodeA.head.propertiesMap.asScala shouldBe Map("int_optional" -> 100)
     genericDomain.nodeB.head.propertiesMap.asScala shouldBe Map()
-  }
-
-  /* sample graph:
-   * L3 <- L2 <- L1 <- Center -> R1 -> R2 -> R3 -> R4 -> R5
-   */
-  val flatlineGraph = TestGraphs.createFlatlineGraph()
-  def centerTrav    = flatlineGraph.nodeA.stringMandatory("Center")
-
-  "domain specific traversals" in {
-    centerTrav.connectedTo.size shouldBe 2
-    centerTrav.connectedToIn.size shouldBe 0
-  }
-
-  "generic GNode traversals" in {
-    centerTrav.label.l shouldBe Seq(NodeA.Label)
-    centerTrav.outE.size shouldBe 2
-    centerTrav.inE.size shouldBe 0
-    centerTrav.outE(ConnectedTo.Label).size shouldBe 2
-    centerTrav.inE(ConnectedTo.Label).size shouldBe 0
-  }
-
-  "can only be iterated once" in {
-    val one = Iterator.single("one")
-    one.size shouldBe 1
-    one.size shouldBe 0
-
-    val empty = Iterator.empty[String]
-    empty.size shouldBe 0
-    empty.size shouldBe 0
-  }
-
-  ".sideEffect step should apply provided function and do nothing else" in {
-    val sack = mutable.ListBuffer.empty[NodeA]
-    centerTrav.connectedTo.sideEffect(sack.addOne).connectedTo.stringMandatory.toSetMutable shouldBe Set("L2", "R2")
-    sack.map(_.stringMandatory).toSet shouldBe Set("L1", "R1")
-  }
-
-  ".dedup step" should {
-    "remove duplicates" in {
-      Iterator(1, 2, 1, 3).dedup.l shouldBe List(1, 2, 3)
-      Iterator(1, 2, 1, 3).dedupBy(_.hashCode).l shouldBe List(1, 2, 3)
-    }
-
-    "allow method only based on hashCode - to ensure the traversal doesn't hold onto elements after they've been consumed" in {
-      // when run with -Xmx128m we can hold ~7 of these at a time
-      def infiniteTraversalWithLargeElements = new Iterator[Any] {
-        var i       = 0
-        def hasNext = true
-        def next(): Any = {
-          val arr = Array.ofDim[Long](2048, 1024)
-          // assign unique value to make the arrays unique
-          arr(i)(i) = i
-          i += 1
-          arr
-        }
-      }
-
-      /** using dedup by hash comparison, we can traverse over these elements - already consumed elements are garbage collected
-        */
-      val traversal = infiniteTraversalWithLargeElements.dedupBy(_.hashCode)
-      0.to(128).foreach { i =>
-        traversal.next()
-      }
-    }
-  }
-
-  ".sort steps should order" in {
-    Iterator(1, 3, 2).sorted shouldBe Seq(1, 2, 3)
-    Iterator("aa", "aaa", "a").sortBy(_.length) shouldBe Seq("a", "aa", "aaa")
-  }
-
-  "`is` filter step" in {
-    def oneToFour = Iterator(1, 2, 3, 4)
-    oneToFour.is(2).l shouldBe Seq(2)
-  }
-
-  "within/without filter steps" in {
-    def oneToFour = Iterator(1, 2, 3, 4)
-    oneToFour.within(Set(2, 4)).l shouldBe Seq(2, 4)
-    oneToFour.without(Set(2, 4)).l shouldBe Seq(1, 3)
-  }
-
-  ".help step" should {
-    // a specific domain would provide it's own DocSearchPackage implementation, to specify where we're supposed to scan for @Doc annotations
-    given DocSearchPackages      = DocSearchPackages.default
-    given AvailableWidthProvider = new Table.ConstantWidth(120)
-
-    "generic help for `int`" in {
-      val helpText = Iterator(1, 2, 3, 4).help
-      helpText should include(".cast")
-      helpText should include("casts all elements to given type")
-      helpText should include(".whereNot")
-      helpText should include("only preserves elements if the provided traversal does")
-
-      val helpTextVerbose = Iterator(1, 2, 3, 4).helpVerbose
-      helpTextVerbose should include(".cast")
-      helpTextVerbose should include(".whereNot")
-      helpTextVerbose should include("""flatgraph.traversal.GenericSt""") // should contain the location of the step definition...
-    }
-
-    "help for nodes" in {
-      val helpText = Iterator.empty[GNode].help
-      helpText should include(".label")
-      helpText should include(".property")
-      helpText should include(".out")
-      helpText should include(".in")
-      helpText should include(".cast")
-
-      val helpTextVerbose = Iterator.empty[GNode].helpVerbose
-      helpTextVerbose should include(".label")
-      helpTextVerbose should include(".property")
-      helpTextVerbose should include(".cast")
-      helpTextVerbose should include("""flatgraph.traversal.GenericSt""") // should contain the location of the step definition...
-      helpTextVerbose should include("""flatgraph.traversal.NodeSteps""") // should contain the location of the step definition...
-    }
-
-    "give a domain overview" in {
-      given DocSearchPackages = GenericDomain.defaultDocSearchPackage
-      val helpText            = GenericDomain.help
-      // should list starter steps etc.
-      helpText should include(".nodeA")
-      helpText should include(".nodeB")
-      helpText should include("all nodes")
-    }
-
-    "provide node-specific overview" in {
-      val nodeATraversal     = flatlineGraph.nodeA
-      val nodeATraversalHelp = nodeATraversal.help
-
-      // TODO bring these back, by generating the @Doc annotations
-//      nodeATraversalHelp should include(".connectedTo") // step from `flatgraph.traversal.testdomains.simple.SimpleDomainTraversal`
-      nodeATraversalHelp should include(".sideEffect") // step from Traversal
-      nodeATraversalHelp should include(".label")      // step from ElementTraversal
-      nodeATraversalHelp should include(".out")        // step from NodeTraversal
-
-      // scala generates additional `fooBar$extension` methods, but those don't matter in the context of .help/@Doc
-      nodeATraversalHelp shouldNot include("$extension")
-
-      val thingTraversalHelpVerbose = nodeATraversal.helpVerbose
-      // TODO bring these back, by generating the @Doc annotations
-//      thingTraversalHelpVerbose should include("name of the Thing")
-//      thingTraversalHelpVerbose should include("simple.SimpleDomainTravers")
-      thingTraversalHelpVerbose should include("node label")
-      thingTraversalHelpVerbose should include("flatgraph.traversal.NodeSteps")
-      thingTraversalHelpVerbose should include("result to a list")
-      thingTraversalHelpVerbose should include("flatgraph.traversal.GenericSt")
-    }
-
   }
 
 }

--- a/tests/src/test/scala/flatgraph/testutils/TestHelpers.scala
+++ b/tests/src/test/scala/flatgraph/testutils/TestHelpers.scala
@@ -1,0 +1,22 @@
+package flatgraph.testutils
+
+import flatgraph.*
+
+import java.nio.file.{Files, Path}
+import scala.util.Try
+
+object TestHelpers {
+  def withTemporaryFile[A](prefix: String, suffix: String)(fun: Path => A): A = {
+    val storagePath = Files.createTempFile(prefix, s".$suffix")
+    val attempt     = Try(fun(storagePath))
+    Files.deleteIfExists(storagePath)
+    attempt.get
+  }
+
+  def addNodes(graph: Graph, nodes: Seq[DNode]): Seq[GNode] = {
+    val diffGraph = new DiffGraphBuilder(graph.schema)
+    nodes.foreach(diffGraph.addNode)
+    DiffGraphApplier.applyDiff(graph, diffGraph)
+    nodes.map(_.storedRef.get)
+  }
+}


### PR DESCRIPTION
Illegal usage of node properties often roots in deserialising an old
storage format, so we don't want to error out but rather log a warning, and
only do so once for each node/property combination.