### PR TITLE
codegen cache fixes

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.0

--- a/sbt-flatgraph/src/main/scala/flatgraph/codegen/sbt/FileUtils.scala
+++ b/sbt-flatgraph/src/main/scala/flatgraph/codegen/sbt/FileUtils.scala
@@ -20,9 +20,12 @@ object FileUtils {
       file.delete()
   }
 
-  def md5(roots: File*): String = {
+  def md5(root: File): String =
+    md5(Seq(root))
+
+  def md5(roots: Seq[File]): String = {
     val md = MessageDigest.getInstance("MD5")
-    roots.foreach { root =>
+    roots.filter(_.exists).foreach { root =>
       Files.walk(root.toPath).filter(!_.toFile.isDirectory).forEach { path =>
         val dis = new DigestInputStream(Files.newInputStream(path), md)
         // fully consume the inputstream


### PR DESCRIPTION
* don't fail for nonexisting inputs
* allow to add more inputs in the build via a custom setting
* add build's /built.sbt to the default inputs