### PR TITLE
change file header to less common and easier detectable magicbytes

### DIFF
--- a/core/src/main/scala/flatgraph/storage/Deserialization.scala
+++ b/core/src/main/scala/flatgraph/storage/Deserialization.scala
@@ -9,6 +9,7 @@ import java.nio.channels.FileChannel
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import java.nio.{ByteBuffer, ByteOrder}
+import java.util.Arrays
 import scala.collection.mutable
 
 object Deserialization {
@@ -151,7 +152,9 @@ object Deserialization {
     }
     header.flip()
 
-    if (header.getLong() != Keys.Header)
+    val headerBytes = new Array[Byte](Keys.Header.length)
+    header.get(headerBytes)
+    if (!Arrays.equals(headerBytes, Keys.Header))
       throw new DeserializationException(s"expected header (`${Keys.Header}`), but found ${header.getLong}")
 
     val manifestOffset = header.getLong()

--- a/core/src/main/scala/flatgraph/storage/Serialization.scala
+++ b/core/src/main/scala/flatgraph/storage/Serialization.scala
@@ -17,15 +17,11 @@ object Serialization {
 
   def writeGraph(g: Graph, storagePath: Path): Unit = {
     val fileOffset = new AtomicLong(16)
-
-    // else null
     val stringPool = mutable.LinkedHashMap[String, Int]()
 
     val fileChannel =
-      new java.io.RandomAccessFile(
-        storagePath.toAbsolutePath.toFile,
-        "rw"
-      ).getChannel // if (conf.filename != null) { new java.io.RandomAccessFile("/tmp/foo.fg", "w").getChannel }}
+      new java.io.RandomAccessFile(storagePath.toAbsolutePath.toFile, "rw").getChannel
+
     try {
       innerWriteGraph(g, stringPool, fileOffset, fileChannel)
     } finally {
@@ -50,7 +46,6 @@ object Serialization {
         .collect {
           case deleted: GNode if AccessHelpers.isDeleted(deleted) => deleted.seq()
         }
-        .toArray
       val size = g.nodeCountByKind(nodeKind)
       nodes.addOne(new Manifest.NodeItem(nodeLabel, size, deletions))
     }
@@ -102,7 +97,7 @@ object Serialization {
     var pos       = filePtr.get()
     val header    = new Array[Byte](16)
     val headerBuf = ByteBuffer.wrap(header)
-    headerBuf.order(ByteOrder.LITTLE_ENDIAN).asLongBuffer().put(Keys.Header).put(pos)
+    headerBuf.order(ByteOrder.LITTLE_ENDIAN).put(Keys.Header).asLongBuffer().put(pos)
     headerBuf.position(0)
     var headPos = 0L
     while (headerBuf.hasRemaining()) {

--- a/core/src/main/scala/flatgraph/storage/package.scala
+++ b/core/src/main/scala/flatgraph/storage/package.scala
@@ -1,6 +1,13 @@
 package flatgraph
 
+import java.nio.charset.StandardCharsets
+
 package object storage {
+
+  /** file header in order to be able to detect the file type */
+  val HeaderSize       = 16 // size for  than enough space for the MagicBytes
+  val MagicBytesString = "FLT GRPH"
+  val MagicBytes       = MagicBytesString.getBytes(StandardCharsets.UTF_8)
 
   object StorageType {
     val Bool   = "bool"
@@ -34,8 +41,7 @@ package object storage {
     val Properties         = "properties"
     val StringPoolLength   = "stringPoolLength"
     val StringPoolBytes    = "stringPoolBytes"
-    val Header             = 0xdeadbeefdeadbeefL
+    val Header             = MagicBytes
   }
 
-  val HeaderSize = 16
 }

--- a/odb-convert/src/main/scala/flatgraph/convert/Convert.scala
+++ b/odb-convert/src/main/scala/flatgraph/convert/Convert.scala
@@ -184,7 +184,7 @@ object Convert {
       var pos       = filePtr.get()
       val header    = new Array[Byte](16)
       val headerBuf = ByteBuffer.wrap(header)
-      headerBuf.order(ByteOrder.LITTLE_ENDIAN).asLongBuffer().put(Keys.Header).put(pos)
+      headerBuf.order(ByteOrder.LITTLE_ENDIAN).put(Keys.Header).asLongBuffer().put(pos)
       headerBuf.position(0)
       var headPos = 0L
       while (headerBuf.hasRemaining()) {


### PR DESCRIPTION
* unix `file` util reports `data` as type
* `cat` and friends print `FLT GRPH...`

![grafik](https://github.com/user-attachments/assets/0ce5335b-16f4-4118-a0ad-47973ed85daf)

![grafik](https://github.com/user-attachments/assets/30a09a79-b469-4cdc-a53e-afccbd447280)

