### PR TITLE
improve error message for unexpected header

### DIFF
--- a/core/src/main/scala/flatgraph/storage/Deserialization.scala
+++ b/core/src/main/scala/flatgraph/storage/Deserialization.scala
@@ -155,7 +155,7 @@ object Deserialization {
     val headerBytes = new Array[Byte](Keys.Header.length)
     header.get(headerBytes)
     if (!Arrays.equals(headerBytes, Keys.Header))
-      throw new DeserializationException(s"expected header (`${Keys.Header}`), but found ${header.getLong}")
+      throw new DeserializationException(s"expected header '$MagicBytesString' (`${Keys.Header.mkString("")}`), but found '${headerBytes.mkString("")}'")
 
     val manifestOffset = header.getLong()
     val manifestSize   = channel.size() - manifestOffset

--- a/core/src/main/scala/flatgraph/storage/Deserialization.scala
+++ b/core/src/main/scala/flatgraph/storage/Deserialization.scala
@@ -155,7 +155,9 @@ object Deserialization {
     val headerBytes = new Array[Byte](Keys.Header.length)
     header.get(headerBytes)
     if (!Arrays.equals(headerBytes, Keys.Header))
-      throw new DeserializationException(s"expected header '$MagicBytesString' (`${Keys.Header.mkString("")}`), but found '${headerBytes.mkString("")}'")
+      throw new DeserializationException(
+        s"expected header '$MagicBytesString' (`${Keys.Header.mkString("")}`), but found '${headerBytes.mkString("")}'"
+      )
 
     val manifestOffset = header.getLong()
     val manifestSize   = channel.size() - manifestOffset


### PR DESCRIPTION
before:
```
expected header (`[B@75c274f1`), but found 12249
```

now:
```
expected header 'FLT GRPH' (`7076843271828072`), but found '1234-97000'
```