### PR TITLE
add structured debug representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,4 +490,4 @@ linked above). They exist only at compile time. Hence, it's safe to cast a given
 
 Yes, properties are no longer fields of stored nodes. Hence the debugger cannot find them.
 
-But despair not! We have attached the `_debugChildren()` method to the GNode class. In order to see anything useful, you need to tell your debugger to use that in its object inspector. So in intellij, you need to add a custom java type renderer, make it apply to all `flatgraph.GNode` instances, and then tell it to use the expression `_debugChildren()` when expanding a node. See e.g. https://www.jetbrains.com/help/idea/customizing-views.html.
+But despair not! We have attached the `_debugChildren()` method to the GNode class. In order to see anything useful, you need to tell your debugger to use that in its object inspector. So in intellij, you need to add a custom java type renderer, make it apply to all `flatgraph.GNode` instances, and then tell it to use the expression `_debugChildren()` when expanding a node. See e.g. https://www.jetbrains.com/help/idea/customizing-views.html#renderers .

--- a/README.md
+++ b/README.md
@@ -486,3 +486,8 @@ linked above). They exist only at compile time. Hence, it's safe to cast a given
 
 (n.b. these marker traits do not define any members or functions, otherwise their usage would result in a ClasscastException at runtime)
 
+## This looks so bad in the debugger / object inspector!
+
+Yes, properties are no longer fields of stored nodes. Hence the debugger cannot find them.
+
+But despair not! We have attached the `_debugChildren()` method to the GNode class. In order to see anything useful, you need to tell your debugger to use that in its object inspector. So in intellij, you need to add a custom java type renderer, make it apply to all `flatgraph.GNode` instances, and then tell it to use the expression `_debugChildren()` when expanding a node. See e.g. https://www.jetbrains.com/help/idea/customizing-views.html.

--- a/core/src/main/java/flatgraph/GNode.java
+++ b/core/src/main/java/flatgraph/GNode.java
@@ -87,6 +87,8 @@ public class GNode implements DNodeOrNode {
         }
     }
 
+    /** This creates a representation of the node that is suitable for debugging, e.g. in intellij.
+     * This function corresponds to the childrenArray() API in intellij.*/
     public Object[] _debugChildren(){
         return DebugDump.debugChildrenScala(this);
     }

--- a/core/src/main/java/flatgraph/GNode.java
+++ b/core/src/main/java/flatgraph/GNode.java
@@ -2,8 +2,6 @@ package flatgraph;
 
 import flatgraph.misc.DebugDump;
 
-import java.util.ArrayList;
-import java.util.Map;
 import java.util.Objects;
 
 /**

--- a/core/src/main/java/flatgraph/GNode.java
+++ b/core/src/main/java/flatgraph/GNode.java
@@ -1,5 +1,9 @@
 package flatgraph;
 
+import flatgraph.misc.DebugDump;
+
+import java.util.ArrayList;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -47,7 +51,7 @@ public class GNode implements DNodeOrNode {
 
     @Override
     public String toString() {
-        return getClass().getName() + "[label=" + label() + "; id=" + id() + "]";
+        return getClass().getName() + "[label=" + label() + "; seq=" + seq() + "; id=" + id() + "]";
     }
 
     @Override
@@ -83,5 +87,9 @@ public class GNode implements DNodeOrNode {
             this.kind = kind;
             this.seq = seq;
         }
+    }
+
+    public Object[] _debugChildren(){
+        return DebugDump.debugChildrenScala(this);
     }
 }

--- a/core/src/test/scala/flatgraph/util/DiffToolTests.scala
+++ b/core/src/test/scala/flatgraph/util/DiffToolTests.scala
@@ -86,7 +86,7 @@ class DiffToolTests extends AnyWordSpec {
 
     val diff = DiffTool.compare(graph0, graph1).asScala
     diff should contain("node count differs: graph1=2, graph2=1")
-    diff should contain("node flatgraph.GNode[label=V0; id=0] only exists in graph1")
+    diff should contain("node flatgraph.GNode[label=V0; seq=0; id=0] only exists in graph1")
   }
 
 }


### PR DESCRIPTION
As requested @ml86 

Ideally we'd use the intellij annotation stuff to avoid having to manually configure out IDEs (we would pull in the annotations as dependency, but no actual code). Unfortunately I couldn't get that to work :(