### PR TITLE
use logger instead of println

### DIFF
--- a/core/src/main/scala/flatgraph/Graph.scala
+++ b/core/src/main/scala/flatgraph/Graph.scala
@@ -26,7 +26,7 @@ object Graph {
     */
   def withStorage(schema: Schema, storagePath: Path, persistOnClose: Boolean = true): Graph = {
     if (Files.exists(storagePath) && Files.size(storagePath) > 0) {
-      println(s"initialising from existing storage ($storagePath)")
+      logger.info(s"initialising from existing storage ($storagePath)")
       Deserialization.readGraph(storagePath, Option(schema), persistOnClose)
     } else {
       val storagePathMaybe =


### PR DESCRIPTION
One of our scripts started failing once we upgraded to flatgraph because of a previously-unexpected `initialising from existing storage ...` message. Does it make sense to replace that `println` for a logger message? ~I took this opportunity to look for some more `println` calls and replaced those that I thought would fit as logs.~ EDIT: I was being overzealous, and reverted them once I noticed these were behind a verbose flag.