### PR TITLE
fix a bug in edge deletions

### DIFF
--- a/core/src/main/scala/flatgraph/DiffGraphApplier.scala
+++ b/core/src/main/scala/flatgraph/DiffGraphApplier.scala
@@ -488,12 +488,13 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder, 
         var idx      = 0
         while (idx < deletionSeqIndexEnd - deletionSeqIndexStart) {
           if (deletion != null && idx == deletion.subSeq - 1) {
-            deletionCounter += 1
             assert(
               deletion.dst == oldNeighbors(deletionSeqIndexStart + idx),
               s"deletion.dst was supposed to be `${oldNeighbors(deletionSeqIndexStart + idx)}`, but instead is ${deletion.dst}"
             )
+            deletionCounter += 1
             deletion = if (deletionCounter < deletions.size) deletions(deletionCounter) else null
+            if (deletion != null && deletion.src.seq() != deletionSeq) deletion = null
           } else {
             newNeighbors(deletionSeqIndexStart + idx - deletionCounter) = oldNeighbors(deletionSeqIndexStart + idx)
             if (oldProperty != null)


### PR DESCRIPTION
Cf the minimized regression test. What happened is that the diffgraph applier was missing a check to not overread deletions to the next seq, which could happen if the ordering of subseqs was unfortunate. 

Mea culpa for this bug. cc @maltek , thanks for the bug report and reproducer!