### PR TITLE
Make diffgraph applier return number of transitive changes

### DIFF
--- a/core/src/main/scala/flatgraph/DiffGraphApplier.scala
+++ b/core/src/main/scala/flatgraph/DiffGraphApplier.scala
@@ -12,7 +12,7 @@ object DiffGraphApplier {
     graph: Graph,
     diff: DiffGraphBuilder,
     schemaViolationReporter: SchemaViolationReporter = new SchemaViolationReporter
-  ): Unit = {
+  ): Int = {
     if (graph.isClosed) throw new GraphClosedException(s"graph cannot be modified any longer since it's closed")
     new DiffGraphApplier(graph, diff, schemaViolationReporter).applyUpdate()
   }

--- a/core/src/main/scala/flatgraph/DiffGraphApplier.scala
+++ b/core/src/main/scala/flatgraph/DiffGraphApplier.scala
@@ -8,15 +8,15 @@ import flatgraph.misc.SchemaViolationReporter
 import scala.collection.{Iterator, mutable}
 
 object DiffGraphApplier {
+
   /** Apply a diff to a graph. This returns the number of successfully applied changes.
-   * 
-   * Since this applies all changes that are reachable from the DiffGraphBuilder, the number of applied changes can be
-   * vastly larger than the size of the diffgraphBuilder, e.g. if there are newNodes that have properties / contained nodes
-   * that are themselves newNodes.
-   *
-   * This function destroys the diff, in order to permit fast freeing of memory (in cases where we run close to exhausting 
-   * the heap with the diff, the old graph, the new graph, and the temporaries during diff application).
-   */
+    *
+    * Since this applies all changes that are reachable from the DiffGraphBuilder, the number of applied changes can be vastly larger than
+    * the size of the diffgraphBuilder, e.g. if there are newNodes that have properties / contained nodes that are themselves newNodes.
+    *
+    * This function destroys the diff, in order to permit fast freeing of memory (in cases where we run close to exhausting the heap with
+    * the diff, the old graph, the new graph, and the temporaries during diff application).
+    */
   def applyDiff(
     graph: Graph,
     diff: DiffGraphBuilder,

--- a/core/src/main/scala/flatgraph/DiffGraphApplier.scala
+++ b/core/src/main/scala/flatgraph/DiffGraphApplier.scala
@@ -8,6 +8,15 @@ import flatgraph.misc.SchemaViolationReporter
 import scala.collection.{Iterator, mutable}
 
 object DiffGraphApplier {
+  /** Apply a diff to a graph. This returns the number of successfully applied changes.
+   * 
+   * Since this applies all changes that are reachable from the DiffGraphBuilder, the number of applied changes can be
+   * vastly larger than the size of the diffgraphBuilder, e.g. if there are newNodes that have properties / contained nodes
+   * that are themselves newNodes.
+   *
+   * This function destroys the diff, in order to permit fast freeing of memory (in cases where we run close to exhausting 
+   * the heap with the diff, the old graph, the new graph, and the temporaries during diff application).
+   */
   def applyDiff(
     graph: Graph,
     diff: DiffGraphBuilder,

--- a/core/src/main/scala/flatgraph/DiffGraphApplier.scala
+++ b/core/src/main/scala/flatgraph/DiffGraphApplier.scala
@@ -488,12 +488,13 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder, 
         var idx      = 0
         while (idx < deletionSeqIndexEnd - deletionSeqIndexStart) {
           if (deletion != null && idx == deletion.subSeq - 1) {
-            deletionCounter += 1
             assert(
               deletion.dst == oldNeighbors(deletionSeqIndexStart + idx),
               s"deletion.dst was supposed to be `${oldNeighbors(deletionSeqIndexStart + idx)}`, but instead is ${deletion.dst}"
             )
+            deletionCounter += 1
             deletion = if (deletionCounter < deletions.size) deletions(deletionCounter) else null
+            if (deletion != null && deletion.src.seq() != deletionSeq) deletion = null
           } else {
             newNeighbors(deletionSeqIndexStart + idx - deletionCounter) = oldNeighbors(deletionSeqIndexStart + idx)
             if (oldProperty != null)

--- a/tests/src/test/scala/flatgraph/GraphTests.scala
+++ b/tests/src/test/scala/flatgraph/GraphTests.scala
@@ -11,7 +11,7 @@ import testdomains.generic.nodes.{NewNodeA, NewNodeB, NodeA}
 
 import scala.jdk.CollectionConverters.MapHasAsScala
 
-class GraphTests extends AnyWordSpec with MockFactory {
+class GraphTestsWithSchema extends AnyWordSpec with MockFactory {
 
   "node property: log warning for schema-unconform property usage" in {
     // unknown node properties often root in deserialising an old storage format,
@@ -41,4 +41,23 @@ class GraphTests extends AnyWordSpec with MockFactory {
     genericDomain.nodeB.head.propertiesMap.asScala shouldBe Map()
   }
 
+  "diffgraph with contained nodes: Produce the correct node order when merged" in {
+    import testdomains.generic.nodes
+    val genDomain = GenericDomain.empty
+    val nodeB_implicit = nodes.NewNodeB().stringOptional("implicit")
+    val nodeB_explicit = nodes.NewNodeB().stringOptional("explicit")
+    val nodeA = nodes.NewNodeA().node_b(nodeB_implicit)
+    DiffGraphApplier.applyDiff(genDomain.graph, GenericDomain.newDiffGraphBuilder.addNode(nodeA).addNode(nodeB_explicit))
+    genDomain.nodeB.stringOptional.l shouldBe List("implicit", "explicit")
+  }
+  "diffgraph with contained nodes: Produce the correct node order when split" in {
+    import testdomains.generic.nodes
+    val genDomain = GenericDomain.empty
+    val nodeB_implicit = nodes.NewNodeB().stringOptional("implicit")
+    val nodeB_explicit = nodes.NewNodeB().stringOptional("explicit")
+    val nodeA = nodes.NewNodeA().node_b(nodeB_implicit)
+    DiffGraphApplier.applyDiff(genDomain.graph, GenericDomain.newDiffGraphBuilder.addNode(nodeA))
+    DiffGraphApplier.applyDiff(genDomain.graph, GenericDomain.newDiffGraphBuilder.addNode(nodeB_explicit))
+    genDomain.nodeB.stringOptional.l shouldBe List("implicit", "explicit")
+  }
 }

--- a/tests/src/test/scala/flatgraph/GraphTests.scala
+++ b/tests/src/test/scala/flatgraph/GraphTests.scala
@@ -43,19 +43,19 @@ class GraphTestsWithSchema extends AnyWordSpec with MockFactory {
 
   "diffgraph with contained nodes: Produce the correct node order when merged" in {
     import testdomains.generic.nodes
-    val genDomain = GenericDomain.empty
+    val genDomain      = GenericDomain.empty
     val nodeB_implicit = nodes.NewNodeB().stringOptional("implicit")
     val nodeB_explicit = nodes.NewNodeB().stringOptional("explicit")
-    val nodeA = nodes.NewNodeA().node_b(nodeB_implicit)
+    val nodeA          = nodes.NewNodeA().node_b(nodeB_implicit)
     DiffGraphApplier.applyDiff(genDomain.graph, GenericDomain.newDiffGraphBuilder.addNode(nodeA).addNode(nodeB_explicit))
     genDomain.nodeB.stringOptional.l shouldBe List("implicit", "explicit")
   }
   "diffgraph with contained nodes: Produce the correct node order when split" in {
     import testdomains.generic.nodes
-    val genDomain = GenericDomain.empty
+    val genDomain      = GenericDomain.empty
     val nodeB_implicit = nodes.NewNodeB().stringOptional("implicit")
     val nodeB_explicit = nodes.NewNodeB().stringOptional("explicit")
-    val nodeA = nodes.NewNodeA().node_b(nodeB_implicit)
+    val nodeA          = nodes.NewNodeA().node_b(nodeB_implicit)
     DiffGraphApplier.applyDiff(genDomain.graph, GenericDomain.newDiffGraphBuilder.addNode(nodeA))
     DiffGraphApplier.applyDiff(genDomain.graph, GenericDomain.newDiffGraphBuilder.addNode(nodeB_explicit))
     genDomain.nodeB.stringOptional.l shouldBe List("implicit", "explicit")


### PR DESCRIPTION
With this, the diffgraph applier again counts the number of transitive modifications in the graph, in order to restore the logging.

Furthermore this restores the correct order of nodes that are transitively added -- we need to `drainDeferred` after every single update, not just at the end. This behavior was a little subtle and was missing both tests and a comment explaining it, so it got lost in a refactor (cf git blame). Now it's protected by both source-code comment and unit test.