### PR TITLE
Fix generated code snippet for property traversal

### DIFF
--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/CodeSnippets.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/CodeSnippets.scala
@@ -397,14 +397,14 @@ object CodeSnippets {
          |  * Traverse to nodes where the $nameCamelCase does not equal the given `value`
          |  * */
          |def ${nameCamelCase}Not(value: $baseType): Iterator[NodeType] =
-         |  traversal.filter{node => node.$nameCamelCase.empty || node.$nameCamelCase.get != value}
+         |  traversal.filter{node => node.$nameCamelCase.isEmpty || node.$nameCamelCase.get != value}
          |
          |/**
          |  * Traverse to nodes where the $nameCamelCase does not equal any one of the given `values`
          |  * */
          |def ${nameCamelCase}Not(values: $baseType*): Iterator[NodeType] = {
          |  val vset = values.toSet
-         |  traversal.filter{node => node.$nameCamelCase.empty || !vset.contains(node.$nameCamelCase.get)}
+         |  traversal.filter{node => node.$nameCamelCase.isEmpty || !vset.contains(node.$nameCamelCase.get)}
          |}
          |""".stripMargin
     }


### PR DESCRIPTION
The code snippet generated with `FilterSteps#genericOption` results in an error like the one below during compilation.

```
value || is not a member of Iterable[Long @uncheckedVariance]
```

Replacing `.empty` with `.isEmpty` should fix this.