### PR TITLE
storage: create parent directories if they don't exist

### DIFF
--- a/core/src/main/scala/flatgraph/storage/Serialization.scala
+++ b/core/src/main/scala/flatgraph/storage/Serialization.scala
@@ -8,7 +8,7 @@ import flatgraph.storage.Manifest.*
 import java.io.ByteArrayOutputStream
 import java.nio.channels.FileChannel
 import java.nio.charset.StandardCharsets
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
 import java.nio.{ByteBuffer, ByteOrder}
 import java.util.concurrent.atomic.AtomicLong
 import scala.collection.mutable
@@ -18,6 +18,10 @@ object Serialization {
   def writeGraph(g: Graph, storagePath: Path): Unit = {
     val fileOffset = new AtomicLong(16)
     val stringPool = mutable.LinkedHashMap[String, Int]()
+
+    // ensure parent directory exists
+    val parentDir = storagePath.getParent
+    if (Files.notExists(parentDir)) Files.createDirectories(parentDir)
 
     val fileChannel =
       new java.io.RandomAccessFile(storagePath.toAbsolutePath.toFile, "rw").getChannel

--- a/core/src/test/scala/flatgraph/SerializationTests.scala
+++ b/core/src/test/scala/flatgraph/SerializationTests.scala
@@ -1,0 +1,44 @@
+package flatgraph
+
+import flatgraph.TestSchema.testSerialization
+import flatgraph.misc.DebugDump.debugDump
+import flatgraph.storage.{Deserialization, Serialization}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Files
+
+class SerializationTests extends AnyWordSpec with Matchers {
+
+  "creates parent directories" in {
+    val testRoot    = Files.createTempDirectory(getClass.getSimpleName)
+    val storagePath = testRoot.resolve("non-existing-parent/graph.fg")
+
+    val schema = TestSchema.make(1, 1)
+    val graph  = new Graph(schema)
+
+    val diff0 = new DiffGraphBuilder(schema)
+    val V0_0  = new GenericDNode(0)
+    val V0_1  = new GenericDNode(0)
+    diff0
+      ._addEdge(V0_0, V0_1, 0)
+      ._addEdge(V0_1, V0_0, 0)
+    DiffGraphApplier.applyDiff(graph, diff0)
+    val originalDump = debugDump(graph)
+    originalDump shouldBe
+      """#Node numbers (kindId, nnodes) (0: 2), total 2
+        |Node kind 0. (eid, nEdgesOut, nEdgesIn): (0, 2 [dense], 2 [dense]),
+        |   V0_0   [0] -> V0_1
+        |   V0_0   [0] <- V0_1
+        |   V0_1   [0] -> V0_0
+        |   V0_1   [0] <- V0_0
+        |""".stripMargin
+
+    Serialization.writeGraph(graph, storagePath)
+
+    val deserialized = Deserialization.readGraph(storagePath, Option(graph.schema))
+    val newDump      = debugDump(deserialized)
+    originalDump shouldBe newDump
+  }
+
+}


### PR DESCRIPTION
prior to this change, the test would fail with:
```
java.io.FileNotFoundException: /tmp/foo/bar (No such file or directory)
	at java.base/java.io.RandomAccessFile.open0(Native Method)
	at java.base/java.io.RandomAccessFile.open(RandomAccessFile.java:345)
	at java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:259)
	at java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:214)
	at flatgraph.storage.Serialization$.writeGraph(Serialization.scala:23)
```