### PR TITLE
performance: use ArrayList instead of ArrayBuffer

### DIFF
--- a/core/src/main/scala/flatgraph/DiffGraphApplier.scala
+++ b/core/src/main/scala/flatgraph/DiffGraphApplier.scala
@@ -5,8 +5,7 @@ import flatgraph.Edge.Direction
 import flatgraph.Edge.Direction.{Incoming, Outgoing}
 import flatgraph.misc.SchemaViolationReporter
 
-import java.util
-import java.util.{ArrayDeque, ArrayList, Arrays, Comparator, RandomAccess}
+import java.util.{AbstractList, ArrayDeque, ArrayList, Arrays, Comparator, RandomAccess}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 
@@ -645,7 +644,7 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder, 
     val viaNewNode  = newNodeNewProperties(pos)
     val propertyBuf = Option(setNodeProperties(pos)).getOrElse(ArrayList())
     if (setNodeProperties(pos) != null || viaNewNode > 0) {
-      val setPropertyPositionsRaw: util.ArrayList[SetPropertyDesc] =
+      val setPropertyPositionsRaw: ArrayList[SetPropertyDesc] =
         Option(setNodeProperties(pos + 1)).getOrElse(ArrayList[SetPropertyDesc]()).asInstanceOf[ArrayList[SetPropertyDesc]]
       graph.inverseIndices.set(pos, null)
       val setPropertyPositions = sortAndDedup(
@@ -741,7 +740,7 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder, 
 
   /** Sorts the given list and removes all duplicates.
    * Note: this sorts the input buffer in-place... */
-  private def sortAndDedup[A](buf: ArrayList[A], by: A => ?, comparator: Comparator[A]): util.AbstractList[A] & RandomAccess = {
+  private def sortAndDedup[A](buf: ArrayList[A], by: A => ?, comparator: Comparator[A]): AbstractList[A] & RandomAccess = {
     buf.sort(comparator)
     var outIdx = 0
     var idx    = 0
@@ -759,7 +758,7 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder, 
     val dropCount = idx - outIdx
     val keepUntil = buf.size() - dropCount
     // we cast here because SubList is an AbstractList & RandomAccess... it's not guaranteed by the api, but we only want to use it as long as it does have RandomAccess...
-    buf.subList(0, keepUntil).asInstanceOf[util.AbstractList[A] & RandomAccess]
+    buf.subList(0, keepUntil).asInstanceOf[AbstractList[A] & RandomAccess]
   }
 
   /** Creates a bitstring/integeger for fast comparison where

--- a/core/src/main/scala/flatgraph/DiffGraphApplier.scala
+++ b/core/src/main/scala/flatgraph/DiffGraphApplier.scala
@@ -445,10 +445,10 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder, 
 
     // grow array and insert GNodes
     val nodesArrayBefore = graph.nodesArray(nodeKind)
-    val newNodes0 = newNodes(nodeKind)
-    val newLength = nodesArrayBefore.length + newNodes0.size()
-    val nodesArrayNew = Arrays.copyOf(nodesArrayBefore, newLength)
-    var insertAt = nodesArrayBefore.length
+    val newNodes0        = newNodes(nodeKind)
+    val newLength        = nodesArrayBefore.length + newNodes0.size()
+    val nodesArrayNew    = Arrays.copyOf(nodesArrayBefore, newLength)
+    var insertAt         = nodesArrayBefore.length
     newNodes0.forEach { newNode =>
       nodesArrayNew.update(insertAt, newNode.storedRef.get)
       insertAt += 1
@@ -483,7 +483,7 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder, 
   }
 
   private def deleteEdges(nodeKind: Int, direction: Direction, edgeKind: Int): Unit = {
-    val pos       = graph.schema.neighborOffsetArrayIndex(nodeKind, direction, edgeKind)
+    val pos          = graph.schema.neighborOffsetArrayIndex(nodeKind, direction, edgeKind)
     val deletionsRaw = delEdges(pos)
     if (deletionsRaw == null) return
     assert(
@@ -647,12 +647,8 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder, 
       val setPropertyPositionsRaw: ArrayList[SetPropertyDesc] =
         Option(setNodeProperties(pos + 1)).getOrElse(ArrayList[SetPropertyDesc]()).asInstanceOf[ArrayList[SetPropertyDesc]]
       graph.inverseIndices.set(pos, null)
-      val setPropertyPositions = sortAndDedup(
-        setPropertyPositionsRaw,
-        _.node.seq(),
-        (p0, p1) => p0.node.seq().compareTo(p1.node.seq())
-      )
-      val oldQty = Option(graph.properties(pos).asInstanceOf[Array[Int]]).getOrElse(new Array[Int](1))
+      val setPropertyPositions = sortAndDedup(setPropertyPositionsRaw, _.node.seq(), (p0, p1) => p0.node.seq().compareTo(p1.node.seq()))
+      val oldQty               = Option(graph.properties(pos).asInstanceOf[Array[Int]]).getOrElse(new Array[Int](1))
       val lengthDelta = setPropertyPositions.iterator.asScala.map { setP =>
         setP.length - (get(oldQty, setP.node.seq()) - get(oldQty, setP.node.seq() + 1))
       }.sum
@@ -714,17 +710,15 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder, 
     }
   }
 
-  /**
-   * note 1: we assume that the buffer has the correct element types and cast them...
-   *
-   * note 2: we need to do a slow copy here, copying element by element, rather than the fast System.arraycopy
-   * because `ArrayList` (just like the previously used `mutable.ArrayBuffer`) uses an
-   * underlying `Object[] / Array[AnyRef]`, i.e. a non-specialized array
-   */
+  /** note 1: we assume that the buffer has the correct element types and cast them...
+    *
+    * note 2: we need to do a slow copy here, copying element by element, rather than the fast System.arraycopy because `ArrayList` (just
+    * like the previously used `mutable.ArrayBuffer`) uses an underlying `Object[] / Array[AnyRef]`, i.e. a non-specialized array
+    */
   private def copyToArray[T](buf: ArrayList[Any], dst: Array[T]): Unit = {
     try {
       val len = buf.size()
-      var i = 0
+      var i   = 0
       while (i < len) {
         dst.update(i, buf.get(i).asInstanceOf[T])
         i += 1
@@ -738,8 +732,8 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder, 
 
   private def get(a: Array[Int], idx: Int): Int = if (idx < a.length) a(idx) else a.last
 
-  /** Sorts the given list and removes all duplicates.
-   * Note: this sorts the input buffer in-place... */
+  /** Sorts the given list and removes all duplicates. Note: this sorts the input buffer in-place...
+    */
   private def sortAndDedup[A](buf: ArrayList[A], by: A => ?, comparator: Comparator[A]): AbstractList[A] & RandomAccess = {
     buf.sort(comparator)
     var outIdx = 0

--- a/core/src/main/scala/flatgraph/DiffGraphApplier.scala
+++ b/core/src/main/scala/flatgraph/DiffGraphApplier.scala
@@ -449,6 +449,7 @@ private[flatgraph] class DiffGraphApplier(graph: Graph, diff: DiffGraphBuilder, 
     val newLength        = nodesArrayBefore.length + newNodes0.size()
     val nodesArrayNew    = Arrays.copyOf(nodesArrayBefore, newLength)
     var insertAt         = nodesArrayBefore.length
+    // note: this is a slow element-by-element copy, but we need to iterate the newNodes list anyway because we need to get the gnodes out...
     newNodes0.forEach { newNode =>
       nodesArrayNew.update(insertAt, newNode.storedRef.get)
       insertAt += 1

--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/CodeSnippets.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/CodeSnippets.scala
@@ -5,14 +5,14 @@ object CodeSnippets {
   object NewNodeInserters {
     def forSingleItem(nameCamelCase: String, nodeType: String, propertyType: String, isNode: Boolean): String = {
       s"""object NewNodeInserter_${nodeType}_${nameCamelCase} extends flatgraph.NewNodePropertyInsertionHelper {
-         |  override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+         |  override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
          |     if(newNodes.isEmpty) return
          |     val dstCast = dst.asInstanceOf[Array[${propertyType}]]
-         |     val seq = newNodes.head.storedRef.get.seq()
+         |     val seq = newNodes.get(0).storedRef.get.seq()
          |     var offset = offsets(seq)
          |     var idx = 0
-         |     while(idx < newNodes.length){
-         |        val nn = newNodes(idx)
+         |     while(idx < newNodes.size()){
+         |        val nn = newNodes.get(idx)
          |        nn match {
          |          case generated: New${nodeType} =>
          |            dstCast(offset) = ${
@@ -32,14 +32,14 @@ object CodeSnippets {
     }
     def forOptionalItem(nameCamelCase: String, nodeType: String, propertyType: String, isNode: Boolean): String = {
       s"""object NewNodeInserter_${nodeType}_${nameCamelCase} extends flatgraph.NewNodePropertyInsertionHelper {
-         |  override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+         |  override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
          |     if(newNodes.isEmpty) return
          |     val dstCast = dst.asInstanceOf[Array[${propertyType}]]
-         |     val seq = newNodes.head.storedRef.get.seq()
+         |     val seq = newNodes.get(0).storedRef.get.seq()
          |     var offset = offsets(seq)
          |     var idx = 0
-         |     while(idx < newNodes.length){
-         |        val nn = newNodes(idx)
+         |     while(idx < newNodes.size()){
+         |        val nn = newNodes.get(idx)
          |        nn match {
          |          case generated: New${nodeType} =>
          |            generated.${nameCamelCase} match {
@@ -63,14 +63,14 @@ object CodeSnippets {
 
     def forMultiItem(nameCamelCase: String, nodeType: String, propertyType: String, isNode: Boolean): String = {
       s"""object NewNodeInserter_${nodeType}_${nameCamelCase} extends flatgraph.NewNodePropertyInsertionHelper {
-         |  override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+         |  override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
          |     if(newNodes.isEmpty) return
          |     val dstCast = dst.asInstanceOf[Array[${propertyType}]]
-         |     val seq = newNodes.head.storedRef.get.seq()
+         |     val seq = newNodes.get(0).storedRef.get.seq()
          |     var offset = offsets(seq)
          |     var idx = 0
-         |     while(idx < newNodes.length){
-         |        val nn = newNodes(idx)
+         |     while(idx < newNodes.size()){
+         |        val nn = newNodes.get(idx)
          |        nn match {
          |          case generated: New${nodeType} =>
          |            for(item <- generated.${nameCamelCase}){

--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
@@ -521,8 +521,8 @@ class DomainClassesGenerator(schema: Schema) {
         s"""package $basePackage.nodes
            |
            |import $basePackage.language.*
+           |import java.util.ArrayList
            |import scala.collection.immutable.{IndexedSeq, ArraySeq}
-           |import scala.collection.mutable
            |
            |$erasedMarkerType
            |

--- a/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/nodes/Call.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/nodes/Call.scala
@@ -1,8 +1,8 @@
 package testdomains.codepropertygraphminified.nodes
 
 import testdomains.codepropertygraphminified.language.*
+import java.util.ArrayList
 import scala.collection.immutable.{IndexedSeq, ArraySeq}
-import scala.collection.mutable
 
 /** Node base type for compiletime-only checks to improve type safety. EMT stands for: "erased marker trait", i.e. it is erased at runtime
   */
@@ -77,14 +77,14 @@ object NewCall {
 
   object InsertionHelpers {
     object NewNodeInserter_Call_dispatchType extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[String]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewCall =>
               dstCast(offset) = generated.dispatchType
@@ -98,14 +98,14 @@ object NewCall {
       }
     }
     object NewNodeInserter_Call_name extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[String]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewCall =>
               dstCast(offset) = generated.name
@@ -119,14 +119,14 @@ object NewCall {
       }
     }
     object NewNodeInserter_Call_order extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[Int]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewCall =>
               dstCast(offset) = generated.order

--- a/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/nodes/Method.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/nodes/Method.scala
@@ -1,8 +1,8 @@
 package testdomains.codepropertygraphminified.nodes
 
 import testdomains.codepropertygraphminified.language.*
+import java.util.ArrayList
 import scala.collection.immutable.{IndexedSeq, ArraySeq}
-import scala.collection.mutable
 
 /** Node base type for compiletime-only checks to improve type safety. EMT stands for: "erased marker trait", i.e. it is erased at runtime
   */
@@ -63,14 +63,14 @@ object NewMethod {
 
   object InsertionHelpers {
     object NewNodeInserter_Method_name extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[String]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewMethod =>
               dstCast(offset) = generated.name

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/nodes/NodeA.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/nodes/NodeA.scala
@@ -1,8 +1,8 @@
 package testdomains.generic.nodes
 
 import testdomains.generic.language.*
+import java.util.ArrayList
 import scala.collection.immutable.{IndexedSeq, ArraySeq}
-import scala.collection.mutable
 
 /** Node base type for compiletime-only checks to improve type safety. EMT stands for: "erased marker trait", i.e. it is erased at runtime
   */
@@ -105,14 +105,14 @@ object NewNodeA {
 
   object InsertionHelpers {
     object NewNodeInserter_NodeA_intList extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[Int]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewNodeA =>
               for (item <- generated.intList) {
@@ -128,14 +128,14 @@ object NewNodeA {
       }
     }
     object NewNodeInserter_NodeA_intMandatory extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[Int]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewNodeA =>
               dstCast(offset) = generated.intMandatory
@@ -149,14 +149,14 @@ object NewNodeA {
       }
     }
     object NewNodeInserter_NodeA_intOptional extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[Int]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewNodeA =>
               generated.intOptional match {
@@ -174,14 +174,14 @@ object NewNodeA {
       }
     }
     object NewNodeInserter_NodeA_stringList extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[String]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewNodeA =>
               for (item <- generated.stringList) {
@@ -197,14 +197,14 @@ object NewNodeA {
       }
     }
     object NewNodeInserter_NodeA_stringMandatory extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[String]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewNodeA =>
               dstCast(offset) = generated.stringMandatory
@@ -218,14 +218,14 @@ object NewNodeA {
       }
     }
     object NewNodeInserter_NodeA_stringOptional extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[String]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewNodeA =>
               generated.stringOptional match {
@@ -243,14 +243,14 @@ object NewNodeA {
       }
     }
     object NewNodeInserter_NodeA_node_b extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[flatgraph.GNode]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewNodeA =>
               generated.node_b match {

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/nodes/NodeB.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/nodes/NodeB.scala
@@ -1,8 +1,8 @@
 package testdomains.generic.nodes
 
 import testdomains.generic.language.*
+import java.util.ArrayList
 import scala.collection.immutable.{IndexedSeq, ArraySeq}
-import scala.collection.mutable
 
 /** Node base type for compiletime-only checks to improve type safety. EMT stands for: "erased marker trait", i.e. it is erased at runtime
   */
@@ -60,14 +60,14 @@ object NewNodeB {
 
   object InsertionHelpers {
     object NewNodeInserter_NodeB_stringOptional extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[String]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewNodeB =>
               generated.stringOptional match {

--- a/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/nodes/Artist.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/nodes/Artist.scala
@@ -1,8 +1,8 @@
 package testdomains.gratefuldead.nodes
 
 import testdomains.gratefuldead.language.*
+import java.util.ArrayList
 import scala.collection.immutable.{IndexedSeq, ArraySeq}
-import scala.collection.mutable
 
 /** Node base type for compiletime-only checks to improve type safety. EMT stands for: "erased marker trait", i.e. it is erased at runtime
   */
@@ -62,14 +62,14 @@ object NewArtist {
 
   object InsertionHelpers {
     object NewNodeInserter_Artist_name extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[String]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewArtist =>
               dstCast(offset) = generated.name

--- a/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/nodes/Song.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/nodes/Song.scala
@@ -1,8 +1,8 @@
 package testdomains.gratefuldead.nodes
 
 import testdomains.gratefuldead.language.*
+import java.util.ArrayList
 import scala.collection.immutable.{IndexedSeq, ArraySeq}
-import scala.collection.mutable
 
 /** Node base type for compiletime-only checks to improve type safety. EMT stands for: "erased marker trait", i.e. it is erased at runtime
   */
@@ -75,14 +75,14 @@ object NewSong {
 
   object InsertionHelpers {
     object NewNodeInserter_Song_name extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[String]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewSong =>
               dstCast(offset) = generated.name
@@ -96,14 +96,14 @@ object NewSong {
       }
     }
     object NewNodeInserter_Song_performances extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[Int]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewSong =>
               generated.performances match {
@@ -121,14 +121,14 @@ object NewSong {
       }
     }
     object NewNodeInserter_Song_songtype extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[String]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewSong =>
               generated.songtype match {

--- a/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/nodes/NodeX.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/nodes/NodeX.scala
@@ -1,8 +1,8 @@
 package testdomains.hierarchical.nodes
 
 import testdomains.hierarchical.language.*
+import java.util.ArrayList
 import scala.collection.immutable.{IndexedSeq, ArraySeq}
-import scala.collection.mutable
 
 /** Node base type for compiletime-only checks to improve type safety. EMT stands for: "erased marker trait", i.e. it is erased at runtime
   */
@@ -63,14 +63,14 @@ object NewNodeX {
 
   object InsertionHelpers {
     object NewNodeInserter_NodeX_name extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[String]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewNodeX =>
               dstCast(offset) = generated.name

--- a/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/nodes/NodeY.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/nodes/NodeY.scala
@@ -1,8 +1,8 @@
 package testdomains.hierarchical.nodes
 
 import testdomains.hierarchical.language.*
+import java.util.ArrayList
 import scala.collection.immutable.{IndexedSeq, ArraySeq}
-import scala.collection.mutable
 
 /** Node base type for compiletime-only checks to improve type safety. EMT stands for: "erased marker trait", i.e. it is erased at runtime
   */
@@ -63,14 +63,14 @@ object NewNodeY {
 
   object InsertionHelpers {
     object NewNodeInserter_NodeY_name extends flatgraph.NewNodePropertyInsertionHelper {
-      override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
+      override def insertNewNodeProperties(newNodes: ArrayList[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[String]]
-        val seq     = newNodes.head.storedRef.get.seq()
+        val seq     = newNodes.get(0).storedRef.get.seq()
         var offset  = offsets(seq)
         var idx     = 0
-        while (idx < newNodes.length) {
-          val nn = newNodes(idx)
+        while (idx < newNodes.size()) {
+          val nn = newNodes.get(idx)
           nn match {
             case generated: NewNodeY =>
               dstCast(offset) = generated.name


### PR DESCRIPTION
Scala's ArrayBuffer suffers from poor performance because Array.copy uses 
the slowcopy (element by element) rather than the fast System.arraycopy. 
See https://github.com/scala/scala/pull/10962

Profiling showed that the majority of the time is spent in `slowcopy`. 
That part is removed now, and the import time for a large cpg is reduced
from 300s to 280s.
There's likely other places to improve, but this is a large chunk driven
by a rather simple change.

Moving ahead it probably makes sense to replace every ArrayBuffer 
with ArrayList... thoughts?

Flamegraph before:
![grafik](https://github.com/user-attachments/assets/6279a7c2-249c-47e8-9212-2d2757e519a1)

Flamegraph with this PR:
![grafik](https://github.com/user-attachments/assets/9d8eb82a-2cab-418f-9c1b-5577b20dd128)
