### PR TITLE
serialization: handle 'null' value from java's File.getParent api

### DIFF
--- a/core/src/main/scala/flatgraph/storage/Serialization.scala
+++ b/core/src/main/scala/flatgraph/storage/Serialization.scala
@@ -20,8 +20,10 @@ object Serialization {
     val stringPool = mutable.LinkedHashMap[String, Int]()
 
     // ensure parent directory exists
-    val parentDir = storagePath.getParent
-    if (Files.notExists(parentDir)) Files.createDirectories(parentDir)
+    Option(storagePath.getParent) match {
+      case Some(dir) => if (Files.notExists(dir)) Files.createDirectories(dir)
+      case None      => // no parent, i.e. we're at the root dir already
+    }
 
     val fileChannel =
       new java.io.RandomAccessFile(storagePath.toAbsolutePath.toFile, "rw").getChannel

--- a/core/src/test/scala/flatgraph/SerializationTests.scala
+++ b/core/src/test/scala/flatgraph/SerializationTests.scala
@@ -1,6 +1,5 @@
 package flatgraph
 
-import flatgraph.TestSchema.testSerialization
 import flatgraph.misc.DebugDump.debugDump
 import flatgraph.storage.{Deserialization, Serialization}
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
`java.nio.Path::getParent` returns `null` if the path is the root
directory already, so trying to create the root's parent directory both
fails hard and doesn't make any sense