### PR TITLE
schema dsl: make `Property` a case class...

### DIFF
--- a/domain-classes-generator/src/main/scala/flatgraph/schema/Schema.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/schema/Schema.scala
@@ -250,7 +250,7 @@ object EdgeType {
   }
 }
 
-class Property[A](val name: String, val valueType: Property.ValueType[A], val comment: Option[String] = None, val schemaInfo: SchemaInfo)
+case class Property[A](name: String, valueType: Property.ValueType[A], comment: Option[String] = None, schemaInfo: SchemaInfo)
     extends HasClassName
     with HasOptionalProtoId
     with HasSchemaInfo {


### PR DESCRIPTION
... so it can be used nicely in user feedback. Current example _before_
this PR:
```
[error] (schema / Compile / runMain) java.lang.AssertionError: proto ids must be unique across all schema elements, however we found the following duplicates in node properties:
[error] 251 -> flatgraph.schema.Property@52d99cc,flatgraph.schema.Property@a415a1d
[error] (schema / Compile / runMain) java.lang.AssertionError: proto ids must be unique across all schema elements, however we found the following duplicates in node properties:
[error] 251 -> flatgraph.schema.Property@3ab75944,flatgraph.schema.Property@34fe78a8
```