### PR TITLE
downgrade to scala 3.3 LTS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val tests = project
     publish / skip := true,
     libraryDependencies ++= Seq(
       "com.github.pathikrit" %% "better-files" % "3.9.2" % Test,
-      "org.scalamock" %% "scalamock" % "7.2.0" % Test
+      "org.scalamock" %% "scalamock" % "7.3.2" % Test
     ),
   )
 
@@ -130,7 +130,7 @@ lazy val odbConvert = project
   .settings(
     name := "flatgraph-odb-convert",
     libraryDependencies ++= Seq(
-      "io.shiftleft" %% "overflowdb-core" % "1.193+1-df5812b8",
+      "io.shiftleft" %% "overflowdb-core" % "1.194",
       "org.slf4j" % "slf4j-simple" % slf4jVersion % Optional
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,9 @@ name := "flatgraph"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := scala3
 
-val scala3 = "3.6.4"
+val scala3 = "3.3.6"
+// ^ n.b. should always be the current scala LTS release, see
+// https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html#library-maintainers
 val scala2_12 = "2.12.20"
 val osLibVersion = "0.11.4"
 val commonsTextVersion = "1.13.0"
@@ -128,7 +130,7 @@ lazy val odbConvert = project
   .settings(
     name := "flatgraph-odb-convert",
     libraryDependencies ++= Seq(
-      "io.shiftleft" %% "overflowdb-core" % "1.193",
+      "io.shiftleft" %% "overflowdb-core" % "1.193+1-df5812b8",
       "org.slf4j" % "slf4j-simple" % slf4jVersion % Optional
     )
   )

--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
@@ -910,6 +910,7 @@ class DomainClassesGenerator(schema: Schema) {
       traversalsOutputDir / "package.scala",
       s"""package $basePackage
          |
+         |import scala.language.implicitConversions
          |import $basePackage.nodes
          |
          |package object traversals {

--- a/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/traversals/package.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/traversals/package.scala
@@ -1,5 +1,6 @@
 package testdomains.codepropertygraphminified
 
+import scala.language.implicitConversions
 import testdomains.codepropertygraphminified.nodes
 
 package object traversals {

--- a/test-schemas-domain-classes/src/main/scala/testdomains/empty/traversals/package.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/empty/traversals/package.scala
@@ -1,5 +1,6 @@
 package testdomains.empty
 
+import scala.language.implicitConversions
 import testdomains.empty.nodes
 
 package object traversals {

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/traversals/package.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/traversals/package.scala
@@ -1,5 +1,6 @@
 package testdomains.generic
 
+import scala.language.implicitConversions
 import testdomains.generic.nodes
 
 package object traversals {

--- a/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/traversals/package.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/traversals/package.scala
@@ -1,5 +1,6 @@
 package testdomains.gratefuldead
 
+import scala.language.implicitConversions
 import testdomains.gratefuldead.nodes
 
 package object traversals {

--- a/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/traversals/package.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/traversals/package.scala
@@ -1,5 +1,6 @@
 package testdomains.hierarchical
 
+import scala.language.implicitConversions
 import testdomains.hierarchical.nodes
 
 package object traversals {


### PR DESCRIPTION
Projects that are used as libraries should stick to the latest LTS version.

Scala 3 guarantees backward compatibility across minor releases in the entire 3.x series, but no
t forward compatibility. This means that libraries compiled with any Scala 3.x version can be used
in projects compiled with any Scala 3.y version with y >= x.

https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html#library-maintainers
https://docs.scala-lang.org/overviews/core/binary-compatibility-of-scala-releases.html