### PR TITLE
codegen: leave out `.toShort` to avoid accidental integer overflow

### DIFF
--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
@@ -256,7 +256,7 @@ class DomainClassesGenerator(schema: Schema) {
           |}
           |
           |class ${edgeType.className}(src_4762: flatgraph.GNode, dst_4762: flatgraph.GNode, subSeq_4862: Int, property_4862: Any)
-          |  extends flatgraph.Edge(src_4762, dst_4762, ${edgeKindByEdgeType(edgeType)}.toShort, subSeq_4862, property_4862) {
+          |  extends flatgraph.Edge(src_4762, dst_4762, ${edgeKindByEdgeType(edgeType)}, subSeq_4862, property_4862) {
           |  ${propertyNameImplForClass.getOrElse("")}
           |}
           |""".stripMargin
@@ -291,7 +291,7 @@ class DomainClassesGenerator(schema: Schema) {
 
       val storedNode = {
         val mixins = s"${nodeType.className}Base" +: newExtendz.map(_.className) :+ s"StaticType[${nodeType.className}EMT]"
-        s"""class ${nodeType.className}(graph_4762: flatgraph.Graph, seq_4762: Int) extends StoredNode(graph_4762, $kind.toShort , seq_4762)""" +: mixins
+        s"""class ${nodeType.className}(graph_4762: flatgraph.Graph, seq_4762: Int) extends StoredNode(graph_4762, $kind, seq_4762)""" +: mixins
       }.mkString(" with ")
 
       val newNodeProps       = mutable.ArrayBuffer.empty[String]
@@ -467,7 +467,7 @@ class DomainClassesGenerator(schema: Schema) {
            |  }
            |}
            |
-           |class New${nodeType.className} extends NewNode(${nodeKindByNodeType(nodeType)}.toShort) $newNodeMixins {
+           |class New${nodeType.className} extends NewNode(${nodeKindByNodeType(nodeType)}) $newNodeMixins {
            |  override type StoredNodeType = ${nodeType.className}
            |  override def label: String = "${nodeType.name}"
            |
@@ -1457,8 +1457,8 @@ class DomainClassesGenerator(schema: Schema) {
       case ValueType.Boolean                                          => s"${default.value}: Boolean"
       case ValueType.String if default.value == null                  => "null: String"
       case ValueType.String                                           => s""""${escapeJava(default.value.asInstanceOf[String])}": String"""
-      case ValueType.Byte                                             => s"${default.value}.toByte"
-      case ValueType.Short                                            => s"${default.value}.toShort"
+      case ValueType.Byte                                             => s"${default.value}: Byte"
+      case ValueType.Short                                            => s"${default.value}: Short"
       case ValueType.Int                                              => s"${default.value}: Int"
       case ValueType.Long                                             => s"${default.value}L: Long"
       case ValueType.Float if default.value.asInstanceOf[Float].isNaN => "Float.NaN"

--- a/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/edges/EdgeTypes.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/edges/EdgeTypes.scala
@@ -6,4 +6,4 @@ object Call {
 }
 
 class Call(src_4762: flatgraph.GNode, dst_4762: flatgraph.GNode, subSeq_4862: Int, property_4862: Any)
-    extends flatgraph.Edge(src_4762, dst_4762, 0.toShort, subSeq_4862, property_4862) {}
+    extends flatgraph.Edge(src_4762, dst_4762, 0, subSeq_4862, property_4862) {}

--- a/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/nodes/Call.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/nodes/Call.scala
@@ -43,7 +43,7 @@ object Call {
 }
 
 class Call(graph_4762: flatgraph.Graph, seq_4762: Int)
-    extends StoredNode(graph_4762, 0.toShort, seq_4762)
+    extends StoredNode(graph_4762, 0, seq_4762)
     with CallBase
     with CallRepr
     with StaticType[CallEMT] {
@@ -142,7 +142,7 @@ object NewCall {
   }
 }
 
-class NewCall extends NewNode(0.toShort) with CallBase with CallReprNew {
+class NewCall extends NewNode(0) with CallBase with CallReprNew {
   override type StoredNodeType = Call
   override def label: String = "CALL"
 

--- a/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/nodes/Method.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/nodes/Method.scala
@@ -33,7 +33,7 @@ object Method {
 }
 
 class Method(graph_4762: flatgraph.Graph, seq_4762: Int)
-    extends StoredNode(graph_4762, 1.toShort, seq_4762)
+    extends StoredNode(graph_4762, 1, seq_4762)
     with MethodBase
     with Declaration
     with StaticType[MethodEMT] {
@@ -86,7 +86,7 @@ object NewMethod {
   }
 }
 
-class NewMethod extends NewNode(1.toShort) with MethodBase with DeclarationNew {
+class NewMethod extends NewNode(1) with MethodBase with DeclarationNew {
   override type StoredNodeType = Method
   override def label: String = "METHOD"
 

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/edges/EdgeTypes.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/edges/EdgeTypes.scala
@@ -6,6 +6,6 @@ object ConnectedTo {
 }
 
 class ConnectedTo(src_4762: flatgraph.GNode, dst_4762: flatgraph.GNode, subSeq_4862: Int, property_4862: Any)
-    extends flatgraph.Edge(src_4762, dst_4762, 0.toShort, subSeq_4862, property_4862) {
+    extends flatgraph.Edge(src_4762, dst_4762, 0, subSeq_4862, property_4862) {
   override def propertyName: Option[String] = ConnectedTo.propertyName
 }

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/nodes/NodeA.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/nodes/NodeA.scala
@@ -63,7 +63,7 @@ object NodeA {
 }
 
 class NodeA(graph_4762: flatgraph.Graph, seq_4762: Int)
-    extends StoredNode(graph_4762, 0.toShort, seq_4762)
+    extends StoredNode(graph_4762, 0, seq_4762)
     with NodeABase
     with StaticType[NodeAEMT] {
   def node_b: Option[NodeB] = flatgraph.Accessors.getNodePropertyOption[NodeB](graph, nodeKind, 6, seq)
@@ -272,7 +272,7 @@ object NewNodeA {
   }
 }
 
-class NewNodeA extends NewNode(0.toShort) with NodeABase {
+class NewNodeA extends NewNode(0) with NodeABase {
   override type StoredNodeType = NodeA
   override def label: String = "node_a"
 

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/nodes/NodeB.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/nodes/NodeB.scala
@@ -31,7 +31,7 @@ object NodeB {
 }
 
 class NodeB(graph_4762: flatgraph.Graph, seq_4762: Int)
-    extends StoredNode(graph_4762, 1.toShort, seq_4762)
+    extends StoredNode(graph_4762, 1, seq_4762)
     with NodeBBase
     with StaticType[NodeBEMT] {
 
@@ -87,7 +87,7 @@ object NewNodeB {
   }
 }
 
-class NewNodeB extends NewNode(1.toShort) with NodeBBase {
+class NewNodeB extends NewNode(1) with NodeBBase {
   override type StoredNodeType = NodeB
   override def label: String = "node_b"
 

--- a/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/edges/EdgeTypes.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/edges/EdgeTypes.scala
@@ -6,7 +6,7 @@ object Followedby {
 }
 
 class Followedby(src_4762: flatgraph.GNode, dst_4762: flatgraph.GNode, subSeq_4862: Int, property_4862: Any)
-    extends flatgraph.Edge(src_4762, dst_4762, 0.toShort, subSeq_4862, property_4862) {
+    extends flatgraph.Edge(src_4762, dst_4762, 0, subSeq_4862, property_4862) {
   override def propertyName: Option[String] = Followedby.propertyName
 }
 
@@ -16,7 +16,7 @@ object Sungby {
 }
 
 class Sungby(src_4762: flatgraph.GNode, dst_4762: flatgraph.GNode, subSeq_4862: Int, property_4862: Any)
-    extends flatgraph.Edge(src_4762, dst_4762, 1.toShort, subSeq_4862, property_4862) {}
+    extends flatgraph.Edge(src_4762, dst_4762, 1, subSeq_4862, property_4862) {}
 
 object Writtenby {
   val Label = "writtenBy"
@@ -24,4 +24,4 @@ object Writtenby {
 }
 
 class Writtenby(src_4762: flatgraph.GNode, dst_4762: flatgraph.GNode, subSeq_4862: Int, property_4862: Any)
-    extends flatgraph.Edge(src_4762, dst_4762, 2.toShort, subSeq_4862, property_4862) {}
+    extends flatgraph.Edge(src_4762, dst_4762, 2, subSeq_4862, property_4862) {}

--- a/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/nodes/Artist.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/nodes/Artist.scala
@@ -33,7 +33,7 @@ object Artist {
 }
 
 class Artist(graph_4762: flatgraph.Graph, seq_4762: Int)
-    extends StoredNode(graph_4762, 0.toShort, seq_4762)
+    extends StoredNode(graph_4762, 0, seq_4762)
     with ArtistBase
     with StaticType[ArtistEMT] {
 
@@ -85,7 +85,7 @@ object NewArtist {
   }
 }
 
-class NewArtist extends NewNode(0.toShort) with ArtistBase {
+class NewArtist extends NewNode(0) with ArtistBase {
   override type StoredNodeType = Artist
   override def label: String = "artist"
 

--- a/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/nodes/Song.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/nodes/Song.scala
@@ -40,10 +40,7 @@ object Song {
   }
 }
 
-class Song(graph_4762: flatgraph.Graph, seq_4762: Int)
-    extends StoredNode(graph_4762, 1.toShort, seq_4762)
-    with SongBase
-    with StaticType[SongEMT] {
+class Song(graph_4762: flatgraph.Graph, seq_4762: Int) extends StoredNode(graph_4762, 1, seq_4762) with SongBase with StaticType[SongEMT] {
 
   override def productElementName(n: Int): String =
     n match {
@@ -148,7 +145,7 @@ object NewSong {
   }
 }
 
-class NewSong extends NewNode(1.toShort) with SongBase {
+class NewSong extends NewNode(1) with SongBase {
   override type StoredNodeType = Song
   override def label: String = "song"
 

--- a/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/edges/EdgeTypes.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/edges/EdgeTypes.scala
@@ -6,4 +6,4 @@ object ConnectedTo {
 }
 
 class ConnectedTo(src_4762: flatgraph.GNode, dst_4762: flatgraph.GNode, subSeq_4862: Int, property_4862: Any)
-    extends flatgraph.Edge(src_4762, dst_4762, 0.toShort, subSeq_4862, property_4862) {}
+    extends flatgraph.Edge(src_4762, dst_4762, 0, subSeq_4862, property_4862) {}

--- a/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/nodes/NodeX.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/nodes/NodeX.scala
@@ -33,7 +33,7 @@ object NodeX {
 }
 
 class NodeX(graph_4762: flatgraph.Graph, seq_4762: Int)
-    extends StoredNode(graph_4762, 0.toShort, seq_4762)
+    extends StoredNode(graph_4762, 0, seq_4762)
     with NodeXBase
     with BaseNode
     with StaticType[NodeXEMT] {
@@ -86,7 +86,7 @@ object NewNodeX {
   }
 }
 
-class NewNodeX extends NewNode(0.toShort) with NodeXBase with BaseNodeNew {
+class NewNodeX extends NewNode(0) with NodeXBase with BaseNodeNew {
   override type StoredNodeType = NodeX
   override def label: String = "node_x"
 

--- a/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/nodes/NodeY.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/nodes/NodeY.scala
@@ -33,7 +33,7 @@ object NodeY {
 }
 
 class NodeY(graph_4762: flatgraph.Graph, seq_4762: Int)
-    extends StoredNode(graph_4762, 1.toShort, seq_4762)
+    extends StoredNode(graph_4762, 1, seq_4762)
     with NodeYBase
     with BaseNode
     with StaticType[NodeYEMT] {
@@ -86,7 +86,7 @@ object NewNodeY {
   }
 }
 
-class NewNodeY extends NewNode(1.toShort) with NodeYBase with BaseNodeNew {
+class NewNodeY extends NewNode(1) with NodeYBase with BaseNodeNew {
   override type StoredNodeType = NodeY
   override def label: String = "node_y"
 


### PR DESCRIPTION
if the numbers get too large we want the compiler to tell us,
really... compare:

```scala
def foo(s: Short) = print(s)

foo(5)
// 5

foo(500000)
-- [E007] Type Mismatch Error: --------
  |foo(500000)
  |    ^^^^^^
  |    Found:    (500000 : Int)
  |    Required: Short
```