### PR TITLE
Fix PropertyNames for contained nodes

### DIFF
--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
@@ -1172,11 +1172,12 @@ class DomainClassesGenerator(schema: Schema) {
          |}""".stripMargin
     )
     results.addOne(propertiesFile)
-    val propertyNamesSource  = schema.properties.map(p => propertyNameConstantDef(p.comment, p.name)).mkString("\n")
-    val containedNodeTypes   = schema.nodeTypes.flatMap(_.containedNodes).map(_.nodeType)
-    val containedNodesSource = containedNodeTypes.map(n => propertyNameConstantDef(n.comment, n.name)).toSet.mkString("\n")
+    val propertyNamesSource     = schema.properties.map(p => propertyNameConstantDef(p.comment, p.name)).mkString("\n")
+    val containedNodeLocalNames = schema.nodeTypes.flatMap(_.containedNodes).map(_.localName)
+    val containedNodesSource =
+      containedNodeLocalNames.map(n => propertyNameConstantDef(Option("/** This is a contained node */"), n)).toSet.mkString("\n")
     val allNames =
-      (schema.properties.map(p => p.name) ++ containedNodeTypes.map(n => n.name)).map(camelCaseCaps).mkString(",\n")
+      (schema.properties.map(p => p.name) ++ containedNodeLocalNames).map(camelCaseCaps).mkString(",\n")
     val propertyNamesFile = outputDir / "PropertyNames.scala"
     os.write(
       propertyNamesFile,

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/GraphSchema.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/GraphSchema.scala
@@ -23,7 +23,7 @@ object GraphSchema extends flatgraph.Schema {
   )
   val normalNodePropertyNames: Array[String] =
     Array("int_list", "int_mandatory", "int_optional", "string_list", "string_mandatory", "string_optional")
-  val nodePropertyByLabel = normalNodePropertyNames.zipWithIndex.toMap.updated("node_b", 6)
+  val nodePropertyByLabel = normalNodePropertyNames.zipWithIndex.toMap.updated("contained_node_b", 6)
   val nodePropertyDescriptors: Array[FormalQtyType.FormalQuantity | FormalQtyType.FormalType] = {
     val nodePropertyDescriptors = new Array[FormalQtyType.FormalQuantity | FormalQtyType.FormalType](28)
     for (idx <- Range(0, 28)) {
@@ -44,7 +44,7 @@ object GraphSchema extends flatgraph.Schema {
     nodePropertyDescriptors(17) = FormalQtyType.QtyOne
     nodePropertyDescriptors(20) = FormalQtyType.StringType // node_a.string_optional
     nodePropertyDescriptors(21) = FormalQtyType.QtyOption
-    nodePropertyDescriptors(24) = FormalQtyType.RefType // node_a.node_b
+    nodePropertyDescriptors(24) = FormalQtyType.RefType // node_a.contained_node_b
     nodePropertyDescriptors(25) = FormalQtyType.QtyOption
     nodePropertyDescriptors(22) = FormalQtyType.StringType // node_b.string_optional
     nodePropertyDescriptors(23) = FormalQtyType.QtyOption
@@ -58,7 +58,7 @@ object GraphSchema extends flatgraph.Schema {
     _newNodeInserters(12) = nodes.NewNodeA.InsertionHelpers.NewNodeInserter_NodeA_stringList
     _newNodeInserters(16) = nodes.NewNodeA.InsertionHelpers.NewNodeInserter_NodeA_stringMandatory
     _newNodeInserters(20) = nodes.NewNodeA.InsertionHelpers.NewNodeInserter_NodeA_stringOptional
-    _newNodeInserters(24) = nodes.NewNodeA.InsertionHelpers.NewNodeInserter_NodeA_node_b
+    _newNodeInserters(24) = nodes.NewNodeA.InsertionHelpers.NewNodeInserter_NodeA_contained_node_b
     _newNodeInserters(22) = nodes.NewNodeB.InsertionHelpers.NewNodeInserter_NodeB_stringOptional
     _newNodeInserters
   }
@@ -84,7 +84,7 @@ object GraphSchema extends flatgraph.Schema {
 
   override def getPropertyLabel(nodeKind: Int, propertyKind: Int): String = {
     if (propertyKind < 6) normalNodePropertyNames(propertyKind)
-    else if (propertyKind == 6 && nodeKind == 0) "node_b" /*on node node_a*/
+    else if (propertyKind == 6 && nodeKind == 0) "contained_node_b" /*on node node_a*/
     else null
   }
 

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/PropertyNames.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/PropertyNames.scala
@@ -11,8 +11,9 @@ object PropertyNames {
   val StringMandatory: String = "string_mandatory"
   val StringOptional: String  = "string_optional"
 
-  val NodeB: String = "node_b"
+  /** /** This is a contained node */ */
+  val ContainedNodeB: String = "contained_node_b"
 
   val All: Set[String] =
-    new HashSet[String](Seq(IntList, IntMandatory, IntOptional, StringList, StringMandatory, StringOptional, NodeB).asJava)
+    new HashSet[String](Seq(IntList, IntMandatory, IntOptional, StringList, StringMandatory, StringOptional, ContainedNodeB).asJava)
 }

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/nodes/NewNodeA.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/nodes/NewNodeA.scala
@@ -148,7 +148,7 @@ object NewNodeA {
         }
       }
     }
-    object NewNodeInserter_NodeA_node_b extends flatgraph.NewNodePropertyInsertionHelper {
+    object NewNodeInserter_NodeA_contained_node_b extends flatgraph.NewNodePropertyInsertionHelper {
       override def insertNewNodeProperties(newNodes: mutable.ArrayBuffer[flatgraph.DNode], dst: AnyRef, offsets: Array[Int]): Unit = {
         if (newNodes.isEmpty) return
         val dstCast = dst.asInstanceOf[Array[flatgraph.GNode]]
@@ -159,7 +159,7 @@ object NewNodeA {
           val nn = newNodes(idx)
           nn match {
             case generated: NewNodeA =>
-              generated.node_b match {
+              generated.contained_node_b match {
                 case Some(item) =>
                   dstCast(offset) = item match {
                     case newV: flatgraph.DNode => newV.storedRef.get; case oldV: flatgraph.GNode => oldV; case null => null
@@ -189,23 +189,23 @@ class NewNodeA extends NewNode(nodeKind = 0) with NodeABase {
     NewNodeA.inNeighbors.getOrElse(edgeLabel, Set.empty).contains(n.label)
   }
 
-  var intList: IndexedSeq[Int]                           = ArraySeq.empty
-  var intMandatory: Int                                  = 42: Int
-  var intOptional: Option[Int]                           = None
-  var node_b: Option[NodeBBase]                          = None
-  var stringList: IndexedSeq[String]                     = ArraySeq.empty
-  var stringMandatory: String                            = "<empty>": String
-  var stringOptional: Option[String]                     = None
-  def intList(value: IterableOnce[Int]): this.type       = { this.intList = value.iterator.to(ArraySeq); this }
-  def intMandatory(value: Int): this.type                = { this.intMandatory = value; this }
-  def intOptional(value: Int): this.type                 = { this.intOptional = Option(value); this }
-  def intOptional(value: Option[Int]): this.type         = { this.intOptional = value; this }
-  def node_b(value: NodeBBase): this.type                = { this.node_b = Option(value); this }
-  def node_b(value: Option[NodeBBase]): this.type        = { this.node_b = value; this }
-  def stringList(value: IterableOnce[String]): this.type = { this.stringList = value.iterator.to(ArraySeq); this }
-  def stringMandatory(value: String): this.type          = { this.stringMandatory = value; this }
-  def stringOptional(value: Option[String]): this.type   = { this.stringOptional = value; this }
-  def stringOptional(value: String): this.type           = { this.stringOptional = Option(value); this }
+  var contained_node_b: Option[NodeBBase]                   = None
+  var intList: IndexedSeq[Int]                              = ArraySeq.empty
+  var intMandatory: Int                                     = 42: Int
+  var intOptional: Option[Int]                              = None
+  var stringList: IndexedSeq[String]                        = ArraySeq.empty
+  var stringMandatory: String                               = "<empty>": String
+  var stringOptional: Option[String]                        = None
+  def contained_node_b(value: NodeBBase): this.type         = { this.contained_node_b = Option(value); this }
+  def contained_node_b(value: Option[NodeBBase]): this.type = { this.contained_node_b = value; this }
+  def intList(value: IterableOnce[Int]): this.type          = { this.intList = value.iterator.to(ArraySeq); this }
+  def intMandatory(value: Int): this.type                   = { this.intMandatory = value; this }
+  def intOptional(value: Int): this.type                    = { this.intOptional = Option(value); this }
+  def intOptional(value: Option[Int]): this.type            = { this.intOptional = value; this }
+  def stringList(value: IterableOnce[String]): this.type    = { this.stringList = value.iterator.to(ArraySeq); this }
+  def stringMandatory(value: String): this.type             = { this.stringMandatory = value; this }
+  def stringOptional(value: Option[String]): this.type      = { this.stringOptional = value; this }
+  def stringOptional(value: String): this.type              = { this.stringOptional = Option(value); this }
   override def countAndVisitProperties(interface: flatgraph.BatchedUpdateInterface): Unit = {
     interface.countProperty(this, 0, intList.size)
     interface.countProperty(this, 1, 1)
@@ -213,8 +213,8 @@ class NewNodeA extends NewNode(nodeKind = 0) with NodeABase {
     interface.countProperty(this, 3, stringList.size)
     interface.countProperty(this, 4, 1)
     interface.countProperty(this, 5, stringOptional.size)
-    interface.countProperty(this, 6, node_b.size)
-    node_b.foreach(interface.visitContainedNode)
+    interface.countProperty(this, 6, contained_node_b.size)
+    contained_node_b.foreach(interface.visitContainedNode)
   }
 
   override def copy: this.type = {
@@ -225,7 +225,7 @@ class NewNodeA extends NewNode(nodeKind = 0) with NodeABase {
     newInstance.stringList = this.stringList
     newInstance.stringMandatory = this.stringMandatory
     newInstance.stringOptional = this.stringOptional
-    newInstance.node_b = this.node_b
+    newInstance.contained_node_b = this.contained_node_b
     newInstance.asInstanceOf[this.type]
   }
 
@@ -237,7 +237,7 @@ class NewNodeA extends NewNode(nodeKind = 0) with NodeABase {
       case 3 => "stringList"
       case 4 => "stringMandatory"
       case 5 => "stringOptional"
-      case 6 => "node_b"
+      case 6 => "contained_node_b"
       case _ => ""
     }
 
@@ -249,7 +249,7 @@ class NewNodeA extends NewNode(nodeKind = 0) with NodeABase {
       case 3 => this.stringList
       case 4 => this.stringMandatory
       case 5 => this.stringOptional
-      case 6 => this.node_b
+      case 6 => this.contained_node_b
       case _ => null
     }
 

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/nodes/NodeA.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/nodes/NodeA.scala
@@ -16,7 +16,7 @@ trait NodeAEMT
     with HasStringOptionalEMT
 
 trait NodeABase extends AbstractNode with StaticType[NodeAEMT] {
-  def node_b: Option[NodeBBase]
+  def contained_node_b: Option[NodeBBase]
   override def propertiesMap: java.util.Map[String, Any] = {
     import testdomains.generic.accessors.languagebootstrap.*
     val res        = new java.util.HashMap[String, Any]()
@@ -26,7 +26,7 @@ trait NodeABase extends AbstractNode with StaticType[NodeAEMT] {
     val tmpStringList = this.stringList; if (tmpStringList.nonEmpty) res.put("string_list", tmpStringList)
     if (("<empty>": String) != this.stringMandatory) res.put("string_mandatory", this.stringMandatory)
     this.stringOptional.foreach { p => res.put("string_optional", p) }
-    this.node_b.foreach { p => res.put("node_b", p) }
+    this.contained_node_b.foreach { p => res.put("contained_node_b", p) }
     res
   }
 }
@@ -51,13 +51,14 @@ object NodeA {
   *
   * CONTAINED NODES:
   *
-  * ▸ node_b (NodeB); Cardinality `ZeroOrOne` (optional)
+  * ▸ contained_node_b (NodeB); Cardinality `ZeroOrOne` (optional)
   */
 class NodeA(graph_4762: flatgraph.Graph, seq_4762: Int)
     extends StoredNode(graph_4762, 0, seq_4762)
     with NodeABase
     with StaticType[NodeAEMT] {
-  def node_b: Option[NodeB] = flatgraph.Accessors.getNodePropertyOption[NodeB](graph, nodeKind = nodeKind, propertyKind = 6, seq = seq)
+  def contained_node_b: Option[NodeB] =
+    flatgraph.Accessors.getNodePropertyOption[NodeB](graph, nodeKind = nodeKind, propertyKind = 6, seq = seq)
 
   override def productElementName(n: Int): String =
     n match {
@@ -67,7 +68,7 @@ class NodeA(graph_4762: flatgraph.Graph, seq_4762: Int)
       case 3 => "stringList"
       case 4 => "stringMandatory"
       case 5 => "stringOptional"
-      case 6 => "node_b"
+      case 6 => "contained_node_b"
       case _ => ""
     }
 
@@ -79,7 +80,7 @@ class NodeA(graph_4762: flatgraph.Graph, seq_4762: Int)
       case 3 => this.stringList
       case 4 => this.stringMandatory
       case 5 => this.stringOptional
-      case 6 => this.node_b
+      case 6 => this.contained_node_b
       case _ => null
     }
 

--- a/test-schemas/src/main/scala/flatgraph/testdomains/Generic.scala
+++ b/test-schemas/src/main/scala/flatgraph/testdomains/Generic.scala
@@ -28,7 +28,7 @@ object Generic {
       .addNodeType("node_b")
       .addProperty(stringOptional)
 
-    nodeA.addContainedNode(nodeB, "node_b", Cardinality.ZeroOrOne)
+    nodeA.addContainedNode(nodeB, "contained_node_b", Cardinality.ZeroOrOne)
 
     // TODO add support for edge properties with cardinality ONE and LIST
     val connectedTo = builder.addEdgeType("connected_to").withProperty(stringMandatory)

--- a/tests/src/test/scala/flatgraph/GraphTestsWithSchema.scala
+++ b/tests/src/test/scala/flatgraph/GraphTestsWithSchema.scala
@@ -48,7 +48,7 @@ class GraphTestsWithSchema extends AnyWordSpec with MockFactory {
     val genDomain      = GenericDomain.empty
     val nodeB_implicit = nodes.NewNodeB().stringOptional("implicit")
     val nodeB_explicit = nodes.NewNodeB().stringOptional("explicit")
-    val nodeA          = nodes.NewNodeA().node_b(nodeB_implicit)
+    val nodeA          = nodes.NewNodeA().contained_node_b(nodeB_implicit)
     DiffGraphApplier.applyDiff(genDomain.graph, GenericDomain.newDiffGraphBuilder.addNode(nodeA).addNode(nodeB_explicit))
     genDomain.nodeB.stringOptional.l shouldBe List("implicit", "explicit")
   }
@@ -57,7 +57,7 @@ class GraphTestsWithSchema extends AnyWordSpec with MockFactory {
     val genDomain      = GenericDomain.empty
     val nodeB_implicit = nodes.NewNodeB().stringOptional("implicit")
     val nodeB_explicit = nodes.NewNodeB().stringOptional("explicit")
-    val nodeA          = nodes.NewNodeA().node_b(nodeB_implicit)
+    val nodeA          = nodes.NewNodeA().contained_node_b(nodeB_implicit)
     DiffGraphApplier.applyDiff(genDomain.graph, GenericDomain.newDiffGraphBuilder.addNode(nodeA))
     DiffGraphApplier.applyDiff(genDomain.graph, GenericDomain.newDiffGraphBuilder.addNode(nodeB_explicit))
     genDomain.nodeB.stringOptional.l shouldBe List("implicit", "explicit")

--- a/tests/src/test/scala/flatgraph/formats/graphson/GraphSONTests.scala
+++ b/tests/src/test/scala/flatgraph/formats/graphson/GraphSONTests.scala
@@ -47,7 +47,7 @@ class GraphSONTests extends AnyWordSpec {
     DiffGraphApplier.applyDiff(
       graph,
       GenericDomain.newDiffGraphBuilder
-        .setNodeProperty(node2, PropertyNames.NodeB, newNodeB)
+        .setNodeProperty(node2, PropertyNames.ContainedNodeB, newNodeB)
     )
 
     File.usingTemporaryDirectory(getClass.getName) { exportRootDirectory =>


### PR DESCRIPTION
This PR fixes a regression where the node type for contained nodes was used instead of the `localName` when generating the `PropertyNames` file. This PR reverts this change and modifies one of the test schemas to show the effect.