### PR TITLE
Make flatgraph Scala 3.7. compatible.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "flatgraph"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := scala3
 
-val scala3 = "3.3.6"
+val scala3 = "3.3.7"
 // ^ n.b. should always be the current scala LTS release, see
 // https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html#library-maintainers
 val scala2_12 = "2.12.20"
@@ -209,7 +209,6 @@ ThisBuild / scalacOptions ++= Seq(
   "-feature",
   "--release", "8",
   "-language:implicitConversions",
-  "-old-syntax",
   "-no-indent"
 )
 

--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/DomainClassesGenerator.scala
@@ -976,19 +976,19 @@ class DomainClassesGenerator(schema: Schema) {
          |
          |@scala.annotation.implicitNotFound(
          |  \"\"\"If you're using flatgraph purely without a schema and associated generated domain classes, you can
-         |    |start with `given DocSearchPackages = DocSearchPackages.default`.
-         |    |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-         |    |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-         |    |\"\"\".stripMargin)
+         |start with `given DocSearchPackages = DocSearchPackages.default`.
+         |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+         |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+         |\"\"\")
          |  def help(implicit searchPackageNames: DocSearchPackages, availableWidthProvider: AvailableWidthProvider) =
          |    flatgraph.help.TraversalHelp(searchPackageNames).forTraversalSources(verbose = false)
          |
          |@scala.annotation.implicitNotFound(
          |  \"\"\"If you're using flatgraph purely without a schema and associated generated domain classes, you can
-         |    |start with `given DocSearchPackages = DocSearchPackages.default`.
-         |    |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-         |    |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-         |    |\"\"\".stripMargin)
+         |start with `given DocSearchPackages = DocSearchPackages.default`.
+         |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+         |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+         |\"\"\")
          |  def helpVerbose(implicit searchPackageNames: DocSearchPackages, availableWidthProvider: AvailableWidthProvider) =
          |    flatgraph.help.TraversalHelp(searchPackageNames).forTraversalSources(verbose = true)
          |

--- a/help/src/main/scala/flatgraph/help/Language.scala
+++ b/help/src/main/scala/flatgraph/help/Language.scala
@@ -21,10 +21,10 @@ class HelpSteps[A](iterator: Iterator[A]) extends AnyVal {
     */
   @Doc(info = "print help/documentation based on the current elementType `A`.")
   @implicitNotFound("""If you're using flatgraph purely without a schema and associated generated domain classes, you can
-      |start with `given DocSearchPackages = DocSearchPackages.default`.
-      |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-      |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-      |""".stripMargin)
+start with `given DocSearchPackages = DocSearchPackages.default`.
+If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+""")
   def help[B >: A](implicit
     elementType: ClassTag[B],
     searchPackages: DocSearchPackages,
@@ -34,10 +34,10 @@ class HelpSteps[A](iterator: Iterator[A]) extends AnyVal {
 
   @Doc(info = "print verbose help/documentation based on the current elementType `A`.")
   @implicitNotFound("""If you're using flatgraph purely without a schema and associated generated domain classes, you can
-      |start with `given DocSearchPackages = DocSearchPackages.default`.
-      |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-      |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-      |""".stripMargin)
+start with `given DocSearchPackages = DocSearchPackages.default`.
+If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+""")
   def helpVerbose[B >: A](implicit
     elementType: ClassTag[B],
     searchPackages: DocSearchPackages,

--- a/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/CpgMinified.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/CpgMinified.scala
@@ -8,18 +8,18 @@ object CpgMinified {
   val defaultDocSearchPackage = DocSearchPackages.default.withAdditionalPackage(getClass.getPackage.getName)
 
   @scala.annotation.implicitNotFound("""If you're using flatgraph purely without a schema and associated generated domain classes, you can
-    |start with `given DocSearchPackages = DocSearchPackages.default`.
-    |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-    |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-    |""".stripMargin)
+start with `given DocSearchPackages = DocSearchPackages.default`.
+If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+""")
   def help(implicit searchPackageNames: DocSearchPackages, availableWidthProvider: AvailableWidthProvider) =
     flatgraph.help.TraversalHelp(searchPackageNames).forTraversalSources(verbose = false)
 
   @scala.annotation.implicitNotFound("""If you're using flatgraph purely without a schema and associated generated domain classes, you can
-    |start with `given DocSearchPackages = DocSearchPackages.default`.
-    |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-    |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-    |""".stripMargin)
+start with `given DocSearchPackages = DocSearchPackages.default`.
+If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+""")
   def helpVerbose(implicit searchPackageNames: DocSearchPackages, availableWidthProvider: AvailableWidthProvider) =
     flatgraph.help.TraversalHelp(searchPackageNames).forTraversalSources(verbose = true)
 

--- a/test-schemas-domain-classes/src/main/scala/testdomains/empty/Empty.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/empty/Empty.scala
@@ -8,18 +8,18 @@ object Empty {
   val defaultDocSearchPackage = DocSearchPackages.default.withAdditionalPackage(getClass.getPackage.getName)
 
   @scala.annotation.implicitNotFound("""If you're using flatgraph purely without a schema and associated generated domain classes, you can
-    |start with `given DocSearchPackages = DocSearchPackages.default`.
-    |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-    |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-    |""".stripMargin)
+start with `given DocSearchPackages = DocSearchPackages.default`.
+If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+""")
   def help(implicit searchPackageNames: DocSearchPackages, availableWidthProvider: AvailableWidthProvider) =
     flatgraph.help.TraversalHelp(searchPackageNames).forTraversalSources(verbose = false)
 
   @scala.annotation.implicitNotFound("""If you're using flatgraph purely without a schema and associated generated domain classes, you can
-    |start with `given DocSearchPackages = DocSearchPackages.default`.
-    |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-    |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-    |""".stripMargin)
+start with `given DocSearchPackages = DocSearchPackages.default`.
+If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+""")
   def helpVerbose(implicit searchPackageNames: DocSearchPackages, availableWidthProvider: AvailableWidthProvider) =
     flatgraph.help.TraversalHelp(searchPackageNames).forTraversalSources(verbose = true)
 

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/GenericDomain.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/GenericDomain.scala
@@ -8,18 +8,18 @@ object GenericDomain {
   val defaultDocSearchPackage = DocSearchPackages.default.withAdditionalPackage(getClass.getPackage.getName)
 
   @scala.annotation.implicitNotFound("""If you're using flatgraph purely without a schema and associated generated domain classes, you can
-    |start with `given DocSearchPackages = DocSearchPackages.default`.
-    |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-    |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-    |""".stripMargin)
+start with `given DocSearchPackages = DocSearchPackages.default`.
+If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+""")
   def help(implicit searchPackageNames: DocSearchPackages, availableWidthProvider: AvailableWidthProvider) =
     flatgraph.help.TraversalHelp(searchPackageNames).forTraversalSources(verbose = false)
 
   @scala.annotation.implicitNotFound("""If you're using flatgraph purely without a schema and associated generated domain classes, you can
-    |start with `given DocSearchPackages = DocSearchPackages.default`.
-    |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-    |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-    |""".stripMargin)
+start with `given DocSearchPackages = DocSearchPackages.default`.
+If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+""")
   def helpVerbose(implicit searchPackageNames: DocSearchPackages, availableWidthProvider: AvailableWidthProvider) =
     flatgraph.help.TraversalHelp(searchPackageNames).forTraversalSources(verbose = true)
 

--- a/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/GratefulDead.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/GratefulDead.scala
@@ -8,18 +8,18 @@ object GratefulDead {
   val defaultDocSearchPackage = DocSearchPackages.default.withAdditionalPackage(getClass.getPackage.getName)
 
   @scala.annotation.implicitNotFound("""If you're using flatgraph purely without a schema and associated generated domain classes, you can
-    |start with `given DocSearchPackages = DocSearchPackages.default`.
-    |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-    |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-    |""".stripMargin)
+start with `given DocSearchPackages = DocSearchPackages.default`.
+If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+""")
   def help(implicit searchPackageNames: DocSearchPackages, availableWidthProvider: AvailableWidthProvider) =
     flatgraph.help.TraversalHelp(searchPackageNames).forTraversalSources(verbose = false)
 
   @scala.annotation.implicitNotFound("""If you're using flatgraph purely without a schema and associated generated domain classes, you can
-    |start with `given DocSearchPackages = DocSearchPackages.default`.
-    |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-    |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-    |""".stripMargin)
+start with `given DocSearchPackages = DocSearchPackages.default`.
+If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+""")
   def helpVerbose(implicit searchPackageNames: DocSearchPackages, availableWidthProvider: AvailableWidthProvider) =
     flatgraph.help.TraversalHelp(searchPackageNames).forTraversalSources(verbose = true)
 

--- a/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/Hierarchical.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/Hierarchical.scala
@@ -8,18 +8,18 @@ object Hierarchical {
   val defaultDocSearchPackage = DocSearchPackages.default.withAdditionalPackage(getClass.getPackage.getName)
 
   @scala.annotation.implicitNotFound("""If you're using flatgraph purely without a schema and associated generated domain classes, you can
-    |start with `given DocSearchPackages = DocSearchPackages.default`.
-    |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-    |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-    |""".stripMargin)
+start with `given DocSearchPackages = DocSearchPackages.default`.
+If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+""")
   def help(implicit searchPackageNames: DocSearchPackages, availableWidthProvider: AvailableWidthProvider) =
     flatgraph.help.TraversalHelp(searchPackageNames).forTraversalSources(verbose = false)
 
   @scala.annotation.implicitNotFound("""If you're using flatgraph purely without a schema and associated generated domain classes, you can
-    |start with `given DocSearchPackages = DocSearchPackages.default`.
-    |If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
-    |If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
-    |""".stripMargin)
+start with `given DocSearchPackages = DocSearchPackages.default`.
+If you have generated domain classes, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage`.
+If you have additional custom extension steps that specify help texts via @Doc annotations, use `given DocSearchPackages = MyDomain.defaultDocSearchPackage.withAdditionalPackage("my.custom.package)"`
+""")
   def helpVerbose(implicit searchPackageNames: DocSearchPackages, availableWidthProvider: AvailableWidthProvider) =
     flatgraph.help.TraversalHelp(searchPackageNames).forTraversalSources(verbose = true)
 


### PR DESCRIPTION
The `ImplicitNotFound` annotation only accepts compile time constants as argument since Scala 3.7..
To adjust for that I removed the `.stripMargin` call.

Also bumped to latest LTS Scala version 3.3.7 and remove `-old-syntax`
flag which does not have any impact anymore.

Replaces https://github.com/joernio/flatgraph/pull/354

