### PR TITLE
use -Yfuture-lazy-vals and fix some compiler warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -211,7 +211,8 @@ ThisBuild / scalacOptions ++= Seq(
   "--release", "11",
   "-language:implicitConversions",
   "-no-indent", // Require classical {...} syntax, indentation is not significant.
-  "-old-syntax" // Require `(...)` around conditions.
+  "-old-syntax", // Require `(...)` around conditions.
+  "-Yfuture-lazy-vals"
 )
 
 val scalacOptionsFor2_12 = Seq(

--- a/core/src/main/scala/flatgraph/storage/ZstdWrapper.scala
+++ b/core/src/main/scala/flatgraph/storage/ZstdWrapper.scala
@@ -74,9 +74,9 @@ object ZstdWrapper {
 
     override def close(): Unit = this.synchronized {
       compressCtxs.foreach(_.close())
-      compressCtxs.clear
+      compressCtxs.clear()
       decompressCtxs.foreach(_.close())
-      decompressCtxs.clear
+      decompressCtxs.clear()
       this.closed = true
     }
   }

--- a/core/src/main/scala/flatgraph/traversal/IterableOnceExtension.scala
+++ b/core/src/main/scala/flatgraph/traversal/IterableOnceExtension.scala
@@ -10,7 +10,7 @@ class IterableOnceExtension[A](val iterable: IterableOnce[A]) extends AnyVal {
     *   the one and only element from an Iterable
     * @throws NoSuchElementException
     *   if the Iterable is empty
-    * @throws AssertionError
+    * @throws java.lang.AssertionError
     *   if the Iterable has more than one element
     */
   def loneElement(hint: String): A = {

--- a/core/src/main/scala/flatgraph/traversal/Language.scala
+++ b/core/src/main/scala/flatgraph/traversal/Language.scala
@@ -69,7 +69,7 @@ class GenericSteps[A](iterator: Iterator[A]) extends AnyVal {
   def groupByStable[K](f: A => K): scala.collection.SeqMap[K, scala.collection.Seq[A]] = {
     val res = mutable.LinkedHashMap[K, mutable.ArrayBuffer[A]]()
     while (iterator.hasNext) {
-      val item = iterator.next
+      val item = iterator.next()
       val key  = f(item)
       res.getOrElseUpdate(key, mutable.ArrayBuffer[A]()).addOne(item)
     }

--- a/core/src/main/scala/flatgraph/traversal/PathAwareRepeatStep.scala
+++ b/core/src/main/scala/flatgraph/traversal/PathAwareRepeatStep.scala
@@ -10,7 +10,7 @@ object PathAwareRepeatStep {
   case class WorklistItem[A](traversal: Iterator[A], depth: Int)
 
   /** @see
-    *   [[Traversal.repeat]] for a detailed overview
+    *   [[flatgraph.traversal.GenericSteps.repeat]] for a detailed overview
     *
     * Implementation note: using recursion results in nicer code, but uses the JVM stack, which only has enough space for ~10k steps. So
     * instead, this uses a programmatic Stack which is semantically identical. The RepeatTraversalTests cover this case.

--- a/core/src/main/scala/flatgraph/traversal/RepeatStep.scala
+++ b/core/src/main/scala/flatgraph/traversal/RepeatStep.scala
@@ -6,7 +6,7 @@ import scala.collection.{mutable, Iterator}
 object RepeatStep {
 
   /** @see
-    *   [[language.repeat]] for a detailed overview
+    *   [[flatgraph.traversal.GenericSteps.repeat]] for a detailed overview
     *
     * Implementation note: using recursion results in nicer code, but uses the JVM stack, which only has enough space for ~10k steps. So
     * instead, this uses a programmatic Stack which is semantically identical. The RepeatTraversalTests cover this case.

--- a/domain-classes-generator/src/main/scala/flatgraph/codegen/CodeSnippets.scala
+++ b/domain-classes-generator/src/main/scala/flatgraph/codegen/CodeSnippets.scala
@@ -118,7 +118,7 @@ object CodeSnippets {
          |  * */
          |def ${nameCamelCase}Exact(value: $baseType): Iterator[NodeType] = traversal match {
          |    case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-         |      val someNode = init.next
+         |      val someNode = init.next()
          |      flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind,  $propertyId, value).asInstanceOf[Iterator[NodeType]]
          |    case _ => traversal.filter{_.$nameCamelCase == value}
          |  }
@@ -130,7 +130,7 @@ object CodeSnippets {
          |  if(values.length == 1) return ${nameCamelCase}Exact(values.head)
          |  traversal match {
          |    case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-         |      val someNode = init.next
+         |      val someNode = init.next()
          |      values.iterator.flatMap { value =>
          |        flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind,  $propertyId, value).asInstanceOf[Iterator[NodeType]]
          |      }
@@ -188,7 +188,7 @@ object CodeSnippets {
          |  * */
          |def ${nameCamelCase}Exact(value: $baseType): Iterator[NodeType] = traversal match {
          |    case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-         |      val someNode = init.next
+         |      val someNode = init.next()
          |      flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind,  $propertyId, value).asInstanceOf[Iterator[NodeType]]
          |     case _ => traversal.filter{node => val tmp = node.$nameCamelCase; tmp.isDefined && tmp.get == value}
          |}

--- a/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/traversals/TraversalCallBase.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/traversals/TraversalCallBase.scala
@@ -30,7 +30,7 @@ final class TraversalCallBase[NodeType <: nodes.CallBase](val traversal: Iterato
     */
   def dispatchTypeExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
     case _ => traversal.filter { _.dispatchType == value }
   }
@@ -41,7 +41,7 @@ final class TraversalCallBase[NodeType <: nodes.CallBase](val traversal: Iterato
     if (values.length == 1) return dispatchTypeExact(values.head)
     traversal match {
       case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-        val someNode = init.next
+        val someNode = init.next()
         values.iterator.flatMap { value =>
           flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
         }

--- a/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/traversals/TraversalCallreprBase.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/traversals/TraversalCallreprBase.scala
@@ -30,7 +30,7 @@ final class TraversalCallreprBase[NodeType <: nodes.CallReprBase](val traversal:
     */
   def nameExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 1, value).asInstanceOf[Iterator[NodeType]]
     case _ => traversal.filter { _.name == value }
   }
@@ -41,7 +41,7 @@ final class TraversalCallreprBase[NodeType <: nodes.CallReprBase](val traversal:
     if (values.length == 1) return nameExact(values.head)
     traversal match {
       case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-        val someNode = init.next
+        val someNode = init.next()
         values.iterator.flatMap { value =>
           flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 1, value).asInstanceOf[Iterator[NodeType]]
         }

--- a/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/traversals/TraversalDeclarationBase.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/traversals/TraversalDeclarationBase.scala
@@ -30,7 +30,7 @@ final class TraversalDeclarationBase[NodeType <: nodes.DeclarationBase](val trav
     */
   def nameExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 1, value).asInstanceOf[Iterator[NodeType]]
     case _ => traversal.filter { _.name == value }
   }
@@ -41,7 +41,7 @@ final class TraversalDeclarationBase[NodeType <: nodes.DeclarationBase](val trav
     if (values.length == 1) return nameExact(values.head)
     traversal match {
       case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-        val someNode = init.next
+        val someNode = init.next()
         values.iterator.flatMap { value =>
           flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 1, value).asInstanceOf[Iterator[NodeType]]
         }

--- a/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/traversals/TraversalPropertyDispatchType.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/traversals/TraversalPropertyDispatchType.scala
@@ -32,7 +32,7 @@ final class TraversalPropertyDispatchType[NodeType <: nodes.StoredNode & nodes.S
     */
   def dispatchTypeExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
     case _ => traversal.filter { _.dispatchType == value }
   }
@@ -43,7 +43,7 @@ final class TraversalPropertyDispatchType[NodeType <: nodes.StoredNode & nodes.S
     if (values.length == 1) return dispatchTypeExact(values.head)
     traversal match {
       case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-        val someNode = init.next
+        val someNode = init.next()
         values.iterator.flatMap { value =>
           flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
         }

--- a/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/traversals/TraversalPropertyName.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/codepropertygraphminified/traversals/TraversalPropertyName.scala
@@ -31,7 +31,7 @@ final class TraversalPropertyName[NodeType <: nodes.StoredNode & nodes.StaticTyp
     */
   def nameExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 1, value).asInstanceOf[Iterator[NodeType]]
     case _ => traversal.filter { _.name == value }
   }
@@ -42,7 +42,7 @@ final class TraversalPropertyName[NodeType <: nodes.StoredNode & nodes.StaticTyp
     if (values.length == 1) return nameExact(values.head)
     traversal match {
       case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-        val someNode = init.next
+        val someNode = init.next()
         values.iterator.flatMap { value =>
           flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 1, value).asInstanceOf[Iterator[NodeType]]
         }

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/traversals/TraversalNodeaBase.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/traversals/TraversalNodeaBase.scala
@@ -259,7 +259,7 @@ final class TraversalNodeaBase[NodeType <: nodes.NodeABase](val traversal: Itera
     */
   def stringMandatoryExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 8, value).asInstanceOf[Iterator[NodeType]]
     case _ => traversal.filter { _.stringMandatory == value }
   }
@@ -270,7 +270,7 @@ final class TraversalNodeaBase[NodeType <: nodes.NodeABase](val traversal: Itera
     if (values.length == 1) return stringMandatoryExact(values.head)
     traversal match {
       case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-        val someNode = init.next
+        val someNode = init.next()
         values.iterator.flatMap { value =>
           flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 8, value).asInstanceOf[Iterator[NodeType]]
         }
@@ -328,7 +328,7 @@ final class TraversalNodeaBase[NodeType <: nodes.NodeABase](val traversal: Itera
     */
   def stringOptionalExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 9, value).asInstanceOf[Iterator[NodeType]]
     case _ =>
       traversal.filter { node =>

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/traversals/TraversalNodebBase.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/traversals/TraversalNodebBase.scala
@@ -35,7 +35,7 @@ final class TraversalNodebBase[NodeType <: nodes.NodeBBase](val traversal: Itera
     */
   def stringOptionalExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 9, value).asInstanceOf[Iterator[NodeType]]
     case _ =>
       traversal.filter { node =>

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/traversals/TraversalPropertyStringMandatory.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/traversals/TraversalPropertyStringMandatory.scala
@@ -32,7 +32,7 @@ final class TraversalPropertyStringMandatory[NodeType <: nodes.StoredNode & node
     */
   def stringMandatoryExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 8, value).asInstanceOf[Iterator[NodeType]]
     case _ => traversal.filter { _.stringMandatory == value }
   }
@@ -43,7 +43,7 @@ final class TraversalPropertyStringMandatory[NodeType <: nodes.StoredNode & node
     if (values.length == 1) return stringMandatoryExact(values.head)
     traversal match {
       case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-        val someNode = init.next
+        val someNode = init.next()
         values.iterator.flatMap { value =>
           flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 8, value).asInstanceOf[Iterator[NodeType]]
         }

--- a/test-schemas-domain-classes/src/main/scala/testdomains/generic/traversals/TraversalPropertyStringOptional.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/generic/traversals/TraversalPropertyStringOptional.scala
@@ -37,7 +37,7 @@ final class TraversalPropertyStringOptional[NodeType <: nodes.StoredNode & nodes
     */
   def stringOptionalExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 9, value).asInstanceOf[Iterator[NodeType]]
     case _ =>
       traversal.filter { node =>

--- a/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/traversals/TraversalArtistBase.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/traversals/TraversalArtistBase.scala
@@ -30,7 +30,7 @@ final class TraversalArtistBase[NodeType <: nodes.ArtistBase](val traversal: Ite
     */
   def nameExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
     case _ => traversal.filter { _.name == value }
   }
@@ -41,7 +41,7 @@ final class TraversalArtistBase[NodeType <: nodes.ArtistBase](val traversal: Ite
     if (values.length == 1) return nameExact(values.head)
     traversal match {
       case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-        val someNode = init.next
+        val someNode = init.next()
         values.iterator.flatMap { value =>
           flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
         }

--- a/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/traversals/TraversalPropertyName.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/traversals/TraversalPropertyName.scala
@@ -31,7 +31,7 @@ final class TraversalPropertyName[NodeType <: nodes.StoredNode & nodes.StaticTyp
     */
   def nameExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
     case _ => traversal.filter { _.name == value }
   }
@@ -42,7 +42,7 @@ final class TraversalPropertyName[NodeType <: nodes.StoredNode & nodes.StaticTyp
     if (values.length == 1) return nameExact(values.head)
     traversal match {
       case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-        val someNode = init.next
+        val someNode = init.next()
         values.iterator.flatMap { value =>
           flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
         }

--- a/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/traversals/TraversalPropertySongtype.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/traversals/TraversalPropertySongtype.scala
@@ -37,7 +37,7 @@ final class TraversalPropertySongtype[NodeType <: nodes.StoredNode & nodes.Stati
     */
   def songtypeExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 2, value).asInstanceOf[Iterator[NodeType]]
     case _ =>
       traversal.filter { node =>

--- a/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/traversals/TraversalSongBase.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/gratefuldead/traversals/TraversalSongBase.scala
@@ -30,7 +30,7 @@ final class TraversalSongBase[NodeType <: nodes.SongBase](val traversal: Iterato
     */
   def nameExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
     case _ => traversal.filter { _.name == value }
   }
@@ -41,7 +41,7 @@ final class TraversalSongBase[NodeType <: nodes.SongBase](val traversal: Iterato
     if (values.length == 1) return nameExact(values.head)
     traversal match {
       case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-        val someNode = init.next
+        val someNode = init.next()
         values.iterator.flatMap { value =>
           flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
         }
@@ -174,7 +174,7 @@ final class TraversalSongBase[NodeType <: nodes.SongBase](val traversal: Iterato
     */
   def songtypeExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 2, value).asInstanceOf[Iterator[NodeType]]
     case _ =>
       traversal.filter { node =>

--- a/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/traversals/TraversalBasenodeBase.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/traversals/TraversalBasenodeBase.scala
@@ -30,7 +30,7 @@ final class TraversalBasenodeBase[NodeType <: nodes.BaseNodeBase](val traversal:
     */
   def nameExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
     case _ => traversal.filter { _.name == value }
   }
@@ -41,7 +41,7 @@ final class TraversalBasenodeBase[NodeType <: nodes.BaseNodeBase](val traversal:
     if (values.length == 1) return nameExact(values.head)
     traversal match {
       case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-        val someNode = init.next
+        val someNode = init.next()
         values.iterator.flatMap { value =>
           flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
         }

--- a/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/traversals/TraversalPropertyName.scala
+++ b/test-schemas-domain-classes/src/main/scala/testdomains/hierarchical/traversals/TraversalPropertyName.scala
@@ -31,7 +31,7 @@ final class TraversalPropertyName[NodeType <: nodes.StoredNode & nodes.StaticTyp
     */
   def nameExact(value: String): Iterator[NodeType] = traversal match {
     case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-      val someNode = init.next
+      val someNode = init.next()
       flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
     case _ => traversal.filter { _.name == value }
   }
@@ -42,7 +42,7 @@ final class TraversalPropertyName[NodeType <: nodes.StoredNode & nodes.StaticTyp
     if (values.length == 1) return nameExact(values.head)
     traversal match {
       case init: flatgraph.misc.InitNodeIterator[flatgraph.GNode @unchecked] if init.isVirgin && init.hasNext =>
-        val someNode = init.next
+        val someNode = init.next()
         values.iterator.flatMap { value =>
           flatgraph.Accessors.getWithInverseIndex(someNode.graph, someNode.nodeKind, 0, value).asInstanceOf[Iterator[NodeType]]
         }

--- a/tests/src/test/scala/flatgraph/CompileTests.scala
+++ b/tests/src/test/scala/flatgraph/CompileTests.scala
@@ -29,16 +29,16 @@ class CompileTests extends AnyWordSpec with Matchers {
     lazy val compiles = {
       iter.name("a")
       iter.order
-      iter.next.order
+      iter.next().order
       iter.isStatic.orderGt(3).staticCallee
-      iter.next.isStatic.map(_.staticCallee)
+      iter.next().isStatic.map(_.staticCallee)
 
       val isStaticIter = iter.isStatic
       // resolved type is both a Call and our ad-hoc defined `IsStatic` trait
       val _: Call & StaticType[IsStaticEMT] = isStaticIter.next()
 
       // edge accessors
-      iter.next.method
+      iter.next().method
       iter.method
     }
   }
@@ -48,9 +48,9 @@ class CompileTests extends AnyWordSpec with Matchers {
     lazy val compiles = {
       iter.name("a")
       iter.order
-      iter.next.order
+      iter.next().order
       iter.isStatic
-      iter.next.isStatic
+      iter.next().isStatic
 
       val isStaticIter = iter.isStatic
       // resolved type is both a Call and our ad-hoc defined `IsStatic` trait
@@ -65,9 +65,9 @@ class CompileTests extends AnyWordSpec with Matchers {
     lazy val compiles = {
       iter.name("a")
       iter.order
-      iter.next.order
+      iter.next().order
       iter.isStatic
-      iter.next.isStatic
+      iter.next().isStatic
 
       val isStaticIter = iter.isStatic
       // resolved type is both a Call and our ad-hoc defined `IsStatic` trait
@@ -81,7 +81,7 @@ class CompileTests extends AnyWordSpec with Matchers {
     lazy val iter: Iterator[Declaration] = ???
     lazy val compiles = {
       iter.name("a")
-      iter.next.name
+      iter.next().name
     }
 
   }
@@ -91,7 +91,7 @@ class CompileTests extends AnyWordSpec with Matchers {
     lazy val compiles = {
       iter.name("a")
       iter.order
-      iter.next.order
+      iter.next().order
     }
   }
 
@@ -100,7 +100,7 @@ class CompileTests extends AnyWordSpec with Matchers {
     lazy val compiles = {
       iter.name("a")
       iter.order
-      iter.next.order
+      iter.next().order
     }
   }
 
@@ -113,7 +113,7 @@ class CompileTests extends AnyWordSpec with Matchers {
       lazy val compiles = {
         iter.name("a")
         iter.order
-        iter.next.name
+        iter.next().name
       }
     }
 
@@ -122,7 +122,7 @@ class CompileTests extends AnyWordSpec with Matchers {
       lazy val compiles = {
         iter.name("a")
         iter.order
-        iter.next.name
+        iter.next().name
       }
     }
 
@@ -131,7 +131,7 @@ class CompileTests extends AnyWordSpec with Matchers {
       lazy val compiles = {
         iter.name("a")
         iter.order
-        iter.next.name
+        iter.next().name
       }
     }
   }


### PR DESCRIPTION
I've checked the byte code - the new flag really is needed to get the `lazy` implementation using  `VarHandle`s