### PR TITLE
fix: validate manifest offset bounds before allocation in Deserialization

### DIFF
--- a/core/src/main/scala/flatgraph/storage/Deserialization.scala
+++ b/core/src/main/scala/flatgraph/storage/Deserialization.scala
@@ -193,9 +193,9 @@ object Deserialization {
     }
 
     val manifestOffset = header.getLong()
-    val manifestSize   = channel.size() - manifestOffset
-    if (manifestSize > fileSize)
-      throw new DeserializationException(s"corrupt file: manifest size ($manifestSize) cannot be larger than the file's size ($fileSize)")
+    if (manifestOffset < 0 || manifestOffset >= channel.size())
+      throw new DeserializationException(s"corrupt file: manifest offset ($manifestOffset) is out of bounds (file size: ${channel.size()})")
+    val manifestSize = channel.size() - manifestOffset
     if (manifestSize > Int.MaxValue)
       throw new DeserializationException(s"corrupt file: unreasonably large manifest size ($manifestSize)... aborting")
 

--- a/core/src/test/scala/flatgraph/SerializationTests.scala
+++ b/core/src/test/scala/flatgraph/SerializationTests.scala
@@ -67,7 +67,25 @@ class SerializationTests extends AnyWordSpec with Matchers {
     // `java.lang.OutOfMemoryError: Requested array size exceeds VM limit`
     intercept[DeserializationException] {
       Deserialization.readGraph(storagePath, Option(graph.schema))
-    }.getMessage should include("corrupt file: manifest size")
+    }.getMessage should include("corrupt file: manifest offset")
+  }
+
+  /* Show that a truncated file (manifest offset beyond EOF) produces a clear error instead of
+   * `java.lang.IllegalArgumentException: capacity < 0` deep in ByteBuffer.allocate.
+   */
+  "rejects a truncated file where manifest offset points beyond EOF" in {
+    val schema = TestSchema.make(1, 0)
+    val graph  = Graph(schema)
+    val diff   = DiffGraphBuilder(schema).addNode(new GenericDNode(0))
+    DiffGraphApplier.applyDiff(graph, diff)
+
+    val storagePath = Files.createTempFile(s"flatgraph-${getClass.getSimpleName}", "fg")
+    Serialization.writeGraph(graph, storagePath)
+    truncateFile(storagePath)
+
+    intercept[DeserializationException] {
+      Deserialization.readGraph(storagePath, Option(graph.schema))
+    }.getMessage should include("corrupt file: manifest offset")
   }
 
   /** manipulate file as detailed in https: //github.com/joernio/flatgraph/security/advisories/GHSA-jqmx-3x2p-69vh */
@@ -86,6 +104,13 @@ class SerializationTests extends AnyWordSpec with Matchers {
       buffer.order(ByteOrder.LITTLE_ENDIAN)
       buffer.putLong(maliciousOffset)
       file.write(buffer.array())
+    }
+  }
+
+  /** simulate a truncated file: keep only the header so the manifest offset always points past EOF */
+  private def truncateFile(path: Path): Unit = {
+    Using.resource(new RandomAccessFile(path.toFile, "rw")) { file =>
+      file.setLength(storage.HeaderSize)
     }
   }
 


### PR DESCRIPTION
## QT-1269 - Root Cause

When loading a flatgraph file, `readManifest` reads an 8-byte little-endian manifest offset from the file header, then computes:

```scala
val manifestSize = channel.size() - manifestOffset
```

If the file is **truncated** (e.g. interrupted download), the manifest offset stored in the header points beyond the actual end of the file, making `manifestSize` a **negative Long**. Two existing guards both failed to catch this:

1. `manifestSize > fileSize` — only triggers if `manifestOffset < 0`, which is not the case for a truncated file
2. `manifestSize > Int.MaxValue` — a negative Long is never greater than `Int.MaxValue`

The negative Long then passes both checks, `.toInt` narrows it to a negative `Int`, and `ByteBuffer.allocate(negativeInt)` throws:

```
java.lang.IllegalArgumentException: capacity < 0: (-237638205 < 0)
    at java.base/java.nio.ByteBuffer.allocate(ByteBuffer.java:390)
    at flatgraph.storage.Deserialization$.readManifest(Deserialization.scala:202)
```

## Fix

Replace the flawed `manifestSize > fileSize` guard with an explicit bounds check on `manifestOffset` itself, before `manifestSize` is even computed:

```scala
if (manifestOffset < 0 || manifestOffset >= channel.size())
  throw new DeserializationException(
    s"corrupt file: manifest offset ($manifestOffset) is out of bounds (file size: ${channel.size()})"
  )
```

This produces a clear, actionable error message instead of a cryptic JVM crash deep in buffer allocation.

## Verification

Confirmed against the real `cpg.bin.zip` (121.5 MB on disk, manifest offset pointing to 348.2 MB):

```
Magic bytes:        FLT GRPH   ← valid header
File size:          127,451,136 bytes (121.5 MB)
Manifest offset:    365,089,341 bytes (348.2 MB)
Manifest size:      -237,638,205 bytes  ← was passed to ByteBuffer.allocate
Offset out of bounds: True
```

Fixes https://harness.atlassian.net/browse/QT-1269